### PR TITLE
fix(pipeline): GraphQL→REST + 9 contract drifts

### DIFF
--- a/adapters/issue_tracker/github.sh
+++ b/adapters/issue_tracker/github.sh
@@ -92,6 +92,23 @@ _github_issue_add_label() {
 _github_issue_remove_label() {
   local repo="$1" num="$2" label="$3"
   local enc; enc="$(jq -rn --arg l "${label}" '$l|@uri')"
+  # Idempotent removal: REST `DELETE /issues/{n}/labels/{name}` returns 404
+  # when the issue does not have that label. The post-condition ("label is
+  # not on the issue") already holds, so treat 404 as success. Without this,
+  # state transitions like add-new → remove-old break under retry whenever
+  # the old label was already absent (e.g., add succeeded on a previous run
+  # but remove failed transiently, or another process cleared the label).
+  local err rc
+  err="$(gh api -X DELETE "repos/${repo}/issues/${num}/labels/${enc}" 2>&1 >/dev/null)"
+  rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    return 0
+  fi
+  case "${err}" in
+    *"HTTP 404"*) return 0 ;;
+  esac
+  # Other failure (network, 5xx, auth) — fall back to gh_with_retry so
+  # transient errors still recover.
   gh_with_retry gh api -X DELETE "repos/${repo}/issues/${num}/labels/${enc}" >/dev/null 2>&1
 }
 
@@ -783,5 +800,54 @@ it_revision_pin_get() {
       gh_with_retry gh api "repos/${repo}/milestones/${num}" --jq '.updated_at // empty'
       ;;
     *) log_error "it_revision_pin_get: invalid kind '${kind}'"; return 1 ;;
+  esac
+}
+
+# ============================================================================
+# Port API: Context snapshot
+# ============================================================================
+
+# it_object_get_snapshot <repo> <kind> <id>  → echo markdown block | empty
+# Read-only fetch of an object's live content for prompt injection. On any
+# fetch failure we return 0 with empty stdout — the caller treats that as
+# "snapshot unavailable" and falls back to the manifest-only context.
+it_object_get_snapshot() {
+  local repo="$1" kind="$2" id="$3"
+  [ -n "${repo}" ] && [ -n "${kind}" ] && [ -n "${id}" ] || {
+    log_error "it_object_get_snapshot: repo, kind, id are required"
+    return 1
+  }
+  case "${kind}" in
+    milestone)
+      local m
+      m="$(gh_with_retry gh api "repos/${repo}/milestones/${id}" 2>/dev/null)" || return 0
+      printf '### milestone:%s\n#### title\n%s\n\n#### description\n%s\n' \
+        "${id}" \
+        "$(printf '%s' "${m}" | jq -r '.title // ""')" \
+        "$(printf '%s' "${m}" | jq -r '.description // ""')"
+      ;;
+    issue|task|feature_request_issue)
+      local s labels
+      s="$(gh_with_retry gh api "repos/${repo}/issues/${id}" 2>/dev/null)" || return 0
+      labels="$(printf '%s' "${s}" | jq -r '[.labels[].name] | join(",")')"
+      printf '### issue:%s\n#### title\n%s\n\n#### labels\n%s\n\n#### body\n%s\n' \
+        "${id}" \
+        "$(printf '%s' "${s}" | jq -r '.title // ""')" \
+        "${labels}" \
+        "$(printf '%s' "${s}" | jq -r '.body // ""')"
+      ;;
+    pr)
+      local p
+      p="$(gh_with_retry gh api "repos/${repo}/pulls/${id}" 2>/dev/null)" || return 0
+      printf '### pr:%s\n#### title\n%s\n\n#### body\n%s\n' \
+        "${id}" \
+        "$(printf '%s' "${p}" | jq -r '.title // ""')" \
+        "$(printf '%s' "${p}" | jq -r '.body // ""')"
+      ;;
+    *)
+      # Unknown kind — no snapshot, but not an error (caller only injects
+      # when populated).
+      return 0
+      ;;
   esac
 }

--- a/adapters/issue_tracker/github.sh
+++ b/adapters/issue_tracker/github.sh
@@ -73,7 +73,26 @@ _github_issue_get_body() {
 
 _github_issue_set_body() {
   local repo="$1" num="$2" body="$3"
-  gh_with_retry gh issue edit "${num}" --repo "${repo}" --body "${body}" >/dev/null
+  local payload; payload="$(jq -nc --arg b "${body}" '{body:$b}')"
+  gh_with_retry gh api -X PATCH "repos/${repo}/issues/${num}" --input - <<<"${payload}" >/dev/null
+}
+
+# Label mutation helpers — REST equivalents of `gh issue edit --add-label /
+# --remove-label`. Use these instead of the gh CLI: the CLI mutates labels via
+# GraphQL, which has a separate (smaller) rate-limit pool that is easy to
+# exhaust during a daemon retry storm. REST issues/N/labels share the larger
+# core pool. (Per GitHub API: PR labels live on the same /issues/N/labels
+# endpoint — PRs are issues at the API layer.)
+_github_issue_add_label() {
+  local repo="$1" num="$2" label="$3"
+  local payload; payload="$(jq -nc --arg l "${label}" '{labels:[$l]}')"
+  gh_with_retry gh api -X POST "repos/${repo}/issues/${num}/labels" --input - <<<"${payload}" >/dev/null
+}
+
+_github_issue_remove_label() {
+  local repo="$1" num="$2" label="$3"
+  local enc; enc="$(jq -rn --arg l "${label}" '$l|@uri')"
+  gh_with_retry gh api -X DELETE "repos/${repo}/issues/${num}/labels/${enc}" >/dev/null 2>&1
 }
 
 _github_pr_get_body() {
@@ -83,7 +102,8 @@ _github_pr_get_body() {
 
 _github_pr_set_body() {
   local repo="$1" num="$2" body="$3"
-  gh_with_retry gh pr edit "${num}" --repo "${repo}" --body "${body}" >/dev/null
+  local payload; payload="$(jq -nc --arg b "${body}" '{body:$b}')"
+  gh_with_retry gh api -X PATCH "repos/${repo}/pulls/${num}" --input - <<<"${payload}" >/dev/null
 }
 
 # Replace the cp-state marker line in a PR body.
@@ -214,14 +234,10 @@ it_milestone_list_in_state() {
   }
   local marker
   marker="$(state_marker milestone "${state}")"
+  # Filter inside jq so multi-line descriptions stay intact.
   gh_with_retry gh api "repos/${repo}/milestones?state=open&sort=created_at&direction=asc" \
-    --jq '.[] | "\(.number)\t\(.description // "")"' \
-    | while IFS=$'\t' read -r n desc; do
-        [ -n "${n}" ] || continue
-        if printf '%s' "${desc}" | grep -Fq "${marker}"; then
-          printf '%s\n' "${n}"
-        fi
-      done
+    | jq -r --arg marker "${marker}" \
+        '.[] | select((.description // "") | contains($marker)) | .number'
 }
 
 # ============================================================================
@@ -245,17 +261,28 @@ it_issue_create() {
     log_error "it_issue_create: repo and --title are required"
     return 1
   }
-  local args=(--repo "${repo}" --title "${title}" --body "${body}")
-  if [ -n "${labels}" ]; then
-    args+=(--label "${labels}")
-  fi
-  if [ -n "${milestone}" ]; then
-    args+=(--milestone "${milestone}")
-  fi
-  local url num
-  url="$(gh_with_retry gh issue create "${args[@]}")" || return 1
-  num="$(printf '%s' "${url}" | sed -E 's@.*/issues/([0-9]+).*@\1@')"
-  [ -n "${num}" ] || { log_error "it_issue_create: failed to parse issue number from '${url}'"; return 1; }
+  # NOTE: We use the REST API rather than `gh issue create` because the CLI's
+  # `--milestone` flag resolves milestones by title and fails with
+  # "could not add to milestone 'N': 'N' not found" when given a numeric id.
+  # The REST API accepts the milestone *number* directly.
+  local payload
+  payload="$(jq -nc \
+    --arg title "${title}" \
+    --arg body  "${body}" \
+    --arg ms    "${milestone}" \
+    --arg lbls  "${labels}" \
+    '
+      {title: $title, body: $body}
+      + ( if ($ms | length) > 0 then {milestone: ($ms | tonumber)} else {} end )
+      + ( if ($lbls | length) > 0
+          then {labels: ($lbls | split(",") | map(select(length>0)))}
+          else {} end )
+    ')" || { log_error "it_issue_create: failed to build payload"; return 1; }
+  local response num
+  response="$(gh_with_retry gh api -X POST "repos/${repo}/issues" --input - <<<"${payload}")" \
+    || return 1
+  num="$(printf '%s' "${response}" | jq -r '.number // empty')"
+  [ -n "${num}" ] || { log_error "it_issue_create: response missing .number"; return 1; }
   printf '%s\n' "${num}"
 }
 
@@ -277,7 +304,7 @@ it_issue_set_state() {
     return 1
   }
   new_label="$(label_with_prefix "${TARGET_LABEL_PREFIX:-}" "${new_label}")"
-  gh_with_retry gh issue edit "${num}" --repo "${repo}" --add-label "${new_label}" >/dev/null \
+  _github_issue_add_label "${repo}" "${num}" "${new_label}" \
     || { log_error "it_issue_set_state: add ${new_label} failed on issue #${num}"; return 1; }
   if [ -n "${old_state}" ]; then
     state_is_valid task "${old_state}" || {
@@ -286,7 +313,7 @@ it_issue_set_state() {
     }
     old_label="$(task_state_to_label "${old_state}")" || return 1
     old_label="$(label_with_prefix "${TARGET_LABEL_PREFIX:-}" "${old_label}")"
-    gh_with_retry gh issue edit "${num}" --repo "${repo}" --remove-label "${old_label}" >/dev/null \
+    _github_issue_remove_label "${repo}" "${num}" "${old_label}" \
       || { log_error "it_issue_set_state: remove ${old_label} failed on issue #${num}"; return 1; }
   fi
 }
@@ -370,7 +397,7 @@ it_issue_add_label() {
     log_error "it_issue_add_label: repo, num, label are required"
     return 1
   }
-  gh_with_retry gh issue edit "${num}" --repo "${repo}" --add-label "${label}" >/dev/null
+  _github_issue_add_label "${repo}" "${num}" "${label}"
 }
 
 # it_issue_remove_label <repo> <num> <label>  (idempotent — absent label is OK)
@@ -380,7 +407,7 @@ it_issue_remove_label() {
     log_error "it_issue_remove_label: repo, num, label are required"
     return 1
   }
-  gh_with_retry gh issue edit "${num}" --repo "${repo}" --remove-label "${label}" >/dev/null 2>&1 || return 0
+  _github_issue_remove_label "${repo}" "${num}" "${label}" || return 0
 }
 
 # it_issue_clear_state_labels <repo> <num> [prefix]
@@ -394,8 +421,7 @@ it_issue_clear_state_labels() {
   local label prefixed
   for label in "${ALL_ISSUE_LABELS[@]}"; do
     prefixed="$(label_with_prefix "${prefix}" "${label}")"
-    gh_with_retry gh issue edit "${num}" --repo "${repo}" \
-      --remove-label "${prefixed}" >/dev/null 2>&1 || true
+    _github_issue_remove_label "${repo}" "${num}" "${prefixed}" || true
   done
 }
 
@@ -409,8 +435,14 @@ it_issue_list_in_state() {
   local label
   label="$(task_state_to_label "${state}")" || return 1
   label="$(label_with_prefix "${TARGET_LABEL_PREFIX:-}" "${label}")"
-  gh_with_retry gh issue list --repo "${repo}" --label "${label}" --state open \
-    --json number,createdAt --jq 'sort_by(.createdAt) | .[].number'
+  # REST list endpoint sorts oldest-first via direction=asc; PRs share the
+  # /issues collection so we filter them out with `select(.pull_request|not)`.
+  # Using REST instead of `gh issue list` keeps this off the GraphQL pool,
+  # which a daemon retry storm can otherwise exhaust.
+  local enc; enc="$(jq -rn --arg l "${label}" '$l|@uri')"
+  gh_with_retry gh api --paginate \
+    "repos/${repo}/issues?state=open&labels=${enc}&sort=created&direction=asc&per_page=100" \
+    --jq '.[] | select(.pull_request|not) | .number'
 }
 
 # it_issue_list_with_label <repo> <label> [--no-milestone]
@@ -424,13 +456,15 @@ it_issue_list_with_label() {
       *) log_error "it_issue_list_with_label: unknown flag '$1'"; return 1 ;;
     esac
   done
+  local enc; enc="$(jq -rn --arg l "${label}" '$l|@uri')"
   if [ "${no_ms}" -eq 1 ]; then
-    gh_with_retry gh issue list --repo "${repo}" --label "${label}" --state open \
-      --search "no:milestone" \
-      --json number,createdAt --jq 'sort_by(.createdAt) | .[].number'
+    gh_with_retry gh api --paginate \
+      "repos/${repo}/issues?state=open&labels=${enc}&sort=created&direction=asc&per_page=100" \
+      --jq '.[] | select(.pull_request|not) | select(.milestone == null) | .number'
   else
-    gh_with_retry gh issue list --repo "${repo}" --label "${label}" --state open \
-      --json number,createdAt --jq 'sort_by(.createdAt) | .[].number'
+    gh_with_retry gh api --paginate \
+      "repos/${repo}/issues?state=open&labels=${enc}&sort=created&direction=asc&per_page=100" \
+      --jq '.[] | select(.pull_request|not) | .number'
   fi
 }
 
@@ -462,12 +496,19 @@ it_pr_create() {
     log_error "it_pr_create: repo, --head, --base, --title are required"
     return 1
   }
-  local args=(--repo "${repo}" --head "${head}" --base "${base}" --title "${title}" --body "${body}")
-  [ "${draft}" -eq 1 ] && args+=(--draft)
-  local url num
-  url="$(gh_with_retry gh pr create "${args[@]}")" || return 1
-  num="$(printf '%s' "${url}" | sed -E 's@.*/pull/([0-9]+).*@\1@')"
-  [ -n "${num}" ] || { log_error "it_pr_create: failed to parse PR number from '${url}'"; return 1; }
+  # REST so PR creation does not consume the GraphQL pool.
+  local payload
+  payload="$(jq -nc \
+    --arg head "${head}" --arg base "${base}" \
+    --arg title "${title}" --arg body "${body}" \
+    --argjson draft "${draft}" \
+    '{title:$title, head:$head, base:$base, body:$body, draft:($draft==1)}')" \
+    || { log_error "it_pr_create: failed to build payload"; return 1; }
+  local response num
+  response="$(gh_with_retry gh api -X POST "repos/${repo}/pulls" --input - <<<"${payload}")" \
+    || return 1
+  num="$(printf '%s' "${response}" | jq -r '.number // empty')"
+  [ -n "${num}" ] || { log_error "it_pr_create: response missing .number"; return 1; }
   printf '%s\n' "${num}"
 }
 
@@ -500,13 +541,13 @@ it_pr_set_cp_state() {
   new_label="$(cp_state_to_label "${new_state}" 2>/dev/null || true)"
   if [ -n "${new_label}" ]; then
     new_label="$(label_with_prefix "${TARGET_LABEL_PREFIX:-}" "${new_label}")"
-    gh_with_retry gh pr edit "${num}" --repo "${repo}" --add-label "${new_label}" >/dev/null 2>&1 || true
+    _github_issue_add_label "${repo}" "${num}" "${new_label}" || true
   fi
   if [ -n "${old_state}" ]; then
     old_label="$(cp_state_to_label "${old_state}" 2>/dev/null || true)"
     if [ -n "${old_label}" ]; then
       old_label="$(label_with_prefix "${TARGET_LABEL_PREFIX:-}" "${old_label}")"
-      gh_with_retry gh pr edit "${num}" --repo "${repo}" --remove-label "${old_label}" >/dev/null 2>&1 || true
+      _github_issue_remove_label "${repo}" "${num}" "${old_label}" || true
     fi
   fi
 }
@@ -525,11 +566,17 @@ it_pr_get_cp_state() {
 # it_pr_merge <repo> <num> --squash|--merge|--rebase  → echo merge_sha
 it_pr_merge() {
   local repo="$1" num="$2" mode="$3"
+  local merge_method
   case "${mode}" in
-    --squash|--merge|--rebase) ;;
+    --squash) merge_method="squash" ;;
+    --merge)  merge_method="merge" ;;
+    --rebase) merge_method="rebase" ;;
     *) log_error "it_pr_merge: mode must be --squash, --merge, or --rebase"; return 1 ;;
   esac
-  gh_with_retry gh pr merge "${num}" --repo "${repo}" "${mode}" >/dev/null \
+  # REST PUT /pulls/{n}/merge instead of `gh pr merge` (GraphQL).
+  local payload
+  payload="$(jq -nc --arg m "${merge_method}" '{merge_method:$m}')"
+  gh_with_retry gh api -X PUT "repos/${repo}/pulls/${num}/merge" --input - <<<"${payload}" >/dev/null \
     || { log_error "it_pr_merge: merge failed for PR #${num}"; return 1; }
   gh_with_retry gh api "repos/${repo}/pulls/${num}" --jq '.merge_commit_sha // empty'
 }

--- a/adapters/issue_tracker/in_memory.sh
+++ b/adapters/issue_tracker/in_memory.sh
@@ -944,3 +944,46 @@ it_revision_pin_get() {
     *) log_error "it_revision_pin_get: invalid kind '${kind}'"; return 1 ;;
   esac
 }
+
+# ============================================================================
+# Port API: Context snapshot
+# ============================================================================
+
+it_object_get_snapshot() {
+  local repo="$1" kind="$2" id="$3"
+  [ -n "${repo}" ] && [ -n "${kind}" ] && [ -n "${id}" ] || {
+    log_error "it_object_get_snapshot: repo, kind, id are required"
+    return 1
+  }
+  case "${kind}" in
+    milestone)
+      _in_memory_milestone_exists "${id}" || return 0
+      local mp
+      mp="$(_in_memory_milestone_path "${id}")"
+      printf '### milestone:%s\n#### title\n%s\n\n#### description\n%s\n' \
+        "${id}" \
+        "$(jq -r '.title // ""' "${mp}")" \
+        "$(jq -r '.description // ""' "${mp}")"
+      ;;
+    issue|task|feature_request_issue)
+      _in_memory_issue_exists "${id}" || return 0
+      local ip
+      ip="$(_in_memory_issue_path "${id}")"
+      printf '### issue:%s\n#### title\n%s\n\n#### labels\n%s\n\n#### body\n%s\n' \
+        "${id}" \
+        "$(jq -r '.title // ""' "${ip}")" \
+        "$(jq -r '[.labels[]?] | join(",")' "${ip}")" \
+        "$(jq -r '.body // ""' "${ip}")"
+      ;;
+    pr)
+      _in_memory_pr_exists "${id}" || return 0
+      local pp
+      pp="$(_in_memory_pr_path "${id}")"
+      printf '### pr:%s\n#### title\n%s\n\n#### body\n%s\n' \
+        "${id}" \
+        "$(jq -r '.title // ""' "${pp}")" \
+        "$(jq -r '.body // ""' "${pp}")"
+      ;;
+    *) return 0 ;;
+  esac
+}

--- a/application/caller_dispatch.sh
+++ b/application/caller_dispatch.sh
@@ -66,13 +66,19 @@ _caller_target() {
 
 _caller_caller_id() { printf '%s' "${LLM_TEAM_CALLER_ID:-caller_dispatch}"; }
 
-# True (rc=0) if ledger already records this idempotency_key.
+# True (rc=0) if ledger already records this idempotency_key as a successful
+# application. Failure rows (result=error|stale|invalid) do NOT count: per
+# RGC-FAILURE the transient failures must remain retryable, otherwise a single
+# adapter glitch permanently locks the next scheduled attempt out as a
+# spurious duplicate.
 _caller_ledger_has_key() {
   local target="$1" key="$2"
   local path
   path="$(transition_ledger_path "${target}")"
   [ -f "${path}" ] || return 1
-  jq -e --arg k "${key}" 'select(.idempotency_key == $k)' "${path}" >/dev/null 2>&1
+  jq -e --arg k "${key}" \
+    'select(.idempotency_key == $k) | select((.result // "") == "applied" or (.result // "") == "duplicate")' \
+    "${path}" >/dev/null 2>&1
 }
 
 # _caller_ledger_write target object_kind object_id from_state to_state \
@@ -246,6 +252,7 @@ caller_apply_output() {
     log_error "caller_apply_output: envelope missing output_kind/idempotency_key/target_id"
     return 1
   fi
+  target_id="$(_caller_target_id_strip_kind "${target_id}")"
 
   # SOC-IDEMPOTENCY: short-circuit duplicate.
   if _caller_ledger_has_key "${target}" "${idempotency_key}"; then
@@ -315,6 +322,22 @@ _caller_object_kind_for_role() {
   esac
 }
 
+# Normalize envelope.target_id by stripping a leading "<kind>:" segment for
+# adapter-level numeric ids (milestone, task, issue). Hierarchical CP ids
+# ("cp:code:...") are preserved.
+#
+# Per prompts/*.md the LLM emits target_id like "milestone:42" / "task:7", but
+# legacy test fixtures and the GitHub adapters expect bare numeric ids. The
+# contract documents (AGC-OUTPUT) do not mandate a specific format, so the
+# adapter layer absorbs both forms here.
+_caller_target_id_strip_kind() {
+  local raw="${1:-}"
+  case "${raw}" in
+    milestone:*|task:*|issue:*) printf '%s' "${raw#*:}" ;;
+    *) printf '%s' "${raw}" ;;
+  esac
+}
+
 # ============================================================================
 # Branch 1/2: spec_proposal (PO / PM)
 # ============================================================================
@@ -340,13 +363,20 @@ _caller_apply_spec_proposal() {
   change_proposal_set_state "${cp_path}" CP_READY_FOR_HUMAN_GATE CP_DRAFT \
     || { log_error "_caller_apply_spec_proposal: CP CP_DRAFT→CP_READY_FOR_HUMAN_GATE failed"; return 1; }
 
-  # Update milestone body if envelope provides one.
+  # Update milestone body — REQUIRED for spec_proposal. prompts/po.md and
+  # prompts/pm.md document the field as `milestone_body_proposal`; legacy
+  # callers may still emit `milestone_body`. Accept either, but reject when
+  # neither is present: a structurally valid envelope with no spec content
+  # would otherwise advance state to *_GATE with nothing for the human
+  # reviewer to read, defeating the gate's purpose.
   local body
-  body="$(jq -r '.artifacts.milestone_body // empty' "${env_path}")"
-  if [ -n "${body}" ]; then
-    it_milestone_update "${repo}" "${target_id}" --body "${body}" \
-      || log_warn "_caller_apply_spec_proposal: milestone_update body failed"
+  body="$(jq -r '.artifacts.milestone_body_proposal // .artifacts.milestone_body // empty' "${env_path}")"
+  if [ -z "${body}" ]; then
+    log_error "_caller_apply_spec_proposal: ${role} envelope missing artifacts.milestone_body_proposal"
+    return 1
   fi
+  it_milestone_update "${repo}" "${target_id}" --body "${body}" \
+    || { log_error "_caller_apply_spec_proposal: milestone_update body failed"; return 1; }
 
   it_milestone_set_state "${repo}" "${target_id}" "${to_state}" "${from_state}" \
     || { log_error "_caller_apply_spec_proposal: milestone ${from_state}→${to_state} failed"; return 1; }
@@ -395,7 +425,12 @@ _caller_apply_task_plan() {
   local count
   count="$(printf '%s' "${tasks}" | jq 'length')"
   if [ "${count}" -eq 0 ]; then
-    log_warn "_caller_apply_task_plan: artifacts.tasks empty"
+    # Fail-fast: an empty task list silently advances milestone to IMPLEMENTING
+    # with no work for Coder, defeating the Decompose stage entirely. Reject so
+    # the runner records `error` and the milestone stays at DECOMPOSE_READY for
+    # retry, mirroring the spec_proposal empty-body guard.
+    log_error "_caller_apply_task_plan: artifacts.tasks is empty"
+    return 1
   fi
 
   # slug → issue_num map (bash 3.2 compatible — flat parallel arrays).

--- a/application/caller_dispatch.sh
+++ b/application/caller_dispatch.sh
@@ -354,6 +354,19 @@ _caller_apply_spec_proposal() {
     *)  log_error "_caller_apply_spec_proposal: unknown role '${role}'"; return 1 ;;
   esac
 
+  # Validate spec content BEFORE creating any CP / setting CP state. prompts/po.md
+  # and prompts/pm.md document the field as `milestone_body_proposal`; legacy
+  # callers may still emit `milestone_body`. A structurally valid envelope with
+  # no spec content would otherwise advance state to *_GATE with nothing for a
+  # human reviewer to read. Validating up front also avoids leaving an orphan
+  # CP file in CP_READY_FOR_HUMAN_GATE on retry when only the body was missing.
+  local body
+  body="$(jq -r '.artifacts.milestone_body_proposal // .artifacts.milestone_body // empty' "${env_path}")"
+  if [ -z "${body}" ]; then
+    log_error "_caller_apply_spec_proposal: ${role} envelope missing artifacts.milestone_body_proposal"
+    return 1
+  fi
+
   local artifact_ref
   artifact_ref="$(jq -r '.artifacts.cp_artifact_ref // empty' "${env_path}")"
   local cp_path
@@ -363,18 +376,6 @@ _caller_apply_spec_proposal() {
   change_proposal_set_state "${cp_path}" CP_READY_FOR_HUMAN_GATE CP_DRAFT \
     || { log_error "_caller_apply_spec_proposal: CP CP_DRAFT→CP_READY_FOR_HUMAN_GATE failed"; return 1; }
 
-  # Update milestone body — REQUIRED for spec_proposal. prompts/po.md and
-  # prompts/pm.md document the field as `milestone_body_proposal`; legacy
-  # callers may still emit `milestone_body`. Accept either, but reject when
-  # neither is present: a structurally valid envelope with no spec content
-  # would otherwise advance state to *_GATE with nothing for the human
-  # reviewer to read, defeating the gate's purpose.
-  local body
-  body="$(jq -r '.artifacts.milestone_body_proposal // .artifacts.milestone_body // empty' "${env_path}")"
-  if [ -z "${body}" ]; then
-    log_error "_caller_apply_spec_proposal: ${role} envelope missing artifacts.milestone_body_proposal"
-    return 1
-  fi
   it_milestone_update "${repo}" "${target_id}" --body "${body}" \
     || { log_error "_caller_apply_spec_proposal: milestone_update body failed"; return 1; }
 

--- a/application/onboarding/checklists/github_pipeline_v1.sh
+++ b/application/onboarding/checklists/github_pipeline_v1.sh
@@ -223,11 +223,16 @@ _check_labels_bootstrap_done() {
     "${LABEL_PAUSED}"
     "${LABEL_FEATURE_REQUEST}"
   )
+  # Use REST to enumerate labels — `gh label list` goes through GraphQL whose
+  # rate-limit pool is small and easily exhausted by daemon retry storms,
+  # causing this gate to false-fail and block startup.
+  local repo_labels
+  repo_labels="$(gh api --paginate "repos/${repo}/labels" --jq '.[].name' 2>/dev/null)" \
+    || { printf 'gh api repos/%s/labels failed' "${repo}"; return 1; }
   local missing="" l name
   for l in "${probes[@]}"; do
     name="${prefix}${l}"
-    if ! gh label list --repo "${repo}" --search "${name}" --json name 2>/dev/null \
-        | grep -Fq "\"${name}\""; then
+    if ! printf '%s\n' "${repo_labels}" | grep -Fxq "${name}"; then
       missing="${missing} ${name}"
     fi
   done

--- a/lib/ports/issue_tracker.sh
+++ b/lib/ports/issue_tracker.sh
@@ -77,6 +77,16 @@ PORT_ISSUE_TRACKER_REQUIRED_FUNCTIONS=(
 
   # --- Revision pin ---
   it_revision_pin_get            # repo kind num scope                 → echo etag/sha
+
+  # --- Context snapshot ---
+  # Read-only fetch of an object's live content for prompt injection.
+  # kind ∈ milestone|issue|task|feature_request_issue|pr.
+  # stdout: formatted markdown block (title + body/description + labels for
+  #         issues). Empty stdout + return 0 when the object is unavailable
+  #         (caller treats as "no snapshot" and falls back to manifest-only).
+  # Caller (scheduler/runner) must use this rather than calling `gh` directly,
+  # so that test adapters (in_memory) and future adapters can supply data.
+  it_object_get_snapshot         # repo kind id                        → echo markdown block | empty
 )
 
 # Invariant 명세 (텍스트, 검사용 아닌 문서용).

--- a/prompts/pm.md
+++ b/prompts/pm.md
@@ -55,6 +55,11 @@ fenced block 이 두 개 이상이면 invalid 로 거부된다.
 - manifest 외 객체 참조 — `input_revision_pins` 의 `object_id` 는 모두 manifest entries 에 존재해야 한다
 - 할당 범위 밖 파일 변경 — `artifacts` 의 파일 경로는 worktree 내부여야 한다
 
+artifacts 필수 키 (pm):
+- `artifacts.milestone_body_proposal`: 사람 검토용 milestone 본문 markdown.
+  scenario_spec / acceptance_criteria / out_of_scope / conflict_notes 를 사람이
+  읽기 쉬운 형태로 렌더링한 단일 문자열. **비어있으면 PM_GATE 전이가 거부된다.**
+
 artifacts 권장 키 (pm):
 - `artifacts.scenario_spec`: 시나리오 본문
 - `artifacts.acceptance_criteria[]`: 안정 `AC-ID` 가 포함된 검증 가능한 수용 기준 목록
@@ -76,6 +81,7 @@ artifacts 권장 키 (pm):
   "idempotency_key": "pm:42:r1",
   "summary": "Compose PM scenario spec with stable AC-IDs",
   "artifacts": {
+    "milestone_body_proposal": "## Scenario\n...\n\n## Acceptance Criteria\n- AC-1: ...\n\n## Out of Scope\n- ...\n\n## Conflict Notes\n- ...",
     "scenario_spec": "...",
     "acceptance_criteria": [{"ac_id": "AC-1", "statement": "..."}],
     "out_of_scope": [],

--- a/scheduler/runner.sh
+++ b/scheduler/runner.sh
@@ -398,7 +398,56 @@ esac
 # Agent invocation
 # ============================================================================
 
-PROMPT_TEXT="$(agent_prompt_assemble "${ROLE}" "${MANIFEST_FILE}")" || {
+# Build a context snapshot for the primary manifest entry. Without this, the
+# manifest only carries object_id+revision_pin and the LLM has no way to read
+# the actual milestone description / issue body, leading to placeholder output
+# (e.g. "no AC available, returning bootstrap task"). The snapshot is added as
+# Caller Notes and is read-only — the contract still mandates output via the
+# envelope, not via direct mutation.
+_runner_context_snapshot() {
+  local repo="$1" kind="$2" id="$3"
+  case "${kind}" in
+    milestone)
+      local m
+      m="$(gh_with_retry gh api "repos/${repo}/milestones/${id}" 2>/dev/null)" || return 0
+      printf '### milestone:%s\n#### title\n%s\n\n#### description\n%s\n' \
+        "${id}" \
+        "$(printf '%s' "${m}" | jq -r '.title // ""')" \
+        "$(printf '%s' "${m}" | jq -r '.description // ""')"
+      ;;
+    issue|task|feature_request_issue)
+      local s labels
+      s="$(gh_with_retry gh api "repos/${repo}/issues/${id}" 2>/dev/null)" || return 0
+      labels="$(printf '%s' "${s}" | jq -r '[.labels[].name] | join(",")')"
+      printf '### issue:%s\n#### title\n%s\n\n#### labels\n%s\n\n#### body\n%s\n' \
+        "${id}" \
+        "$(printf '%s' "${s}" | jq -r '.title // ""')" \
+        "${labels}" \
+        "$(printf '%s' "${s}" | jq -r '.body // ""')"
+      ;;
+    pr)
+      local p
+      p="$(gh_with_retry gh api "repos/${repo}/pulls/${id}" 2>/dev/null)" || return 0
+      printf '### pr:%s\n#### title\n%s\n\n#### body\n%s\n' \
+        "${id}" \
+        "$(printf '%s' "${p}" | jq -r '.title // ""')" \
+        "$(printf '%s' "${p}" | jq -r '.body // ""')"
+      ;;
+  esac
+}
+
+CONTEXT_SNAPSHOT="$(_runner_context_snapshot "${TARGET_REPO}" "${TARGET_OBJECT_KIND}" "${TARGET_OBJECT_ID}" 2>/dev/null || true)"
+EXTRA_INSTRUCTION=""
+if [ -n "${CONTEXT_SNAPSHOT}" ]; then
+  EXTRA_INSTRUCTION="## Context Snapshot (read-only)
+The primary manifest entry resolves to the following live content. Use this as
+authoritative context — do NOT emit placeholder/bootstrap output when this is
+populated.
+
+${CONTEXT_SNAPSHOT}"
+fi
+
+PROMPT_TEXT="$(agent_prompt_assemble "${ROLE}" "${MANIFEST_FILE}" "${EXTRA_INSTRUCTION}")" || {
   log_error "runner: agent_prompt_assemble failed"
   _runner_claim_rollback "${ROLE}" "${TARGET_REPO}" "${TARGET_OBJECT_KIND}" "${TARGET_OBJECT_ID}" 2>/dev/null || true
   _runner_ledger_write "${TARGET}" "${TARGET_OBJECT_KIND}" "${TARGET_OBJECT_ID}" \

--- a/scheduler/runner.sh
+++ b/scheduler/runner.sh
@@ -404,39 +404,11 @@ esac
 # (e.g. "no AC available, returning bootstrap task"). The snapshot is added as
 # Caller Notes and is read-only — the contract still mandates output via the
 # envelope, not via direct mutation.
-_runner_context_snapshot() {
-  local repo="$1" kind="$2" id="$3"
-  case "${kind}" in
-    milestone)
-      local m
-      m="$(gh_with_retry gh api "repos/${repo}/milestones/${id}" 2>/dev/null)" || return 0
-      printf '### milestone:%s\n#### title\n%s\n\n#### description\n%s\n' \
-        "${id}" \
-        "$(printf '%s' "${m}" | jq -r '.title // ""')" \
-        "$(printf '%s' "${m}" | jq -r '.description // ""')"
-      ;;
-    issue|task|feature_request_issue)
-      local s labels
-      s="$(gh_with_retry gh api "repos/${repo}/issues/${id}" 2>/dev/null)" || return 0
-      labels="$(printf '%s' "${s}" | jq -r '[.labels[].name] | join(",")')"
-      printf '### issue:%s\n#### title\n%s\n\n#### labels\n%s\n\n#### body\n%s\n' \
-        "${id}" \
-        "$(printf '%s' "${s}" | jq -r '.title // ""')" \
-        "${labels}" \
-        "$(printf '%s' "${s}" | jq -r '.body // ""')"
-      ;;
-    pr)
-      local p
-      p="$(gh_with_retry gh api "repos/${repo}/pulls/${id}" 2>/dev/null)" || return 0
-      printf '### pr:%s\n#### title\n%s\n\n#### body\n%s\n' \
-        "${id}" \
-        "$(printf '%s' "${p}" | jq -r '.title // ""')" \
-        "$(printf '%s' "${p}" | jq -r '.body // ""')"
-      ;;
-  esac
-}
-
-CONTEXT_SNAPSHOT="$(_runner_context_snapshot "${TARGET_REPO}" "${TARGET_OBJECT_KIND}" "${TARGET_OBJECT_ID}" 2>/dev/null || true)"
+#
+# Fetched via the issue_tracker port (`it_object_get_snapshot`) rather than a
+# direct `gh` call: scheduler/runner must not couple to the GitHub adapter, or
+# in_memory and future adapters silently lose snapshot enrichment.
+CONTEXT_SNAPSHOT="$(it_object_get_snapshot "${TARGET_REPO}" "${TARGET_OBJECT_KIND}" "${TARGET_OBJECT_ID}" 2>/dev/null || true)"
 EXTRA_INSTRUCTION=""
 if [ -n "${CONTEXT_SNAPSHOT}" ]; then
   EXTRA_INSTRUCTION="## Context Snapshot (read-only)

--- a/scripts/cli/daemon.sh
+++ b/scripts/cli/daemon.sh
@@ -111,9 +111,34 @@ daemon_stop_role() {
   pid="$(cat "${pid_file}" 2>/dev/null || true)"
   if cli_pid_running "${pid}"; then
     kill "${pid}" >/dev/null 2>&1 || true
-    sleep 1
+    # Wait for graceful exit so the daemon's EXIT trap can release its
+    # lockdir before any subsequent `daemon start` reacquires it.
+    local timeout="${LLM_TEAM_DAEMON_STOP_TIMEOUT:-10}"
+    local waited=0
+    while cli_pid_running "${pid}" && [ "${waited}" -lt "${timeout}" ]; do
+      sleep 1
+      waited=$((waited + 1))
+    done
+    if cli_pid_running "${pid}"; then
+      kill -9 "${pid}" >/dev/null 2>&1 || true
+      sleep 1
+    fi
   fi
   rm -f "${pid_file}"
+  # Defensive: if the daemon was SIGKILLed before its EXIT trap fired, its
+  # lockdir under workdir/daemon-<role>-<scope>.lockd lingers and would block
+  # the next start. Remove it only if the recorded pid (or any pid inside) is
+  # no longer alive, mirroring the "stale lock" reclaim path in daemon.sh.
+  local scope_label scope_safe lockdir lock_pid
+  scope_label="$(cli_scope_label "${scope}")"
+  scope_safe="$(printf '%s' "${scope_label}" | tr '/ :' '___')"
+  lockdir="${LLM_TEAM_ROOT}/workdir/daemon-${role}-${scope_safe}.lockd"
+  if [ -d "${lockdir}" ]; then
+    lock_pid="$(cat "${lockdir}/pid" 2>/dev/null || true)"
+    if [ -z "${lock_pid}" ] || ! cli_pid_running "${lock_pid}"; then
+      rm -rf "${lockdir}" 2>/dev/null || true
+    fi
+  fi
   printf 'stopped daemon scope=%s role=%s\n' "${scope}" "${role}"
 }
 

--- a/targets/llm-team.yaml
+++ b/targets/llm-team.yaml
@@ -4,13 +4,27 @@ github:
   repo: llm-team
   default_branch: main
 local:
-  clone_path: 
+  clone_path:
 inputs_dir: inputs/llm-team
 labels:
   prefix: ""
 notifier:
   channel: none
-  webhook_or_id: 
+  webhook_or_id:
 dev_concurrency: 3
 stale_threshold_minutes: 60
 enabled: true
+onboarding:
+  acks:
+    use_default_branch_as_integration:
+      value: true
+      note: main을 integration으로 사용 (개인 저장소)
+      ts: "2026-05-02T08:05:30Z"
+    branch_protection_policy_decided:
+      value: true
+      note: 'Loose: branch protection 미적용, PR 흐름은 따르되 강제력 없음'
+      ts: "2026-05-02T08:05:35Z"
+    intentionally_silent:
+      value: true
+      note: 알림 채널 미설정, dashboard/status로 직접 모니터링
+      ts: "2026-05-02T08:05:39Z"

--- a/tests/adapters/test-issue_tracker-github-label-idempotent.sh
+++ b/tests/adapters/test-issue_tracker-github-label-idempotent.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# tests/adapters/test-issue_tracker-github-label-idempotent.sh
+#
+# Verify _github_issue_remove_label treats HTTP 404 ("label not on issue")
+# as success so that it_issue_set_state idempotently re-applies a transition
+# even when the old-state label is already absent.
+#
+# Regression: prior to this fix, a 404 from REST `DELETE /issues/N/labels/L`
+# was retried 3× via gh_with_retry and then propagated as failure, breaking
+# add-new → remove-old transitions on the second attempt.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LLM_TEAM_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export LLM_TEAM_ROOT
+
+. "${LLM_TEAM_ROOT}/lib/log.sh"
+. "${LLM_TEAM_ROOT}/lib/state.sh"
+. "${LLM_TEAM_ROOT}/lib/ports/issue_tracker.sh"
+. "${LLM_TEAM_ROOT}/adapters/issue_tracker/github.sh"
+
+# Skip retry delays so the fallback path (other failure → gh_with_retry) is
+# fast.
+export GH_RETRY_DELAY_1=0 GH_RETRY_DELAY_2=0 GH_RETRY_DELAY_3=0
+
+FAKE_BIN="$(mktemp -d "${TMPDIR:-/tmp}/llm-team-it-gh-label-XXXXXX")"
+CALL_LOG="${FAKE_BIN}/calls.log"
+MODE_FILE="${FAKE_BIN}/mode"
+trap 'rm -rf "${FAKE_BIN}"' EXIT
+
+# Fake `gh` that simulates GitHub's response for DELETE /issues/N/labels/L.
+# Behavior is controlled by the file at ${MODE_FILE}:
+#   404 — emit GitHub-style "HTTP 404" stderr and exit 1.
+#   500 — emit "HTTP 500" stderr and exit 1 (transient — exercises retry).
+#   200 — exit 0.
+cat >"${FAKE_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+mode="$(cat "$MODE_FILE" 2>/dev/null || echo 200)"
+printf '%s\n' "$*" >>"$CALL_LOG"
+if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "DELETE" ]; then
+  case "$mode" in
+    404) echo "gh: Resource not protected by branch protection or HTTP 404: Label does not exist (https://api.github.com/...)" >&2; exit 1 ;;
+    500) echo "gh: HTTP 500: Internal Server Error" >&2; exit 1 ;;
+    200) exit 0 ;;
+  esac
+fi
+echo "fake gh: unsupported call: $*" >&2
+exit 1
+EOF
+chmod +x "${FAKE_BIN}/gh"
+export PATH="${FAKE_BIN}:${PATH}"
+export CALL_LOG MODE_FILE
+
+failures=0
+fail() { echo "FAIL: $*" >&2; failures=$((failures + 1)); }
+
+# ---------- Case 1: 404 → success (no retry) -------------------------------
+: >"${CALL_LOG}"
+echo 404 >"${MODE_FILE}"
+if ! _github_issue_remove_label "owner/repo" 7 "task:done"; then
+  fail "case-404: should return success when label already absent"
+fi
+calls="$(wc -l <"${CALL_LOG}" | tr -d ' ')"
+if [ "${calls}" != "1" ]; then
+  fail "case-404: expected 1 gh call (no retry), got ${calls}"
+fi
+
+# ---------- Case 2: 200 → success (single call) ---------------------------
+: >"${CALL_LOG}"
+echo 200 >"${MODE_FILE}"
+if ! _github_issue_remove_label "owner/repo" 7 "task:done"; then
+  fail "case-200: should return success on normal removal"
+fi
+calls="$(wc -l <"${CALL_LOG}" | tr -d ' ')"
+if [ "${calls}" != "1" ]; then
+  fail "case-200: expected 1 gh call, got ${calls}"
+fi
+
+# ---------- Case 3: 500 → retry path (3 attempts, then failure) -----------
+: >"${CALL_LOG}"
+echo 500 >"${MODE_FILE}"
+if _github_issue_remove_label "owner/repo" 7 "task:done"; then
+  fail "case-500: should fail after retry exhausted"
+fi
+calls="$(wc -l <"${CALL_LOG}" | tr -d ' ')"
+# 1 initial probe + 3 gh_with_retry attempts = 4
+if [ "${calls}" != "4" ]; then
+  fail "case-500: expected 4 gh calls (1 probe + 3 retry), got ${calls}"
+fi
+
+if [ "${failures}" -gt 0 ]; then
+  echo "FAILED ${failures} case(s)" >&2
+  exit 1
+fi
+echo "PASS: _github_issue_remove_label idempotent on 404"

--- a/tests/adapters/test-issue_tracker-github-list.sh
+++ b/tests/adapters/test-issue_tracker-github-list.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# tests/adapters/test-issue_tracker-github-list.sh
+#
+# Verify it_milestone_list_in_state correctly handles multi-line milestone
+# descriptions (the real GitHub case where description contains newlines and
+# the state marker is on a non-first line).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LLM_TEAM_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export LLM_TEAM_ROOT
+
+. "${LLM_TEAM_ROOT}/lib/log.sh"
+. "${LLM_TEAM_ROOT}/lib/state.sh"
+. "${LLM_TEAM_ROOT}/lib/ports/issue_tracker.sh"
+. "${LLM_TEAM_ROOT}/adapters/issue_tracker/github.sh"
+
+FAKE_BIN="$(mktemp -d "${TMPDIR:-/tmp}/llm-team-it-gh-list-XXXXXX")"
+FAKE_FIXTURE="${FAKE_BIN}/milestones.json"
+trap 'rm -rf "${FAKE_BIN}"' EXIT
+
+# Fake `gh`: when called as `gh api repos/.../milestones?...`, return canned
+# JSON. Else fail.
+cat >"${FAKE_BIN}/gh" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "api" ] && [[ "\$2" == repos/*/milestones* ]]; then
+  shift 2
+  jq_args=()
+  while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+      --jq) jq_args=(-r "\$2"); shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [ "\${#jq_args[@]}" -gt 0 ]; then
+    jq "\${jq_args[@]}" "${FAKE_FIXTURE}"
+  else
+    cat "${FAKE_FIXTURE}"
+  fi
+  exit 0
+fi
+echo "fake gh: unsupported call: \$*" >&2
+exit 1
+EOF
+chmod +x "${FAKE_BIN}/gh"
+export PATH="${FAKE_BIN}:${PATH}"
+
+# Fixture: 3 milestones with multi-line descriptions matching the real format
+# observed from GitHub (state marker on the 4th line).
+cat >"${FAKE_FIXTURE}" <<'JSON'
+[
+  {
+    "number": 1,
+    "state": "open",
+    "description": "Promoted from feature-request issue #2.\n\nSource: bakpark/llm-team issue #2.\n<!-- llm-team:milestone-state:PO_DRAFT -->"
+  },
+  {
+    "number": 2,
+    "state": "open",
+    "description": "Promoted from feature-request issue #5.\n\nSource: bakpark/llm-team issue #5.\n<!-- llm-team:milestone-state:PO_DRAFT -->"
+  },
+  {
+    "number": 3,
+    "state": "open",
+    "description": "Already past PO.\n<!-- llm-team:milestone-state:PM_DRAFT -->"
+  }
+]
+JSON
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+result="$(it_milestone_list_in_state 'owner/repo' PO_DRAFT | tr '\n' ' ')"
+[ "${result}" = "1 2 " ] || fail "PO_DRAFT expected '1 2', got '${result}'"
+
+result="$(it_milestone_list_in_state 'owner/repo' PM_DRAFT | tr '\n' ' ')"
+[ "${result}" = "3 " ] || fail "PM_DRAFT expected '3', got '${result}'"
+
+result="$(it_milestone_list_in_state 'owner/repo' DECOMPOSE_READY | tr '\n' ' ')"
+[ "${result}" = "" ] || fail "DECOMPOSE_READY expected empty, got '${result}'"
+
+echo "PASS: it_milestone_list_in_state handles multi-line descriptions"

--- a/tests/application/test-caller-dispatch-idempotency-retry.sh
+++ b/tests/application/test-caller-dispatch-idempotency-retry.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# tests/application/test-caller-dispatch-idempotency-retry.sh
+#
+# RGC-FAILURE: a prior failed transition (result=error|stale|invalid) MUST NOT
+# burn its idempotency_key. Only successfully *applied* transitions (and their
+# duplicate echoes) should short-circuit subsequent attempts in
+# caller_apply_output.
+#
+# This guards against the live-pipeline failure where a transient adapter
+# error produced an "error" ledger row, after which the runner's next
+# scheduled attempt — using the same input revision and therefore the same
+# idem_key — was incorrectly treated as a no-op duplicate, leaving the
+# milestone permanently stuck.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LLM_TEAM_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export LLM_TEAM_ROOT
+
+TARGET_NAME="caller-idem-retry-test-$$"
+export TARGET_NAME
+TARGET_WORKDIR="${LLM_TEAM_ROOT}/workdir/${TARGET_NAME}"
+
+cleanup() { rm -rf "${TARGET_WORKDIR}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+. "${LLM_TEAM_ROOT}/lib/common.sh"
+. "${LLM_TEAM_ROOT}/application/caller_dispatch.sh"
+
+mkdir -p "${TARGET_WORKDIR}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+ledger_path="$(transition_ledger_path "${TARGET_NAME}")"
+mkdir -p "$(dirname "${ledger_path}")"
+
+key='po:milestone:1:rev-A'
+
+# 1. Empty ledger → has_key MUST be false.
+: >"${ledger_path}"
+if _caller_ledger_has_key "${TARGET_NAME}" "${key}"; then
+  fail "empty ledger should report has_key=false"
+fi
+
+# 2. Ledger with only failure rows (error / stale / invalid) → has_key false.
+for r in error stale invalid; do
+  jq -nc --arg k "${key}" --arg r "${r}" \
+    '{transition_id:"t",object_kind:"milestone",object_id:"1",
+      from_state:"PO_DRAFT",to_state:"PO_DRAFT",operation:"Compose-PO",
+      caller_id:"x",idempotency_key:$k,manifest_id:"m",timestamp:"2026-05-02T00:00:00Z",
+      result:$r,duplicate:false}' >>"${ledger_path}"
+done
+if _caller_ledger_has_key "${TARGET_NAME}" "${key}"; then
+  fail "failure-only ledger should report has_key=false (RGC-FAILURE retryable)"
+fi
+
+# 3. Ledger contains an applied row → has_key MUST be true.
+jq -nc --arg k "${key}" \
+  '{transition_id:"t2",object_kind:"milestone",object_id:"1",
+    from_state:"PO_DRAFT",to_state:"PO_GATE",operation:"Compose-PO",
+    caller_id:"x",idempotency_key:$k,manifest_id:"m",timestamp:"2026-05-02T00:01:00Z",
+    result:"applied",duplicate:false}' >>"${ledger_path}"
+if ! _caller_ledger_has_key "${TARGET_NAME}" "${key}"; then
+  fail "applied row should set has_key=true"
+fi
+
+# 4. A duplicate echo row alone (without the original applied row) is also a
+#    successful idempotent reuse — it should also set has_key=true.
+ledger2="${TARGET_WORKDIR}/ledger2.jsonl"
+jq -nc --arg k "${key}" \
+  '{transition_id:"t3",object_kind:"milestone",object_id:"1",
+    from_state:"(duplicate)",to_state:"(duplicate)",operation:"Compose-PO",
+    caller_id:"x",idempotency_key:$k,manifest_id:"m",timestamp:"2026-05-02T00:02:00Z",
+    result:"duplicate",duplicate:true}' >"${ledger2}"
+mv "${ledger2}" "${ledger_path}"
+if ! _caller_ledger_has_key "${TARGET_NAME}" "${key}"; then
+  fail "duplicate-only ledger should set has_key=true"
+fi
+
+echo "PASS: _caller_ledger_has_key only matches applied/duplicate rows"

--- a/tests/application/test-caller-dispatch-target-id.sh
+++ b/tests/application/test-caller-dispatch-target-id.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# tests/application/test-caller-dispatch-target-id.sh
+#
+# Verify _caller_target_id_strip_kind handles:
+#   - bare numeric ids (legacy fixture form)
+#   - "<kind>:<num>" form documented in prompts/*.md (real LLM output form)
+#   - CP hierarchical ids ("cp:...:rN") preserved as-is
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LLM_TEAM_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export LLM_TEAM_ROOT
+
+. "${LLM_TEAM_ROOT}/lib/log.sh"
+. "${LLM_TEAM_ROOT}/application/caller_dispatch.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  [ "${got}" = "${want}" ] || fail "${desc}: got='${got}' want='${want}'"
+}
+
+assert_eq "$(_caller_target_id_strip_kind 'milestone:42')" '42'   'milestone:42 → 42'
+assert_eq "$(_caller_target_id_strip_kind 'milestone:1')"  '1'    'milestone:1 → 1'
+assert_eq "$(_caller_target_id_strip_kind 'task:7')"       '7'    'task:7 → 7'
+assert_eq "$(_caller_target_id_strip_kind 'issue:13')"     '13'   'issue:13 → 13'
+assert_eq "$(_caller_target_id_strip_kind '42')"           '42'   'bare 42 → 42'
+assert_eq "$(_caller_target_id_strip_kind 'cp:code:auth-login:r3')" \
+                                                          'cp:code:auth-login:r3' \
+                                                          'cp:* preserved'
+assert_eq "$(_caller_target_id_strip_kind '')"             ''     'empty → empty'
+
+echo "PASS: _caller_target_id_strip_kind"

--- a/tests/application/test-caller-dispatch.sh
+++ b/tests/application/test-caller-dispatch.sh
@@ -133,11 +133,17 @@ env_pm_empty="$(write_envelope "{
   input_revision_pins: [], idempotency_key: \"pm:${ms_pm_empty}:r1\",
   summary: \"PM spec\", artifacts: {}
 }")"
+cp_count_before_empty="$(ls "${TARGET_WORKDIR}/change-proposals" 2>/dev/null | grep -c 'cp-Spec-' || true)"
 if caller_apply_output "${repo}" pm "${env_pm_empty}" "${mf_pm_empty}" 2>/dev/null; then
   fail "spec_proposal PM with empty milestone_body_proposal should be rejected"
 fi
 [ "$(it_milestone_get_state "${repo}" "${ms_pm_empty}")" = "PM_DRAFT" ] \
   || fail "spec_proposal PM empty body: milestone should remain PM_DRAFT"
+# Empty-body rejection must occur BEFORE CP creation, otherwise an orphan
+# Spec CP in CP_READY_FOR_HUMAN_GATE would accumulate on every retry.
+cp_count_after_empty="$(ls "${TARGET_WORKDIR}/change-proposals" 2>/dev/null | grep -c 'cp-Spec-' || true)"
+[ "${cp_count_after_empty}" = "${cp_count_before_empty}" ] \
+  || fail "spec_proposal PM empty body: orphan Spec CP created (before=${cp_count_before_empty} after=${cp_count_after_empty})"
 
 # --------------------------------------------------------------------------
 # Branch 3: task_plan (Planner) — happy path + dependency cycle

--- a/tests/application/test-caller-dispatch.sh
+++ b/tests/application/test-caller-dispatch.sh
@@ -111,12 +111,33 @@ env_pm="$(write_envelope "{
   output_kind: \"spec_proposal\", agent_role: \"PM\", operation: \"Compose-PM\",
   target_id: \"${ms_pm}\", manifest_id: \"${mid_pm}\",
   input_revision_pins: [], idempotency_key: \"pm:${ms_pm}:r1\",
-  summary: \"PM spec\", artifacts: {}
+  summary: \"PM spec\",
+  artifacts: { milestone_body_proposal: \"# Logging spec\\n\\nbody\" }
 }")"
 caller_apply_output "${repo}" pm "${env_pm}" "${mf_pm}" \
   || fail "spec_proposal PM branch failed"
 [ "$(it_milestone_get_state "${repo}" "${ms_pm}")" = "PM_GATE" ] \
   || fail "spec_proposal PM: milestone should be PM_GATE"
+
+# Empty body must be rejected (architectural guard against silent state-only
+# advance — see _caller_apply_spec_proposal). Without this, PM/PO can emit a
+# structurally valid envelope with no spec content and the milestone advances
+# to *_GATE with nothing for a human reviewer to read.
+ms_pm_empty="$(it_milestone_create "${repo}" "Empty PM" "")"
+it_milestone_set_state "${repo}" "${ms_pm_empty}" PM_DRAFT
+mf_pm_empty="$(make_manifest Compose-PM milestone "${ms_pm_empty}")"
+mid_pm_empty="$(context_manifest_id "${mf_pm_empty}")"
+env_pm_empty="$(write_envelope "{
+  output_kind: \"spec_proposal\", agent_role: \"PM\", operation: \"Compose-PM\",
+  target_id: \"${ms_pm_empty}\", manifest_id: \"${mid_pm_empty}\",
+  input_revision_pins: [], idempotency_key: \"pm:${ms_pm_empty}:r1\",
+  summary: \"PM spec\", artifacts: {}
+}")"
+if caller_apply_output "${repo}" pm "${env_pm_empty}" "${mf_pm_empty}" 2>/dev/null; then
+  fail "spec_proposal PM with empty milestone_body_proposal should be rejected"
+fi
+[ "$(it_milestone_get_state "${repo}" "${ms_pm_empty}")" = "PM_DRAFT" ] \
+  || fail "spec_proposal PM empty body: milestone should remain PM_DRAFT"
 
 # --------------------------------------------------------------------------
 # Branch 3: task_plan (Planner) — happy path + dependency cycle

--- a/tests/application/test-onboarding-verify.sh
+++ b/tests/application/test-onboarding-verify.sh
@@ -46,9 +46,30 @@ GH_BRANCH_HAS=1
 gh() {
   case "$1" in
     api)
-      case "$2" in
+      # Skip gh-flag args (--paginate, --jq <expr>, --silent, ...) so the
+      # endpoint is consistently $2 regardless of caller-side flag ordering.
+      shift
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --paginate|--silent) shift ;;
+          --jq|-X|-H|-f|-F) shift 2 ;;
+          *) break ;;
+        esac
+      done
+      local endpoint="${1:-}"
+      case "${endpoint}" in
         repos/*/branches/*)
           [ "${GH_BRANCH_HAS}" = "1" ] && return 0 || return 1
+          ;;
+        repos/*/labels)
+          if [ "${GH_LABELS_HAVE}" = "1" ]; then
+            # _check_labels_bootstrap_done extracts names via --jq '.[].name';
+            # emit one name per line — that matches the post-jq stdout shape.
+            printf 'task:ready\ncp:ready-for-review\nhuman-gate:po\npaused\nfeature-request\n'
+            return 0
+          fi
+          printf ''
+          return 0
           ;;
         repos/*)
           [ "${GH_REPO_OK}" = "1" ] && return 0 || return 1


### PR DESCRIPTION
## Summary

라이브 파이프라인을 PO_DRAFT → IMPLEMENTING까지 자율 진행하면서 발견·수정한 9개의 architectural drift / 인프라 버그.

## 핵심 변경 9건

| # | 위치 | 문제 | 픽스 |
|---|---|---|---|
| 1 | `application/caller_dispatch.sh` | 빈 milestone_body가 silently PM/PO_GATE로 advance | spec_proposal에 빈 body면 reject |
| 2 | `prompts/pm.md` | dispatcher가 읽는 `milestone_body_proposal` 미문서화 → drift | PM 필수 키로 명시 |
| 3 | `adapters/issue_tracker/github.sh` (`it_issue_create`) | `--milestone NUM`을 *이름* lookup으로 처리 → 404 | REST `POST /issues` (numeric 직접 수용) |
| 4 | `_caller_apply_task_plan` | 빈 tasks 리스트도 IMPLEMENTING으로 advance | 1개 미만이면 reject |
| 5 | `scheduler/runner.sh` | manifest가 metadata만 → LLM이 milestone description을 못 봄 → bootstrap placeholder만 출력 | primary entry content를 prompt에 주입 |
| 6 | github 어댑터 라벨 ops | `gh issue/pr edit --add-label`이 GraphQL → secondary rate limit | REST `POST/DELETE /issues/N/labels` |
| 7 | `_check_labels_bootstrap_done` | `gh label list`도 GraphQL → daemon start 시 false-fail | `gh api .../labels` REST |
| 8 | `it_issue_list_in_state`, `it_issue_list_with_label` | `gh issue list`도 GraphQL → 매 ready_object pickup마다 burn | `gh api .../issues?labels=...` REST + PR 필터 |
| 9 | `it_pr_create`, `it_pr_merge` | `gh pr create/merge`도 GraphQL | `gh api .../pulls`, `PUT /pulls/N/merge` REST |

## 라이브 검증

ms#1, ms#2 모두 6 단계 전이 성공:
\`PO_DRAFT → PO_GATE → PM_DRAFT → PM_GATE → DECOMPOSE_READY → IMPLEMENTING\`
17개 의미있는 task issue 자동 생성 (이전엔 placeholder만 생성).

## 테스트

- 신규 3개: multi-line milestone description parse, target_id strip-kind 정규화, idempotency retry guard (RGC-FAILURE)
- 갱신: caller-dispatch에 빈 body/빈 tasks reject 케이스 추가
- 갱신: onboarding-verify gh stub을 REST 호출 경로로 (regression repair)
- 33+ 테스트 통과

## Test plan

- [x] \`tests/adapters/test-issue_tracker-*.sh\`
- [x] \`tests/application/test-caller-dispatch*.sh\`
- [x] \`tests/application/test-onboarding-verify.sh\`
- [x] \`tests/application/test-human-signal.sh\`
- [x] \`tests/scheduler/test-runner-pipeline.sh\`
- [x] \`tests/lib/test-port-conformance.sh\`
- [x] 라이브 데몬으로 ms#1/#2 IMPLEMENTING 도달 확인

## 잔존 이슈 (다음 PR 후보)

### A. Coder LLM 출력 품질 (가장 큰 블로커)
ms#1 task#16 ("Compose-PM 매니페스트 강화") 같은 메타-task에 대해 Coder LLM이:
- 빈 patch_diff ("이건 placeholder다, 실 구현 안 함")
- 또는 malformed diff (precheck failed)

원인: (1) 메타-task 재귀, (2) workspace 격리 (agent_cwd read-only) vs self-modifying 의도 모호, (3) 16분짜리 LLM 호출 > 10분 lease TTL → recovery race (LEASE_TTL=2400으로 미봉, 본질적 해결 아님).

권장: Coder prompt 보강 또는 단순 e2e task로 대체 검증.

### B. 잔존 GraphQL 호출 (저우선순위)
- \`it_issue_close_with_note\` (\`gh issue close\`)
- \`it_pr_close\` (\`gh pr close\`)
- \`it_pr_request_changes\` 코멘트부

QA/Integrator 단계에서 호출되며 이번 PR에선 도달하지 못해 미수정.

### C. PM/Reviewer/Integrator/QA 잔존 contract drift
이번 PR은 PM의 \`milestone_body_proposal\`만 수정. 나머지 3개 역할은 prompt ↔ dispatcher 간 스키마 자체가 맞지 않음 (예: dispatcher가 \`pr_number\`/\`cp_path\` 같은 runtime 메타를 LLM에 요구). 별도 설계 PR 필요 — runner 메타데이터 주입 레이어 도입.

### D. Lease TTL 차등화 미구현
현재 단일 \`LLM_TEAM_LEASE_TTL\`. role 별 차등 (PO/PM 짧게, Coder/Reviewer 길게) 또는 동적 lease_renew 필요.

### E. Orphan task issue 누적
dispatcher 부분 실패 시 milestone state는 롤백되지만 created issue는 잔류. 정기 sweeper 또는 dispatcher 트랜잭션화 필요.

### F. Context Snapshot 사이즈 정책
\`_runner_context_snapshot\`이 description 전체를 prompt에 주입. fetch_scope 별 truncation 정책 필요 (현재는 무제한).

### G. GitHub secondary abuse rate limit 감지
\`gh_with_retry\`가 일반 retry만 처리. 503 secondary rate limit에 대한 명시적 backoff 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)