### PR TITLE
feat: llm-team dashboard 명령으로 정적 HTML 리포트 생성

### DIFF
--- a/application/ledger_summary.sh
+++ b/application/ledger_summary.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# application/ledger_summary.sh
+#
+# Read-only aggregation helpers over the per-target transition ledger.
+# Used by `llm-team dashboard` (and optionally other read paths) to avoid
+# duplicating group-by / window logic in multiple scripts.
+#
+# Public:
+#   ledger_pipeline_summary <target>            → JSON array (one row per
+#       (object_kind, object_id) group) with the latest entry's
+#       {object_kind, object_id, from_state, to_state, result, timestamp,
+#        operation, manifest_id}.
+#   ledger_caller_window <target> <since_iso>   → JSON object
+#       {applied, invalid, duplicate, error, total} counted across rows whose
+#       timestamp >= since_iso.
+#   ledger_recent <target> <limit>              → last N raw JSONL entries
+#       (newest last, preserving file order).
+#
+# All functions return 0 with an empty/zeroed result when the ledger does not
+# exist. Malformed lines are skipped silently (jq -c parse errors swallowed).
+
+# Path helper is provided by lib/ledger.sh::transition_ledger_path.
+
+# Internal: stream valid JSON objects from the ledger (one per line).
+_ledger_summary_stream() {
+  local target="$1" path
+  path="$(transition_ledger_path "${target}")"
+  [ -f "${path}" ] || return 0
+  # `jq -c` per-line tolerates partial garbage by erroring; instead read via
+  # `jq --slurpfile` style would buffer everything. Use a per-line jq with
+  # `2>/dev/null` so a single bad row does not abort the stream.
+  while IFS= read -r line; do
+    [ -n "${line}" ] || continue
+    printf '%s\n' "${line}" | jq -c '.' 2>/dev/null
+  done <"${path}"
+}
+
+ledger_pipeline_summary() {
+  local target="$1"
+  if [ -z "${target}" ]; then
+    log_error "ledger_pipeline_summary: target is required"
+    return 1
+  fi
+  local stream
+  stream="$(_ledger_summary_stream "${target}")"
+  if [ -z "${stream}" ]; then
+    printf '[]'
+    return 0
+  fi
+  printf '%s\n' "${stream}" | jq -s '
+    map(select(
+      (.object_kind | type == "string" and length > 0) and
+      (.object_id   | type == "string" and length > 0) and
+      (.timestamp   | type == "string" and length > 0)
+    ))
+    | group_by([.object_kind, .object_id])
+    | map(
+        sort_by(.timestamp) | last |
+        {
+          object_kind, object_id,
+          from_state: (.from_state // ""),
+          to_state:   (.to_state   // ""),
+          result:     (.result     // "applied"),
+          operation:  (.operation  // ""),
+          manifest_id:(.manifest_id // ""),
+          timestamp:  .timestamp
+        }
+      )
+    | sort_by(.timestamp) | reverse
+  '
+}
+
+ledger_caller_window() {
+  local target="$1" since="$2"
+  if [ -z "${target}" ] || [ -z "${since}" ]; then
+    log_error "ledger_caller_window: target and since_iso are required"
+    return 1
+  fi
+  local stream
+  stream="$(_ledger_summary_stream "${target}")"
+  if [ -z "${stream}" ]; then
+    printf '{"applied":0,"invalid":0,"duplicate":0,"error":0,"total":0}'
+    return 0
+  fi
+  printf '%s\n' "${stream}" | jq -s --arg since "${since}" '
+    map(select((.timestamp // "") >= $since))
+    | {
+        applied:   map(select((.result // "applied") == "applied"))   | length,
+        invalid:   map(select((.result // "")        == "invalid"))   | length,
+        duplicate: map(select((.result // "")        == "duplicate")) | length,
+        error:     map(select((.result // "")        == "error"))     | length,
+        total:     length
+      }
+  '
+}
+
+ledger_recent() {
+  local target="$1" limit="${2:-20}"
+  if [ -z "${target}" ]; then
+    log_error "ledger_recent: target is required"
+    return 1
+  fi
+  case "${limit}" in
+    ''|*[!0-9]*) log_error "ledger_recent: limit must be a non-negative integer"; return 1 ;;
+  esac
+  local path
+  path="$(transition_ledger_path "${target}")"
+  [ -f "${path}" ] || return 0
+  tail -n "${limit}" "${path}"
+}

--- a/bin/llm-team
+++ b/bin/llm-team
@@ -28,6 +28,7 @@ Commands:
   run-once <target> [--roles list] [--dry-run]
   daemon <start|stop|status|logs>
   status [target]
+  dashboard [--out path] [--target name]... [--lines N] [--no-github]
   pause [--all]
   resume [--all]
 
@@ -67,6 +68,10 @@ case "${cmd}" in
   status)
     shift
     exec "${LLM_TEAM_ROOT}/scripts/cli/status.sh" "$@"
+    ;;
+  dashboard)
+    shift
+    exec "${LLM_TEAM_ROOT}/scripts/cli/dashboard.sh" "$@"
     ;;
   pause|resume)
     shift

--- a/lib/html.sh
+++ b/lib/html.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# lib/html.sh — small HTML rendering helpers for static report generators.
+#
+# All helpers write to stdout. They are deliberately kept simple — no DOM,
+# no templating engine, no JS. Keep the contract minimal so callers can
+# compose freely.
+#
+# Public:
+#   html_escape <stdin>            — escape & < > " ' for HTML text/attribute
+#                                    contexts. Stream-safe (line-by-line via sed).
+#   html_escape_arg <string>       — same, but for a single argument.
+#   html_table_open <th> [<th>...] — emit `<table><thead><tr>…</tr></thead><tbody>`.
+#                                    Header cells are escaped.
+#   html_table_close               — emit `</tbody></table>`.
+#   html_table_row <td> [<td>...]  — emit `<tr><td>…</td></tr>` with cells escaped.
+#   html_details_open <summary>    — emit `<details><summary>…</summary><pre>`.
+#                                    Summary is escaped.
+#   html_details_close             — emit `</pre></details>`.
+
+html_escape() {
+  # & must be replaced first so that subsequent replacements don't double-escape.
+  sed -e 's/&/\&amp;/g' \
+      -e 's/</\&lt;/g'  \
+      -e 's/>/\&gt;/g'  \
+      -e 's/"/\&quot;/g' \
+      -e "s/'/\\&#39;/g"
+}
+
+html_escape_arg() {
+  printf '%s' "${1-}" | html_escape
+}
+
+html_table_open() {
+  printf '<table><thead><tr>'
+  local h
+  for h in "$@"; do
+    printf '<th>'
+    printf '%s' "${h}" | html_escape
+    printf '</th>'
+  done
+  printf '</tr></thead><tbody>\n'
+}
+
+html_table_close() {
+  printf '</tbody></table>\n'
+}
+
+html_table_row() {
+  printf '<tr>'
+  local c
+  for c in "$@"; do
+    printf '<td>'
+    printf '%s' "${c}" | html_escape
+    printf '</td>'
+  done
+  printf '</tr>\n'
+}
+
+html_details_open() {
+  local summary="${1-}"
+  printf '<details><summary>'
+  printf '%s' "${summary}" | html_escape
+  printf '</summary><pre>'
+}
+
+html_details_close() {
+  printf '</pre></details>\n'
+}

--- a/scripts/cli/dashboard.sh
+++ b/scripts/cli/dashboard.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+# Generate a self-contained HTML dashboard for the local llm-team install.
+#
+# Usage:
+#   llm-team dashboard [--out <path>] [--target <name>]... [--lines <N>] [--no-github]
+#
+# Default --out is workdir/dashboard.html. Without --target, all targets whose
+# yaml has enabled=true are rendered. The output is a single static file with
+# inline CSS and zero JavaScript.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "${SCRIPT_DIR}/common.sh"
+# shellcheck source=../../lib/common.sh
+. "${LLM_TEAM_ROOT}/lib/common.sh"
+# shellcheck source=../../lib/html.sh
+. "${LLM_TEAM_ROOT}/lib/html.sh"
+# shellcheck source=../../application/ledger_summary.sh
+. "${LLM_TEAM_ROOT}/application/ledger_summary.sh"
+
+usage() {
+  cat <<EOF
+Usage:
+  llm-team dashboard [--out <path>] [--target <name>]... [--lines <N>] [--no-github]
+EOF
+}
+
+DASH_OUT=""
+DASH_LINES="80"
+DASH_NO_GITHUB=0
+DASH_TARGETS=()
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --out)         DASH_OUT="${2:-}"; shift 2 ;;
+      --target)      DASH_TARGETS+=("${2:-}"); shift 2 ;;
+      --lines)       DASH_LINES="${2:-}"; shift 2 ;;
+      --no-github)   DASH_NO_GITHUB=1; shift ;;
+      -h|--help)     usage; exit 0 ;;
+      --*)           cli_die "unknown dashboard argument: $1" ;;
+      *)             cli_die "unexpected positional argument: $1" ;;
+    esac
+  done
+  case "${DASH_LINES}" in
+    ''|*[!0-9]*) cli_die "--lines must be a positive integer" ;;
+  esac
+  if [ -z "${DASH_OUT}" ]; then
+    DASH_OUT="${LLM_TEAM_ROOT}/workdir/dashboard.html"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+dash_count_files() {
+  local dir="$1"
+  [ -d "${dir}" ] || { printf '0'; return 0; }
+  find "${dir}" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' '
+}
+
+dash_iso_now()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
+dash_iso_24h_ago() {
+  date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ
+}
+
+# Resolve target list: explicit --target args win, else list_active_targets.
+dash_resolve_targets() {
+  if [ "${#DASH_TARGETS[@]}" -gt 0 ]; then
+    local t
+    for t in "${DASH_TARGETS[@]}"; do
+      cli_require_target_file "${t}"
+      printf '%s\n' "${t}"
+    done
+    return 0
+  fi
+  list_active_targets
+}
+
+# Pick the most recent agent log file for a target/role; empty if none.
+dash_latest_agent_log() {
+  local target="$1" role="$2" dir
+  dir="${LLM_TEAM_ROOT}/workdir/${target}/logs"
+  [ -d "${dir}" ] || return 0
+  ls -1t "${dir}/${role}"-*.log 2>/dev/null | head -n 1
+}
+
+# Recent N manifest files (newest first).
+dash_recent_manifests() {
+  local target="$1" limit="${2:-5}" dir
+  dir="${LLM_TEAM_ROOT}/workdir/${target}/manifests"
+  [ -d "${dir}" ] || return 0
+  ls -1t "${dir}"/*.json 2>/dev/null | head -n "${limit}"
+}
+
+# Open change-proposal files (state ∉ {CP_CLOSED, CP_MERGED}).
+dash_open_change_proposals() {
+  local target="$1" dir f state
+  dir="${LLM_TEAM_ROOT}/workdir/${target}/change-proposals"
+  [ -d "${dir}" ] || return 0
+  for f in "${dir}"/*.json; do
+    [ -f "${f}" ] || continue
+    state="$(jq -r '.state // ""' "${f}" 2>/dev/null || true)"
+    case "${state}" in
+      CP_CLOSED|CP_MERGED) ;;
+      *) printf '%s\n' "${f}" ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Rendering: top-level structure
+# ---------------------------------------------------------------------------
+
+dash_render_head() {
+  cat <<'EOF'
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>llm-team dashboard</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         margin: 0 auto; max-width: 1200px; padding: 1.5em; color: #222; }
+  h1 { margin-bottom: 0.2em; }
+  h2 { border-bottom: 1px solid #ddd; padding-bottom: 0.2em; margin-top: 2em; }
+  h3 { margin-top: 1.4em; }
+  table { border-collapse: collapse; width: 100%; margin: 0.5em 0; font-size: 0.9em; }
+  th, td { border: 1px solid #ddd; padding: 4px 8px; text-align: left;
+           vertical-align: top; }
+  th { background: #f5f5f5; }
+  pre { background: #f8f8f8; border: 1px solid #ddd; padding: 8px;
+        overflow-x: auto; font-size: 0.8em; max-height: 400px; }
+  details { margin: 0.4em 0; }
+  summary { cursor: pointer; font-weight: 600; }
+  .badge { display: inline-block; padding: 1px 6px; border-radius: 3px;
+           font-size: 0.75em; background: #eee; margin-right: 4px; }
+  .running { background: #c8e6c9; }
+  .paused  { background: #ffe082; }
+  .stopped { background: #f5f5f5; color: #888; }
+  .stale-pid { background: #ffccbc; }
+  .meta { color: #666; font-size: 0.85em; }
+  nav a { margin-right: 1em; }
+  footer { margin-top: 3em; color: #888; font-size: 0.8em; }
+</style>
+</head>
+<body>
+EOF
+}
+
+dash_render_summary() {
+  local control targets target_count daemon_active=0
+  control="$(cli_control_state_get)"
+  targets="$1"  # newline-separated
+  target_count="$(printf '%s\n' "${targets}" | grep -c .)" || true
+
+  # Active daemon count: scan global + per-target daemon dirs.
+  local daemon_dirs=("${LLM_TEAM_ROOT}/workdir/daemon")
+  local t
+  while IFS= read -r t; do
+    [ -n "${t}" ] || continue
+    daemon_dirs+=("${LLM_TEAM_ROOT}/workdir/${t}/daemon")
+  done <<<"${targets}"
+  local d pid_file pid
+  for d in "${daemon_dirs[@]}"; do
+    [ -d "${d}" ] || continue
+    for pid_file in "${d}"/*.pid; do
+      [ -f "${pid_file}" ] || continue
+      pid="$(cat "${pid_file}" 2>/dev/null || true)"
+      if cli_pid_running "${pid}"; then
+        daemon_active=$((daemon_active + 1))
+      fi
+    done
+  done
+
+  printf '<section id="summary">\n'
+  printf '<h1>llm-team dashboard</h1>\n'
+  printf '<p class="meta">Generated %s</p>\n' \
+    "$(html_escape_arg "$(dash_iso_now)")"
+  printf '<p>Control: <span class="badge %s">%s</span></p>\n' \
+    "$(printf '%s' "${control}" | tr '[:upper:]' '[:lower:]' | html_escape)" \
+    "$(html_escape_arg "${control}")"
+  printf '<p>Targets: %d &middot; Active daemons: %d</p>\n' \
+    "${target_count}" "${daemon_active}"
+
+  # Aggregate caller results window.
+  local since="$(dash_iso_24h_ago)"
+  local agg_applied=0 agg_invalid=0 agg_dup=0 agg_err=0 agg_total=0
+  while IFS= read -r t; do
+    [ -n "${t}" ] || continue
+    local w
+    w="$(ledger_caller_window "${t}" "${since}")"
+    agg_applied=$((agg_applied + $(printf '%s' "${w}" | jq -r '.applied')))
+    agg_invalid=$((agg_invalid + $(printf '%s' "${w}" | jq -r '.invalid')))
+    agg_dup=$((agg_dup + $(printf '%s' "${w}" | jq -r '.duplicate')))
+    agg_err=$((agg_err + $(printf '%s' "${w}" | jq -r '.error')))
+    agg_total=$((agg_total + $(printf '%s' "${w}" | jq -r '.total')))
+  done <<<"${targets}"
+  printf '<p>Caller results (24h): total=%d &middot; applied=%d &middot; invalid=%d &middot; duplicate=%d &middot; error=%d</p>\n' \
+    "${agg_total}" "${agg_applied}" "${agg_invalid}" "${agg_dup}" "${agg_err}"
+
+  # Anchor nav.
+  if [ "${target_count}" -gt 0 ]; then
+    printf '<nav>'
+    while IFS= read -r t; do
+      [ -n "${t}" ] || continue
+      printf '<a href="#target-%s">%s</a>' \
+        "$(html_escape_arg "${t}")" "$(html_escape_arg "${t}")"
+    done <<<"${targets}"
+    printf '</nav>\n'
+  fi
+  printf '</section>\n'
+}
+
+# ---------------------------------------------------------------------------
+# Per-target sections
+# ---------------------------------------------------------------------------
+
+dash_render_daemons() {
+  local target="$1" yaml_file owner repo branch enabled
+  yaml_file="$(cli_target_file "${target}")"
+  owner="$(yq -r '.github.owner // ""' "${yaml_file}")"
+  repo="$(yq -r '.github.repo // ""' "${yaml_file}")"
+  branch="$(yq -r '.github.default_branch // "main"' "${yaml_file}")"
+  enabled="$(yq -r '.enabled // false' "${yaml_file}")"
+
+  printf '<p class="meta">repo: %s/%s &middot; branch: %s &middot; enabled: %s</p>\n' \
+    "$(html_escape_arg "${owner}")" \
+    "$(html_escape_arg "${repo}")" \
+    "$(html_escape_arg "${branch}")" \
+    "$(html_escape_arg "${enabled}")"
+
+  printf '<h3>Daemons</h3>\n'
+  html_table_open "scope" "role" "status" "pid" "log"
+  local scope role pid_file pid status log_file
+  for scope in all "${target}"; do
+    local dir
+    if [ "${scope}" = "all" ]; then
+      dir="${LLM_TEAM_ROOT}/workdir/daemon"
+    else
+      dir="${LLM_TEAM_ROOT}/workdir/${scope}/daemon"
+    fi
+    for role in "${CLI_ROLES[@]}"; do
+      pid_file="${dir}/${role}.pid"
+      log_file="${dir}/${role}.log"
+      pid=""
+      status="stopped"
+      if [ -f "${pid_file}" ]; then
+        pid="$(cat "${pid_file}" 2>/dev/null || true)"
+        if cli_pid_running "${pid}"; then
+          status="running"
+        else
+          status="stale-pid"
+        fi
+      fi
+      # Skip rows with no pid file and no log file to avoid noise.
+      if [ -z "${pid}" ] && [ ! -f "${log_file}" ]; then
+        continue
+      fi
+      html_table_row "${scope}" "${role}" "${status}" "${pid:--}" "${log_file}"
+    done
+  done
+  html_table_close
+}
+
+dash_render_github() {
+  local target="$1" yaml_file owner repo full_repo
+  yaml_file="$(cli_target_file "${target}")"
+  owner="$(yq -r '.github.owner // ""' "${yaml_file}")"
+  repo="$(yq -r '.github.repo // ""' "${yaml_file}")"
+  full_repo="${owner}/${repo}"
+
+  printf '<h3>GitHub</h3>\n'
+  if [ "${DASH_NO_GITHUB}" -eq 1 ]; then
+    printf '<p class="meta">(skipped via --no-github)</p>\n'
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    printf '<p class="meta">(unavailable: gh not installed)</p>\n'
+    return 0
+  fi
+  if [ -z "${owner}" ] || [ -z "${repo}" ]; then
+    printf '<p class="meta">(unavailable: target repo not configured)</p>\n'
+    return 0
+  fi
+
+  local issues prs milestones rc=0
+  issues="$(gh issue list --repo "${full_repo}" --state open --limit 1000 --json number 2>/dev/null \
+              | jq 'length' 2>/dev/null)" || rc=1
+  prs="$(gh pr list --repo "${full_repo}" --state open --limit 1000 --json number 2>/dev/null \
+           | jq 'length' 2>/dev/null)" || rc=1
+  milestones="$(gh api "repos/${full_repo}/milestones?state=open&per_page=100" --jq 'length' 2>/dev/null)" || rc=1
+
+  if [ "${rc}" -ne 0 ] || [ -z "${issues}" ] || [ -z "${prs}" ] || [ -z "${milestones}" ]; then
+    printf '<p class="meta">(unavailable: gh request failed)</p>\n'
+    return 0
+  fi
+  html_table_open "open issues" "open PRs" "open milestones"
+  html_table_row "${issues}" "${prs}" "${milestones}"
+  html_table_close
+}
+
+dash_render_caller_results() {
+  local target="$1" since w
+  since="$(dash_iso_24h_ago)"
+  w="$(ledger_caller_window "${target}" "${since}")"
+  printf '<h3>Caller results (24h)</h3>\n'
+  html_table_open "total" "applied" "invalid" "duplicate" "error"
+  html_table_row \
+    "$(printf '%s' "${w}" | jq -r '.total')" \
+    "$(printf '%s' "${w}" | jq -r '.applied')" \
+    "$(printf '%s' "${w}" | jq -r '.invalid')" \
+    "$(printf '%s' "${w}" | jq -r '.duplicate')" \
+    "$(printf '%s' "${w}" | jq -r '.error')"
+  html_table_close
+}
+
+dash_render_pipeline() {
+  local target="$1" rows
+  rows="$(ledger_pipeline_summary "${target}")"
+  printf '<h3>Pipeline</h3>\n'
+  local count
+  count="$(printf '%s' "${rows}" | jq 'length')"
+  if [ "${count}" -eq 0 ]; then
+    printf '<p class="meta">(no transitions yet)</p>\n'
+    return 0
+  fi
+  html_table_open "kind" "id" "from" "to" "result" "operation" "timestamp"
+  while IFS= read -r row; do
+    [ -n "${row}" ] || continue
+    html_table_row \
+      "$(printf '%s' "${row}" | jq -r '.object_kind')" \
+      "$(printf '%s' "${row}" | jq -r '.object_id')" \
+      "$(printf '%s' "${row}" | jq -r '.from_state')" \
+      "$(printf '%s' "${row}" | jq -r '.to_state')" \
+      "$(printf '%s' "${row}" | jq -r '.result')" \
+      "$(printf '%s' "${row}" | jq -r '.operation')" \
+      "$(printf '%s' "${row}" | jq -r '.timestamp')"
+  done < <(printf '%s' "${rows}" | jq -c '.[]')
+  html_table_close
+}
+
+dash_render_leases() {
+  local target="$1" dir f
+  dir="${LLM_TEAM_ROOT}/workdir/${target}/leases"
+  printf '<h3>Active leases</h3>\n'
+  if [ ! -d "${dir}" ] || [ -z "$(ls -A "${dir}" 2>/dev/null)" ]; then
+    printf '<p class="meta">(none)</p>\n'
+    return 0
+  fi
+  html_table_open "object_id" "operation" "worker" "claimed_at" "expires_at"
+  for f in "${dir}"/*.json; do
+    [ -f "${f}" ] || continue
+    html_table_row \
+      "$(jq -r '.object_id // ""' "${f}")" \
+      "$(jq -r '.operation // ""' "${f}")" \
+      "$(jq -r '.worker_id // ""' "${f}")" \
+      "$(jq -r '.claimed_at // ""' "${f}")" \
+      "$(jq -r '.expires_at // ""' "${f}")"
+  done
+  html_table_close
+}
+
+dash_render_manifests() {
+  local target="$1" files f
+  printf '<h3>Recent manifests</h3>\n'
+  files="$(dash_recent_manifests "${target}" 5)"
+  if [ -z "${files}" ]; then
+    printf '<p class="meta">(none)</p>\n'
+    return 0
+  fi
+  html_table_open "manifest_id" "operation" "target" "created_at" "entries"
+  while IFS= read -r f; do
+    [ -n "${f}" ] || continue
+    html_table_row \
+      "$(jq -r '.manifest_id // ""' "${f}")" \
+      "$(jq -r '.operation // ""' "${f}")" \
+      "$(jq -r '"\(.target.kind // "")#\(.target.id // "")"' "${f}")" \
+      "$(jq -r '.created_at // ""' "${f}")" \
+      "$(jq -r '.entries | length' "${f}")"
+  done <<<"${files}"
+  html_table_close
+}
+
+dash_render_change_proposals() {
+  local target="$1" files f
+  printf '<h3>Open change-proposals</h3>\n'
+  files="$(dash_open_change_proposals "${target}")"
+  if [ -z "${files}" ]; then
+    printf '<p class="meta">(none)</p>\n'
+    return 0
+  fi
+  html_table_open "id" "kind" "role" "target_id" "state" "pr"
+  while IFS= read -r f; do
+    [ -n "${f}" ] || continue
+    html_table_row \
+      "$(jq -r '.change_proposal_id // ""' "${f}")" \
+      "$(jq -r '.cp_kind // ""' "${f}")" \
+      "$(jq -r '.source_role // ""' "${f}")" \
+      "$(jq -r '.target_id // ""' "${f}")" \
+      "$(jq -r '.state // ""' "${f}")" \
+      "$(jq -r '.pr_number // "" | tostring' "${f}")"
+  done <<<"${files}"
+  html_table_close
+}
+
+dash_render_logs_section() {
+  local target="$1" heading="$2" picker="$3"
+  printf '<h3>%s (last %s lines)</h3>\n' \
+    "$(html_escape_arg "${heading}")" "$(html_escape_arg "${DASH_LINES}")"
+  local rendered=0 role log_file
+  for role in "${CLI_ROLES[@]}"; do
+    log_file="$("${picker}" "${target}" "${role}")"
+    [ -n "${log_file}" ] && [ -f "${log_file}" ] || continue
+    rendered=$((rendered + 1))
+    html_details_open "${role} — ${log_file}"
+    tail -n "${DASH_LINES}" "${log_file}" | html_escape
+    html_details_close
+  done
+  if [ "${rendered}" -eq 0 ]; then
+    printf '<p class="meta">(no logs)</p>\n'
+  fi
+}
+
+dash_pick_agent_log() {
+  dash_latest_agent_log "$1" "$2"
+}
+
+dash_pick_daemon_log() {
+  local target="$1" role="$2"
+  local target_log="${LLM_TEAM_ROOT}/workdir/${target}/daemon/${role}.log"
+  if [ -f "${target_log}" ]; then
+    printf '%s' "${target_log}"
+    return 0
+  fi
+  local global_log="${LLM_TEAM_ROOT}/workdir/daemon/${role}.log"
+  if [ -f "${global_log}" ]; then
+    printf '%s' "${global_log}"
+  fi
+}
+
+dash_render_target() {
+  local target="$1"
+  printf '<section id="target-%s">\n' "$(html_escape_arg "${target}")"
+  printf '<h2>%s</h2>\n' "$(html_escape_arg "${target}")"
+  dash_render_daemons          "${target}"
+  dash_render_github           "${target}"
+  dash_render_caller_results   "${target}"
+  dash_render_pipeline         "${target}"
+  dash_render_leases           "${target}"
+  dash_render_manifests        "${target}"
+  dash_render_change_proposals "${target}"
+  dash_render_logs_section     "${target}" "Agent logs"  dash_pick_agent_log
+  dash_render_logs_section     "${target}" "Daemon logs" dash_pick_daemon_log
+  printf '</section>\n'
+}
+
+dash_render_footer() {
+  printf '<footer>Generated by llm-team dashboard at %s</footer>\n' \
+    "$(html_escape_arg "$(dash_iso_now)")"
+  printf '</body></html>\n'
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  parse_args "$@"
+  cli_require_cmd jq
+  cli_require_cmd yq
+
+  local out_dir tmp targets t
+  out_dir="$(dirname "${DASH_OUT}")"
+  mkdir -p "${out_dir}" || cli_die "cannot create output directory: ${out_dir}" 1
+
+  targets="$(dash_resolve_targets || true)"
+
+  tmp="$(mktemp "${DASH_OUT}.XXXXXX")" || cli_die "mktemp failed" 1
+  {
+    dash_render_head
+    dash_render_summary "${targets}"
+    while IFS= read -r t; do
+      [ -n "${t}" ] || continue
+      dash_render_target "${t}"
+    done <<<"${targets}"
+    dash_render_footer
+  } >"${tmp}"
+  mv "${tmp}" "${DASH_OUT}"
+  printf 'wrote dashboard: %s\n' "${DASH_OUT}"
+}
+
+main "$@"

--- a/tests/application/test-ledger-summary.sh
+++ b/tests/application/test-ledger-summary.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# tests/application/test-ledger-summary.sh
+#
+# Unit test for application/ledger_summary.sh:
+#   • ledger_pipeline_summary group-by + last-by-timestamp
+#   • ledger_caller_window inclusive lower bound + result counting
+#   • ledger_recent line slice
+#   • Malformed lines tolerated
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LLM_TEAM_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export LLM_TEAM_ROOT
+
+TARGET_NAME="ledger-summary-test-$$"
+TARGET_WORKDIR="${LLM_TEAM_ROOT}/workdir/${TARGET_NAME}"
+
+cleanup() { rm -rf "${TARGET_WORKDIR}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# shellcheck source=../../lib/common.sh
+. "${LLM_TEAM_ROOT}/lib/common.sh"
+# shellcheck source=../../application/ledger_summary.sh
+. "${LLM_TEAM_ROOT}/application/ledger_summary.sh"
+
+failures=0
+fail() { echo "FAIL: $*" >&2; failures=$((failures + 1)); }
+
+mkdir -p "${TARGET_WORKDIR}/ledger"
+ledger_path="$(transition_ledger_path "${TARGET_NAME}")"
+
+# Five ledger entries:
+#   • milestone#1 has two rows (last wins)
+#   • task#10 applied
+#   • task#11 duplicate
+#   • task#12 invalid (older than 24h cutoff)
+ts_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+ts_old="$(date -u -d '2 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+          || date -u -v-2d +%Y-%m-%dT%H:%M:%SZ)"
+ts_mid="$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+          || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)"
+
+emit() {
+  jq -nc \
+    --arg transition_id "$1" \
+    --arg object_kind "$2" \
+    --arg object_id "$3" \
+    --arg from_state "$4" \
+    --arg to_state "$5" \
+    --arg operation "$6" \
+    --arg result "$7" \
+    --arg ts "$8" \
+    '{
+      transition_id: $transition_id,
+      object_kind: $object_kind,
+      object_id: $object_id,
+      from_state: $from_state,
+      to_state: $to_state,
+      operation: $operation,
+      caller_id: "test",
+      idempotency_key: $transition_id,
+      manifest_id: "m-1",
+      timestamp: $ts,
+      result: $result,
+      duplicate: false
+    }'
+}
+
+{
+  emit tx-1 milestone 1 PO_DRAFT  PO_GATE        spec_proposal applied   "${ts_old}"
+  emit tx-2 milestone 1 PO_GATE   PM_DRAFT       spec_proposal applied   "${ts_mid}"
+  emit tx-3 task      10 TASK_READY TASK_REVIEW_READY patch        applied   "${ts_now}"
+  emit tx-4 task      11 "(duplicate)" "(duplicate)" patch         duplicate "${ts_now}"
+  emit tx-5 task      12 TASK_READY  TASK_READY    verdict        invalid   "${ts_old}"
+  printf 'this is not json garbage\n'
+} >"${ledger_path}"
+
+# ---- ledger_pipeline_summary ------------------------------------------------
+summary="$(ledger_pipeline_summary "${TARGET_NAME}")"
+group_count="$(printf '%s' "${summary}" | jq 'length')"
+[ "${group_count}" = "4" ] || fail "pipeline_summary group count: expected 4, got ${group_count} :: ${summary}"
+
+ms1_to="$(printf '%s' "${summary}" \
+  | jq -r '.[] | select(.object_kind=="milestone" and .object_id=="1") | .to_state')"
+[ "${ms1_to}" = "PM_DRAFT" ] || fail "pipeline_summary milestone#1 last to_state: expected PM_DRAFT, got ${ms1_to}"
+
+# ---- ledger_caller_window ---------------------------------------------------
+since_24h="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+              || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)"
+window="$(ledger_caller_window "${TARGET_NAME}" "${since_24h}")"
+applied="$(printf '%s' "${window}" | jq -r '.applied')"
+duplicate="$(printf '%s' "${window}" | jq -r '.duplicate')"
+invalid="$(printf '%s' "${window}" | jq -r '.invalid')"
+total="$(printf '%s' "${window}" | jq -r '.total')"
+# tx-1 (old) and tx-5 (old) are outside the 24h window.
+# Inside: tx-2 applied, tx-3 applied, tx-4 duplicate.
+[ "${applied}"   = "2" ] || fail "caller_window.applied: expected 2, got ${applied} :: ${window}"
+[ "${duplicate}" = "1" ] || fail "caller_window.duplicate: expected 1, got ${duplicate}"
+[ "${invalid}"   = "0" ] || fail "caller_window.invalid: expected 0, got ${invalid}"
+[ "${total}"     = "3" ] || fail "caller_window.total: expected 3, got ${total}"
+
+# ---- ledger_recent ----------------------------------------------------------
+recent="$(ledger_recent "${TARGET_NAME}" 2 | wc -l | tr -d ' ')"
+[ "${recent}" = "2" ] || fail "ledger_recent 2: expected 2 lines, got ${recent}"
+
+# ---- empty ledger fallbacks -------------------------------------------------
+empty_target="ledger-summary-empty-$$"
+empty_summary="$(ledger_pipeline_summary "${empty_target}")"
+[ "${empty_summary}" = "[]" ] || fail "pipeline_summary empty: expected [], got ${empty_summary}"
+
+empty_window="$(ledger_caller_window "${empty_target}" "${since_24h}" | jq -r '.total')"
+[ "${empty_window}" = "0" ] || fail "caller_window empty.total: expected 0, got ${empty_window}"
+
+if [ "${failures}" -eq 0 ]; then
+  printf 'PASS tests/application/test-ledger-summary.sh\n'
+  exit 0
+fi
+printf 'FAIL tests/application/test-ledger-summary.sh (failures=%d)\n' "${failures}" >&2
+exit 1

--- a/tests/cli/test-dashboard.sh
+++ b/tests/cli/test-dashboard.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# tests/cli/test-dashboard.sh
+#
+# Integration test for `llm-team dashboard`:
+#   • Generates HTML against a fixture target (manifests / leases / ledger /
+#     change-proposals / logs).
+#   • Verifies summary anchor, target anchor, HTML escaping of hostile data.
+#   • Verifies --lines clamps log tail length.
+#   • Runs with --no-github to avoid live network.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LLM_TEAM_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export LLM_TEAM_ROOT
+
+TARGET_NAME="dashboard-test-$$"
+TARGET_FILE="${LLM_TEAM_ROOT}/targets/${TARGET_NAME}.yaml"
+TARGET_WORKDIR="${LLM_TEAM_ROOT}/workdir/${TARGET_NAME}"
+OUT_FILE="$(mktemp -t dashboard.XXXXXX.html)"
+
+cleanup() {
+  rm -f "${TARGET_FILE}" "${OUT_FILE}" 2>/dev/null || true
+  rm -rf "${TARGET_WORKDIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+failures=0
+fail() { echo "FAIL: $*" >&2; failures=$((failures + 1)); }
+
+# --- fixture: target yaml ---------------------------------------------------
+mkdir -p "${LLM_TEAM_ROOT}/targets"
+cat >"${TARGET_FILE}" <<EOF
+name: ${TARGET_NAME}
+github:
+  owner: acme
+  repo: dashboard-fixture
+  default_branch: main
+local:
+  clone_path: /tmp/${TARGET_NAME}
+inputs_dir: inputs/${TARGET_NAME}
+labels:
+  prefix: ""
+notifier:
+  channel: none
+  webhook_or_id: ""
+dev_concurrency: 1
+stale_threshold_minutes: 60
+enabled: true
+EOF
+
+# --- fixture: workdir contents ---------------------------------------------
+mkdir -p \
+  "${TARGET_WORKDIR}/manifests" \
+  "${TARGET_WORKDIR}/leases" \
+  "${TARGET_WORKDIR}/ledger" \
+  "${TARGET_WORKDIR}/change-proposals" \
+  "${TARGET_WORKDIR}/logs" \
+  "${TARGET_WORKDIR}/daemon"
+
+# Manifest with hostile string in target.id (escaping check).
+HOSTILE='<script>alert(1)</script>'
+cat >"${TARGET_WORKDIR}/manifests/m-test-1.json" <<EOF
+{
+  "manifest_id": "m-test-1",
+  "operation": "spec_proposal",
+  "target": {"kind": "milestone", "id": "${HOSTILE}"},
+  "entries": [],
+  "created_at": "2026-05-01T00:00:00Z"
+}
+EOF
+
+# Active lease.
+cat >"${TARGET_WORKDIR}/leases/42.json" <<'EOF'
+{
+  "lease_id": "lease-42",
+  "object_id": "42",
+  "operation": "patch",
+  "worker_id": "coder-1",
+  "claimed_at": "2026-05-01T01:00:00Z",
+  "expires_at": "2026-05-01T01:15:00Z",
+  "expires_epoch": 9999999999
+}
+EOF
+
+# Ledger transitions.
+LEDGER="${TARGET_WORKDIR}/ledger/transitions.jsonl"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+{
+  jq -nc --arg ts "${NOW}" '{
+    transition_id:"tx-1",object_kind:"milestone",object_id:"7",
+    from_state:"PO_DRAFT",to_state:"PO_GATE",operation:"spec_proposal",
+    caller_id:"caller_dispatch",idempotency_key:"k1",manifest_id:"m-test-1",
+    timestamp:$ts,result:"applied",duplicate:false
+  }'
+  jq -nc --arg ts "${NOW}" '{
+    transition_id:"tx-2",object_kind:"task",object_id:"42",
+    from_state:"TASK_READY",to_state:"TASK_REVIEW_READY",operation:"patch",
+    caller_id:"caller_dispatch",idempotency_key:"k2",manifest_id:"m-test-1",
+    timestamp:$ts,result:"applied",duplicate:false
+  }'
+} >"${LEDGER}"
+
+# Change proposal (open).
+cat >"${TARGET_WORKDIR}/change-proposals/cp-1.json" <<'EOF'
+{
+  "change_proposal_id": "cp-1",
+  "cp_kind": "Code",
+  "source_role": "Coder",
+  "operation": "patch",
+  "target_id": "42",
+  "state": "CP_READY_FOR_REVIEW",
+  "artifact_ref": "branch:llm-team/task-42",
+  "created_at": "2026-05-01T00:00:00Z"
+}
+EOF
+# Closed CP — should NOT appear in the open-CP table.
+cat >"${TARGET_WORKDIR}/change-proposals/cp-old.json" <<'EOF'
+{
+  "change_proposal_id": "cp-old",
+  "cp_kind": "Code",
+  "source_role": "Coder",
+  "operation": "patch",
+  "target_id": "1",
+  "state": "CP_MERGED",
+  "artifact_ref": "branch:llm-team/task-1",
+  "created_at": "2026-04-01T00:00:00Z"
+}
+EOF
+
+# Agent log with 12 lines so we can verify --lines 5 truncation.
+AGENT_LOG="${TARGET_WORKDIR}/logs/coder-20260501T000000Z.log"
+{
+  for i in $(seq 1 12); do
+    printf 'agent log line %d\n' "${i}"
+  done
+} >"${AGENT_LOG}"
+
+# Daemon log (target-scoped).
+mkdir -p "${TARGET_WORKDIR}/daemon"
+printf 'daemon line %s\n' alpha beta gamma >"${TARGET_WORKDIR}/daemon/coder.log"
+
+# --- Run dashboard ----------------------------------------------------------
+if ! "${LLM_TEAM_ROOT}/bin/llm-team" dashboard \
+       --no-github --target "${TARGET_NAME}" \
+       --lines 5 --out "${OUT_FILE}" >/dev/null 2>&1; then
+  fail "dashboard command exited non-zero"
+fi
+
+[ -s "${OUT_FILE}" ] || fail "dashboard output file is empty: ${OUT_FILE}"
+
+assert_contains() {
+  local needle="$1" label="$2"
+  if ! grep -Fq -- "${needle}" "${OUT_FILE}"; then
+    fail "${label}: expected to contain '${needle}'"
+  fi
+}
+assert_not_contains() {
+  local needle="$1" label="$2"
+  if grep -Fq -- "${needle}" "${OUT_FILE}"; then
+    fail "${label}: expected NOT to contain '${needle}'"
+  fi
+}
+
+assert_contains 'id="summary"'                       'summary anchor'
+assert_contains "id=\"target-${TARGET_NAME}\""       'target anchor'
+assert_contains 'TASK_REVIEW_READY'                   'pipeline row rendered'
+assert_contains 'cp-1'                                'open CP listed'
+assert_not_contains 'cp-old'                          'closed CP omitted'
+assert_contains 'coder-1'                             'lease worker rendered'
+
+# Hostile string must be escaped, not raw.
+assert_not_contains '<script>alert(1)</script>'      'hostile script escaped'
+assert_contains '&lt;script&gt;alert(1)&lt;/script&gt;' 'hostile string escaped'
+
+# --lines 5 → at most 5 of the 12 agent lines.
+agent_count="$(grep -c 'agent log line' "${OUT_FILE}" || true)"
+[ "${agent_count}" -le 5 ] || fail "agent log lines: expected <=5 with --lines 5, got ${agent_count}"
+[ "${agent_count}" -ge 1 ] || fail "agent log lines: expected >=1, got ${agent_count}"
+
+# Daemon log should appear.
+assert_contains 'daemon line alpha'                   'daemon log rendered'
+
+# No JS — `<script>` should not appear (only escaped form may exist).
+if grep -Fq '<script' "${OUT_FILE}"; then
+  fail "raw <script tag present in output"
+fi
+
+if [ "${failures}" -eq 0 ]; then
+  printf 'PASS tests/cli/test-dashboard.sh\n'
+  exit 0
+fi
+printf 'FAIL tests/cli/test-dashboard.sh (failures=%d)\n' "${failures}" >&2
+exit 1


### PR DESCRIPTION
## Summary
- `llm-team dashboard [--out path] [--target name]... [--lines N] [--no-github]` 추가 — 단일 self-contained HTML 1개를 생성해 운영자가 GitHub 요약·데몬·ledger·로그를 한 화면에서 본다.
- `application/ledger_summary.sh` — pipeline group-by, 24h caller window, recent slice (status.sh / dashboard.sh 가 동일 집계를 두 번 구현하지 않게 분리).
- `lib/html.sh` — HTML escape + table/details 렌더 헬퍼. 모든 사용자/외부 데이터(이슈 제목, log line, target id 등)는 escape 통과.
- `bin/llm-team` — `dashboard` 분기 + usage 1줄 추가.

## 설계 메모
- 정적 HTML 1파일 + inline CSS, JS 0. 접기/펼치기는 `<details>` 만으로 처리.
- `--no-github` 또는 `gh` 미설치/요청 실패 시 GitHub 섹션은 "(unavailable)" 로 fallback (명령은 0).
- 활성 데몬 카운트는 글로벌 + per-target `*.pid` 파일 모두 스캔.

## Test plan
- [x] `bash tests/application/test-ledger-summary.sh` — group-by, 24h window 경계, 손상 라인 무시, 빈 ledger fallback
- [x] `bash tests/cli/test-dashboard.sh` — 앵커 (`id="summary"`, `id="target-<name>"`), 적대 문자열 escape, 닫힌 CP 제외, `--lines N` 절단
- [x] `bash tests/cli/test-llm-team-cli.sh` — front-door 회귀
- [x] `bash tests/scheduler/test-runner-pipeline.sh` — runner 회귀
- [x] `bash tests/application/test-caller-dispatch.sh` — caller dispatch 회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)