### PR TITLE
chore(architecture): close cross-doc drift (A/B/F docs + ARC E2 lr_call)

### DIFF
--- a/adapters/llm_runner/claude_code.sh
+++ b/adapters/llm_runner/claude_code.sh
@@ -37,9 +37,16 @@ lr_invoke() {
     return 127
   fi
 
+  # Strict numeric validation (review feedback): empty/0 → no timeout. 양의
+  # 정수 → timeout 적용. 기타 값(예: 운영자 typo "30s") 은 silent skip 하지 않고
+  # 66 으로 fail-fast — "no silent timeout skip" 정책 일관성.
   local timeout_sec="${LR_TIMEOUT_SEC:-0}"
   case "${timeout_sec}" in
-    ''|*[!0-9]*) timeout_sec=0 ;;
+    ''|0) timeout_sec=0 ;;
+    *[!0-9]*)
+      log_error "lr_invoke: LR_TIMEOUT_SEC='${timeout_sec}' is not a non-negative integer (fail-fast per #ARC-ADAPTER-SUBSTITUTION)"
+      return 66
+      ;;
   esac
   if [ "${timeout_sec}" -gt 0 ]; then
     if ! command -v timeout >/dev/null 2>&1; then

--- a/adapters/llm_runner/claude_code.sh
+++ b/adapters/llm_runner/claude_code.sh
@@ -11,8 +11,17 @@
 # Exit codes (#ARC-EXIT-CLASSES via lr_classify_exit):
 #   0       ok                     claude 정상 종료
 #   64      transport_error        빈 prompt (port I2)
+#   66      adapter_unavailable    LR_TIMEOUT_SEC>0 인데 `timeout` 부재 (fail-fast)
+#   124     timeout                LR_TIMEOUT_SEC 도달
 #   127     adapter_unavailable    claude 바이너리 미발견
 #   기타     transport_error        claude 의 raw exit code (caller 흡수)
+#
+# Timeout 정책 (#ARC-CALL-SEMANTICS / "adapter 가 timeout 도달 시 호출 중단"):
+# wrapper(`lr_call`) 가 sourced bash function 인 lr_invoke 를 외부 `timeout` 로
+# wrap 할 수 없으므로(PATH 에 없음), adapter 가 *외부 명령 호출 시점에* 자체
+# wrap 한다. LR_TIMEOUT_SEC>0 인데 `timeout` cmd 가 PATH 에 없으면 silent skip
+# 하지 않고 66(adapter_unavailable) 으로 fail-fast 한다 (#ARC-ADAPTER-SUBSTITUTION
+# 의 "동일 timeout 입력에 대해 timeout 동작이 동일" 보장).
 lr_invoke() {
   local prompt
   prompt="$(cat)"
@@ -28,6 +37,18 @@ lr_invoke() {
     return 127
   fi
 
-  # stdin pipe + word-split된 cmd 호출. eval/bash -c 회피 (인용 문제 차단).
-  printf '%s' "${prompt}" | ${cmd}
+  local timeout_sec="${LR_TIMEOUT_SEC:-0}"
+  case "${timeout_sec}" in
+    ''|*[!0-9]*) timeout_sec=0 ;;
+  esac
+  if [ "${timeout_sec}" -gt 0 ]; then
+    if ! command -v timeout >/dev/null 2>&1; then
+      log_error "lr_invoke: LR_TIMEOUT_SEC=${timeout_sec} but 'timeout' cmd not found in PATH (fail-fast per #ARC-ADAPTER-SUBSTITUTION)"
+      return 66
+    fi
+    # stdin pipe + word-split된 cmd 호출. eval/bash -c 회피 (인용 문제 차단).
+    printf '%s' "${prompt}" | timeout "${timeout_sec}" ${cmd}
+  else
+    printf '%s' "${prompt}" | ${cmd}
+  fi
 }

--- a/application/agent_io.sh
+++ b/application/agent_io.sh
@@ -132,6 +132,12 @@ _agent_io_extract_fenced_json() {
 # • '## Manifest' + manifest JSON 본문 append.
 # • '## Envelope Schema' + 리터럴 schema 안내 append.
 # • extra_instruction 이 주어지면 '## Caller Notes' 로 그 뒤에 append.
+#
+# Coupling: prompts/<role>.md 의 첫 3 줄 헤더(`# Role:` / `# Operation:` /
+# `# Manifest-id:`) 는 lib/roles.sh `role_normalize` / `role_operation` 의
+# canonical form 과 1:1 일치해야 한다. 불일치 시 `lr_call` (lib/ports/llm_runner.sh)
+# 의 header consistency check 가 호출 직전에 `adapter_unavailable` 로 차단한다.
+# prompt template 추가/수정 시 lib/roles.sh 매핑과의 일치성 점검이 필수.
 agent_prompt_assemble() {
   local role="$1" manifest_path="$2" extra_instruction="${3:-}"
   if [ -z "${role}" ] || [ -z "${manifest_path}" ]; then

--- a/docs/architecture/agent-runner-adapters.md
+++ b/docs/architecture/agent-runner-adapters.md
@@ -29,7 +29,7 @@ adapters/
 
 | Contract 출력 | 어댑터 결과 |
 |---|---|
-| `exit_status` | 어댑터 종료 코드 → `lib/output.sh` 가 contract enum 으로 매핑 |
+| `exit_status` | 어댑터 종료 코드 → `lib/ports/llm_runner.sh` `lr_classify_exit` 가 contract enum 으로 매핑 |
 | `envelope_ref` | 어댑터가 stdout 또는 파일 경로로 반환 |
 | `diagnostics_ref` | 어댑터의 stderr 로그 파일 경로 |
 | `consumed_at` | 호출 종료 timestamp(어댑터가 기록하지 않으면 caller 가 기록) |
@@ -54,4 +54,6 @@ adapters/
 
 ## 5. role-model 매핑 흐름
 
-[`#TCC-AGENT-RUNNER-MAP`](../contracts/target-config-contract.md#TCC-AGENT-RUNNER-MAP) 의 lookup 결과를 caller 가 `lib/registry.sh` 등을 통해 어댑터 진입 함수로 분기한다. 같은 cycle 내에서 같은 role 은 항상 같은 어댑터에 매핑된다(런타임 중 매핑 변경 없음). 매핑 변경은 [`#TCC-CHANGE-RULES`](../contracts/target-config-contract.md#TCC-CHANGE-RULES) 에 따라 다음 cycle 부터 반영된다.
+**Contract intent**: [`#TCC-AGENT-RUNNER-MAP`](../contracts/target-config-contract.md#TCC-AGENT-RUNNER-MAP) 의 lookup 결과를 caller 가 어댑터 진입 함수로 분기한다. 같은 cycle 내에서 같은 role 은 항상 같은 어댑터에 매핑된다(런타임 중 매핑 변경 없음). 매핑 변경은 [`#TCC-CHANGE-RULES`](../contracts/target-config-contract.md#TCC-CHANGE-RULES) 에 따라 다음 cycle 부터 반영된다.
+
+**현재 상태 (TBD)**: active binding 은 미구현이다. `scheduler/runner.sh` 가 `config_agent_runner_for_role` 을 호출하지 않으며, 어댑터 진입은 정적으로 결정된다. 자세한 상태와 미해결 항목은 [`adapter-inventory.md`](adapter-inventory.md) §5 Open Items 를 single source of truth 로 참조한다.

--- a/docs/architecture/daemons.md
+++ b/docs/architecture/daemons.md
@@ -109,10 +109,16 @@ Stale recovery는 runner loop마다 수행할 수 있다. recovery 대상과 전
 
 ## Daemon Lifecycle
 
-[`RGC-DAEMON-STARTUP`](../contracts/reliability-and-gate-contract.md#RGC-DAEMON-STARTUP) 의 atomic 시작 invariant 는 `scheduler/daemon.sh` 가 적용한다.
+[`RGC-DAEMON-STARTUP`](../contracts/reliability-and-gate-contract.md#RGC-DAEMON-STARTUP) 의 atomic 시작 invariant 는 두 계층이 분담한다. 단일 프로세스의 lock 점유·신호 처리는 `scheduler/daemon.sh` 가, 다중 역할의 atomic 기동·sibling 회수·system-scoped ledger 는 `scripts/cli/daemon.sh` 가 담당한다.
 
-- **PID lockdir**: `workdir/<target>/daemon/<role>.lock/` 디렉토리 형식. `mkdir` 의 atomic 성질로 동일 역할의 중복 기동을 차단한다.
+### Per-process (`scheduler/daemon.sh`)
+
+- **PID lockdir**: `workdir/<target>/daemon/<role>.lock/` 디렉토리 형식. `mkdir` 의 atomic 성질로 동일 역할의 중복 기동을 차단한다. 점유는 `_acquire_daemon_lock` 이 수행한다.
 - **stale-pid 회수**: 기동 시 lockdir 의 기록된 pid 가 살아있지 않은 경우(`kill -0` 실패) 자동 회수한다. 회수는 stale 한 pid 를 제거하고 새 lockdir 를 만든 뒤 진행한다.
-- **부분 기동 차단**: 다중 역할을 함께 기동할 때 모든 lockdir 가 점유 가능한지 *사전 점검* 한 뒤에만 fork 한다. 한 역할이라도 점유에 실패하면 이미 기동된 sibling 을 종료시키고 전체 기동을 실패로 종결한다.
 - **종료 신호**: SIGTERM 수신 시 `SHUTDOWN` 플래그를 셋팅하고 *현재 cycle 종료 후* loop 를 빠져나간다. 진행 중인 lease 는 정상 release 된다. 강제 종료(SIGKILL) 의 잔여물은 [`#RGC-LEASE`](../contracts/reliability-and-gate-contract.md#RGC-LEASE) 의 TTL 만료에 의존한다.
+
+### Atomic multi-role startup (`scripts/cli/daemon.sh`)
+
+- **부분 기동 차단**: 다중 역할을 함께 기동할 때 모든 lockdir 가 점유 가능한지 *사전 점검* 한 뒤에만 fork 한다. `daemon_start_preflight` 가 사전 점검을, `daemon_start_atomic` 이 fork·sibling 회수·결과 집계를 담당한다. 한 역할이라도 점유에 실패하면 이미 기동된 sibling 을 종료시키고 전체 기동을 실패로 종결한다.
+- **System-scoped ledger**: atomic 기동·실패의 흔적은 `_daemon_atomic_ledger` 가 system scope ledger 에 기록한다.
 

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -53,7 +53,7 @@ Agent는 manifest 밖 객체를 읽지 않는다.
 | `change_proposal_set_state` | CP state marker 갱신(from_state 명시 시 전이 검증) |
 | `it_milestone_set_state` | Milestone state marker 갱신 |
 | `human_signal_drain` (`application/human_signal.sh`) | RGC-SIGNALS envelope 읽기·적용 |
-| `nf_send` (`adapters/notifier/`) | push-only 알림 |
+| `nt_send` (`adapters/notifier/`) | push-only 알림 |
 
 `gh pr review`, `gh pr merge`, `gh issue close`, label 변경은 모두 `it_*` 포트 어댑터를 통해서만 실행한다.
 

--- a/lib/ports/llm_runner.sh
+++ b/lib/ports/llm_runner.sh
@@ -19,13 +19,17 @@
 #     each adapter; unknown / non-enum codes fall back to "transport_error"
 #     (#ARC-FAILURE-MODES line 98).
 #
-#   • lr_call <prompt_ref> [agent_cwd] — port-level wrapper that satisfies the
-#     full ARC contract: reads prompt from prompt_ref, invokes the adapter via
+#   • lr_call <role> <operation> <manifest_id> <prompt_ref> <agent_cwd>
+#            <timeout_sec> <idempotency_key>
+#     port-level wrapper that satisfies the full ARC contract: validates the
+#     prompt headers vs args, exports LR_* env (manifest_id/role/operation/
+#     timeout_sec/idempotency_key) for the adapter, invokes the adapter via
 #     stdin, captures stdout to envelope_ref and stderr to diagnostics_ref,
 #     records consumed_at, classifies exit, and emits a single JSON metadata
-#     line on stdout: {exit_status, envelope_ref, diagnostics_ref, consumed_at}.
-#     Returns 0 if the call was *classified* (regardless of enum), non-0 only
-#     for infrastructure failure (e.g. cannot read prompt_ref).
+#     line on stdout: {exit_status, envelope_ref, diagnostics_ref, consumed_at,
+#     error_reason, role, operation, manifest_id, idempotency_key,
+#     timeout_enforced}. Returns 0 if the call was *classified* (regardless of
+#     enum), non-0 only for infrastructure failure (e.g. cannot read prompt_ref).
 #
 # Default adapter: claude_code (claude -p --output-format text).
 # Test adapter:    fake (deterministic fixture lookup).
@@ -97,19 +101,36 @@ lr_classify_diagnostic_reason() {
   printf 'unknown'
 }
 
-# lr_call <prompt_ref> [agent_cwd]
+# lr_call <role> <operation> <manifest_id> <prompt_ref> <agent_cwd> <timeout_sec> <idempotency_key>
+#   role, operation, manifest_id: 7-항목 #ARC-PORT-SIGNATURE 입력 중 4개를 자리
+#     인자로 명시. 어댑터는 prompt 헤더(`# Role:` `# Operation:` `# Manifest-id:`)
+#     로도 같은 값을 본다. wrapper 가 둘의 일치를 검증해 헤더-인자 불일치를
+#     silent skip 하지 않도록 한다 (불일치 시 adapter_unavailable=66).
 #   prompt_ref: path to a regular file containing the prompt body.
 #   agent_cwd:  optional path; if non-empty, lr_invoke runs with this cwd.
+#   timeout_sec: 0 또는 양의 정수. 0 이면 timeout 미적용. 양수이면 어댑터가
+#     LR_TIMEOUT_SEC env 를 읽어 외부 명령을 `timeout` 로 wrap 해야 한다
+#     (wrapper 는 sourced bash function 인 lr_invoke 를 직접 wrap 할 수 없음).
+#   idempotency_key: caller 가 deterministic 하게 산출한 키. 비어있으면 적합
+#     하지 않은 호출로 간주하지 않고(테스트 호환), env 만 빈 값으로 export.
 #
 #   stdout: a single-line JSON object:
 #     {"exit_status":"<enum>","envelope_ref":"<path>",
-#      "diagnostics_ref":"<path>","consumed_at":"<iso8601>"}
+#      "diagnostics_ref":"<path>","consumed_at":"<iso8601>",
+#      "error_reason":"<reason|null>",
+#      "role":"<role>","operation":"<op>","manifest_id":"<id>",
+#      "idempotency_key":"<key>","timeout_enforced":<bool>}
+#     timeout_enforced 는 wrapper 의 *의도* 만 표기 (LR_TIMEOUT_SEC>0). adapter
+#     가 실제 wrap 했는지는 별도 신호(exit 124 → timeout enum) 로 caller 가
+#     확인한다.
 #   stderr: caller-side diagnostics (the adapter's own stderr is captured to
 #           diagnostics_ref, not echoed here).
 #   return: 0 on classification (any enum), non-0 only on infrastructure
 #           failure (prompt_ref missing, mktemp fail).
 lr_call() {
-  local prompt_ref="${1:-}" agent_cwd="${2:-}"
+  local role="${1:-}" operation="${2:-}" manifest_id="${3:-}"
+  local prompt_ref="${4:-}" agent_cwd="${5:-}"
+  local timeout_sec="${6:-0}" idempotency_key="${7:-}"
   if [ -z "${prompt_ref}" ] || [ ! -f "${prompt_ref}" ]; then
     log_error "lr_call: prompt_ref missing or not a regular file: '${prompt_ref}'"
     return 1
@@ -117,6 +138,38 @@ lr_call() {
   local envelope_ref diagnostics_ref consumed_at raw_code exit_status
   envelope_ref="$(mktemp -t lr-envelope.XXXXXX)" || return 1
   diagnostics_ref="$(mktemp -t lr-diagnostics.XXXXXX)" || { rm -f "${envelope_ref}"; return 1; }
+
+  # Header consistency check (gpt5.5 G5): prompt 헤더와 wrapper 인자가 다르면
+  # adapter 가 헤더 기반으로 다른 fixture 를 잡는 등 silent divergence 가 생긴다.
+  # 헤더가 ground truth (#ARC-CALL-SEMANTICS / I3) 이므로 인자가 헤더와 다르면
+  # 어댑터를 호출하지 않고 바로 adapter_unavailable 로 분류. role 은 prompt
+  # 파일이 canonically 소문자(`po`/`pm`/`planner`/...) 이므로 비교 시 양쪽을
+  # 소문자로 정규화 (caller 는 `PO` 등 normalize 결과를 그대로 넘겨도 통과).
+  local hdr_role hdr_op hdr_mid
+  hdr_role="$(head -n 10 "${prompt_ref}" | grep -m1 '^# Role:' | sed -E 's/^# Role:[[:space:]]*//')"
+  hdr_op="$(head -n 10 "${prompt_ref}" | grep -m1 '^# Operation:' | sed -E 's/^# Operation:[[:space:]]*//')"
+  hdr_mid="$(head -n 10 "${prompt_ref}" | grep -m1 '^# Manifest-id:' | sed -E 's/^# Manifest-id:[[:space:]]*//')"
+  local role_lc hdr_role_lc
+  role_lc="$(printf '%s' "${role}" | tr '[:upper:]' '[:lower:]')"
+  hdr_role_lc="$(printf '%s' "${hdr_role}" | tr '[:upper:]' '[:lower:]')"
+  if [ "${hdr_role_lc}" != "${role_lc}" ] || [ "${hdr_op}" != "${operation}" ] || [ "${hdr_mid}" != "${manifest_id}" ]; then
+    log_error "lr_call: prompt header/arg mismatch (header role='${hdr_role}' op='${hdr_op}' manifest_id='${hdr_mid}'; arg role='${role}' op='${operation}' manifest_id='${manifest_id}')"
+    consumed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    exit_status="adapter_unavailable"
+    : >"${envelope_ref}"
+    printf 'lr_call: prompt header/arg mismatch (role/operation/manifest_id)\n' >"${diagnostics_ref}"
+    _lr_call_emit_meta "${exit_status}" "${envelope_ref}" "${diagnostics_ref}" "${consumed_at}" \
+      "header_arg_mismatch" "${role}" "${operation}" "${manifest_id}" \
+      "${idempotency_key}" "${timeout_sec}"
+    return 0
+  fi
+
+  # Export #ARC-PORT-SIGNATURE 입력 중 prompt 외부 채널로 어댑터에 전달되는 값.
+  export LR_ROLE="${role}"
+  export LR_OPERATION="${operation}"
+  export LR_MANIFEST_ID="${manifest_id}"
+  export LR_TIMEOUT_SEC="${timeout_sec}"
+  export LR_IDEMPOTENCY_KEY="${idempotency_key}"
 
   if [ -n "${agent_cwd}" ]; then
     ( cd "${agent_cwd}" && lr_invoke <"${prompt_ref}" ) \
@@ -132,11 +185,30 @@ lr_call() {
     error_reason="$(lr_classify_diagnostic_reason "${exit_status}" "${diagnostics_ref}")"
   fi
 
+  _lr_call_emit_meta "${exit_status}" "${envelope_ref}" "${diagnostics_ref}" "${consumed_at}" \
+    "${error_reason}" "${role}" "${operation}" "${manifest_id}" \
+    "${idempotency_key}" "${timeout_sec}"
+}
+
+# Internal: lr_call JSON metadata emitter (positional args mirror lr_call output schema).
+_lr_call_emit_meta() {
+  local exit_status="$1" envelope_ref="$2" diagnostics_ref="$3" consumed_at="$4"
+  local error_reason="$5" role="$6" operation="$7" manifest_id="$8"
+  local idempotency_key="$9" timeout_sec="${10}"
+  local timeout_enforced="false"
+  if [ "${timeout_sec}" -gt 0 ] 2>/dev/null; then
+    timeout_enforced="true"
+  fi
   jq -cn \
     --arg exit_status "${exit_status}" \
     --arg envelope_ref "${envelope_ref}" \
     --arg diagnostics_ref "${diagnostics_ref}" \
     --arg consumed_at "${consumed_at}" \
     --arg error_reason "${error_reason}" \
-    '{exit_status:$exit_status, envelope_ref:$envelope_ref, diagnostics_ref:$diagnostics_ref, consumed_at:$consumed_at, error_reason:(if $error_reason == "" then null else $error_reason end)}'
+    --arg role "${role}" \
+    --arg operation "${operation}" \
+    --arg manifest_id "${manifest_id}" \
+    --arg idempotency_key "${idempotency_key}" \
+    --argjson timeout_enforced "${timeout_enforced}" \
+    '{exit_status:$exit_status, envelope_ref:$envelope_ref, diagnostics_ref:$diagnostics_ref, consumed_at:$consumed_at, error_reason:(if $error_reason == "" then null else $error_reason end), role:$role, operation:$operation, manifest_id:$manifest_id, idempotency_key:$idempotency_key, timeout_enforced:$timeout_enforced}'
 }

--- a/lib/ports/llm_runner.sh
+++ b/lib/ports/llm_runner.sh
@@ -113,6 +113,12 @@ lr_classify_diagnostic_reason() {
 #     (wrapper 는 sourced bash function 인 lr_invoke 를 직접 wrap 할 수 없음).
 #   idempotency_key: caller 가 deterministic 하게 산출한 키. 비어있으면 적합
 #     하지 않은 호출로 간주하지 않고(테스트 호환), env 만 빈 값으로 export.
+#     **Scope (review 반영)**: 본 wrapper 는 key 의 *plumbing/echo* 만 담당.
+#     `#ARC-IDEMPOTENCY` 의 "ledger 에서 선행 호출 기록을 확인 → ok 면 envelope
+#     재사용" 까지의 멱등성 책임은 caller (application/caller_dispatch.sh) 에
+#     있으며, 현재 caller 는 envelope-derived `.idempotency_key` 로만 duplicate
+#     detection 을 수행한다. wrapper-side key 와 envelope-side key 의 통합
+#     (lr_call key 로 ledger pre-check) 은 별 라운드 의제.
 #
 #   stdout: a single-line JSON object:
 #     {"exit_status":"<enum>","envelope_ref":"<path>",

--- a/scheduler/runner.sh
+++ b/scheduler/runner.sh
@@ -597,9 +597,13 @@ _runner_cleanup_lr_refs() {
   rm -f "${LR_ENVELOPE_REF:-}" "${LR_DIAGNOSTICS_REF:-}" 2>/dev/null || true
 }
 
-# Deterministic idempotency_key (#ARC-IDEMPOTENCY): 같은 (role, operation,
-# manifest_id, attempt) 호출은 같은 key. cycle 내 retry 는 attempt 가 달라
-# 자연히 다른 key 를 받는다 (재시도 방지가 아닌 *멱등성 detection 가능* 보장).
+# Deterministic idempotency_key plumbing (#ARC-IDEMPOTENCY scope, review 반영):
+# 같은 (role, operation, manifest_id, attempt) 호출은 같은 key. cycle 내 retry
+# 는 attempt 가 달라 자연히 다른 key 를 받는다 (재시도 방지가 아닌 *멱등성
+# detection 가능* 보장). 단, 본 key 는 wrapper meta 에 echo 되고 LR_* env 로만
+# 노출되며, ledger 멱등성 검증은 여전히 envelope `.idempotency_key` 기준으로
+# application/caller_dispatch.sh 가 수행한다 (lr_call key ↔ envelope key 의
+# 통합과 ledger pre-check 은 별 라운드 의제).
 _runner_lr_idem_key() {
   local attempt="$1"
   printf '%s|%s|%s|%s' \

--- a/scheduler/runner.sh
+++ b/scheduler/runner.sh
@@ -584,19 +584,34 @@ _runner_cleanup_prompt() { rm -f "${PROMPT_REF:-}" 2>/dev/null || true; }
 LR_MAX_ATTEMPTS="${LLM_TEAM_LR_MAX_ATTEMPTS:-3}"
 LR_BACKOFF_BASE="${LLM_TEAM_LR_BACKOFF_BASE:-5}"
 LR_BACKOFF_MAX="${LLM_TEAM_LR_BACKOFF_MAX:-60}"
+LR_TIMEOUT_SEC="${LLM_TEAM_LR_TIMEOUT_SEC:-0}"
 LR_ATTEMPT=0
 LR_META=""
 LR_EXIT_STATUS=""
 LR_ENVELOPE_REF=""
 LR_DIAGNOSTICS_REF=""
 LR_ERROR_REASON=""
+LR_MANIFEST_ID="$(context_manifest_id "${MANIFEST_FILE}")"
 
 _runner_cleanup_lr_refs() {
   rm -f "${LR_ENVELOPE_REF:-}" "${LR_DIAGNOSTICS_REF:-}" 2>/dev/null || true
 }
 
+# Deterministic idempotency_key (#ARC-IDEMPOTENCY): 같은 (role, operation,
+# manifest_id, attempt) 호출은 같은 key. cycle 내 retry 는 attempt 가 달라
+# 자연히 다른 key 를 받는다 (재시도 방지가 아닌 *멱등성 detection 가능* 보장).
+_runner_lr_idem_key() {
+  local attempt="$1"
+  printf '%s|%s|%s|%s' \
+    "${ROLE}" "${OPERATION}" "${LR_MANIFEST_ID}" "${attempt}" \
+    | shasum -a 256 | cut -c1-16
+}
+
 while :; do
-  if ! LR_META="$(lr_call "${PROMPT_REF}" "${AGENT_CWD}" 2>/dev/null)"; then
+  LR_IDEMPOTENCY_KEY="$(_runner_lr_idem_key "${LR_ATTEMPT}")"
+  if ! LR_META="$(lr_call "${ROLE}" "${OPERATION}" "${LR_MANIFEST_ID}" \
+                          "${PROMPT_REF}" "${AGENT_CWD}" \
+                          "${LR_TIMEOUT_SEC}" "${LR_IDEMPOTENCY_KEY}" 2>/dev/null)"; then
     log_error "runner: lr_call infrastructure failure"
     _runner_cleanup_prompt
     _runner_claim_rollback "${ROLE}" "${TARGET_REPO}" "${TARGET_OBJECT_KIND}" "${TARGET_OBJECT_ID}" 2>/dev/null || true

--- a/tests/lib/test-llm-runner-port.sh
+++ b/tests/lib/test-llm-runner-port.sh
@@ -62,7 +62,7 @@ prompt_ref="$(mktemp -t lrport-prompt.XXXXXX)"
 printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-1\n\nbody...' \
   >"${prompt_ref}"
 
-meta="$(lr_call "${prompt_ref}" 2>/dev/null)" \
+meta="$(lr_call "po" "Compose-PO" "m-port-1" "${prompt_ref}" "" "0" "idem-port-1" 2>/dev/null)" \
   || fail "lr_call should succeed for valid prompt"
 [ -n "${meta}" ] || fail "lr_call should emit JSON metadata to stdout"
 
@@ -91,7 +91,7 @@ rm -f "${envelope_ref}" "${diagnostics_ref}"
 prompt_unknown_ref="$(mktemp -t lrport-prompt-uk.XXXXXX)"
 printf '%s' $'# Role: planner\n# Operation: Decompose\n# Manifest-id: m-port-2\n' \
   >"${prompt_unknown_ref}"
-meta_uk="$(lr_call "${prompt_unknown_ref}" 2>/dev/null)" \
+meta_uk="$(lr_call "planner" "Decompose" "m-port-2" "${prompt_unknown_ref}" "" "0" "idem-port-2" 2>/dev/null)" \
   || fail "lr_call must classify non-ok exit, not propagate error"
 exit_uk="$(printf '%s' "${meta_uk}" | jq -r '.exit_status // ""')"
 [ "${exit_uk}" != "ok" ] \
@@ -110,7 +110,7 @@ env_uk="$(printf '%s' "${meta_uk}" | jq -r '.envelope_ref // ""')"
 rm -f "${env_uk}" "${diag_uk}"
 
 # ── (5) lr_call infrastructure failure on missing prompt_ref ──────────────
-if lr_call "/nonexistent/path-$$.txt" 2>/dev/null; then
+if lr_call "po" "Compose-PO" "m-x" "/nonexistent/path-$$.txt" "" "0" "idem-x" 2>/dev/null; then
   fail "lr_call should return non-zero on missing prompt_ref"
 fi
 
@@ -155,14 +155,14 @@ rm -f "${diag_tmp}"
 # 성공 시 null, 비-ok 시 enum 값이어야 한다 (port 계약 확장).
 prompt_ok_ref="$(mktemp -t lrport-prompt-ok.XXXXXX)"
 printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-7\n\nbody' >"${prompt_ok_ref}"
-meta_ok="$(lr_call "${prompt_ok_ref}" 2>/dev/null)"
+meta_ok="$(lr_call "po" "Compose-PO" "m-port-7" "${prompt_ok_ref}" "" "0" "idem-port-7" 2>/dev/null)"
 reason_ok="$(printf '%s' "${meta_ok}" | jq -r '.error_reason')"
 [ "${reason_ok}" = "null" ] \
   || fail "(7) ok meta.error_reason should be null (json), got '${reason_ok}'"
 
 prompt_uk2_ref="$(mktemp -t lrport-prompt-uk2.XXXXXX)"
 printf '%s' $'# Role: planner\n# Operation: Decompose\n# Manifest-id: m-port-7b\n' >"${prompt_uk2_ref}"
-meta_uk2="$(lr_call "${prompt_uk2_ref}" 2>/dev/null)"
+meta_uk2="$(lr_call "planner" "Decompose" "m-port-7b" "${prompt_uk2_ref}" "" "0" "idem-port-7b" 2>/dev/null)"
 reason_uk2="$(printf '%s' "${meta_uk2}" | jq -r '.error_reason // "null"')"
 case "${reason_uk2}" in
   5xx|4xx|network|timeout|unknown) ;;
@@ -173,6 +173,98 @@ diag_uk2="$(printf '%s' "${meta_uk2}" | jq -r '.diagnostics_ref // ""')"
 env_ok="$(printf '%s' "${meta_ok}" | jq -r '.envelope_ref // ""')"
 diag_ok="$(printf '%s' "${meta_ok}" | jq -r '.diagnostics_ref // ""')"
 rm -f "${env_uk2}" "${diag_uk2}" "${env_ok}" "${diag_ok}" "${prompt_ok_ref}" "${prompt_uk2_ref}"
+
+# ── (8) ARC E2 G5: header/arg mismatch → adapter_unavailable (66 흡수) ────
+# wrapper 가 prompt 헤더와 인자가 다르면 어댑터를 호출하지 않고 즉시 분류.
+prompt_g5_ref="$(mktemp -t lrport-prompt-g5.XXXXXX)"
+printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-g5\n' >"${prompt_g5_ref}"
+meta_g5="$(lr_call "planner" "Decompose" "m-port-g5" "${prompt_g5_ref}" "" "0" "idem-g5" 2>/dev/null)" \
+  || fail "(8) lr_call header-mismatch must return 0 with classification, not infra failure"
+exit_g5="$(printf '%s' "${meta_g5}" | jq -r '.exit_status // ""')"
+[ "${exit_g5}" = "adapter_unavailable" ] \
+  || fail "(8) header-mismatch should classify as adapter_unavailable, got '${exit_g5}'"
+diag_g5="$(printf '%s' "${meta_g5}" | jq -r '.diagnostics_ref // ""')"
+[ -f "${diag_g5}" ] && grep -q 'header/arg mismatch' "${diag_g5}" \
+  || fail "(8) header-mismatch diagnostics should record reason"
+env_g5="$(printf '%s' "${meta_g5}" | jq -r '.envelope_ref // ""')"
+rm -f "${env_g5}" "${diag_g5}" "${prompt_g5_ref}"
+
+# ── (9) ARC E2: JSON output schema (4 echo + timeout_enforced) ───────────
+prompt_j_ref="$(mktemp -t lrport-prompt-j.XXXXXX)"
+printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-9\n\nbody' >"${prompt_j_ref}"
+meta_j="$(lr_call "po" "Compose-PO" "m-port-9" "${prompt_j_ref}" "" "0" "idem-port-9" 2>/dev/null)"
+for k in role operation manifest_id idempotency_key timeout_enforced; do
+  printf '%s' "${meta_j}" | jq -e ". | has(\"${k}\")" >/dev/null \
+    || fail "(9) JSON output missing key '${k}'"
+done
+[ "$(printf '%s' "${meta_j}" | jq -r '.role')"          = "po" ]            || fail "(9) role echo mismatch"
+[ "$(printf '%s' "${meta_j}" | jq -r '.operation')"     = "Compose-PO" ]    || fail "(9) operation echo mismatch"
+[ "$(printf '%s' "${meta_j}" | jq -r '.manifest_id')"   = "m-port-9" ]      || fail "(9) manifest_id echo mismatch"
+[ "$(printf '%s' "${meta_j}" | jq -r '.idempotency_key')" = "idem-port-9" ] || fail "(9) idempotency_key echo mismatch"
+# timeout=0 → timeout_enforced=false (boolean type, not string).
+te_j="$(printf '%s' "${meta_j}" | jq -r '.timeout_enforced')"
+[ "${te_j}" = "false" ] || fail "(9) timeout=0 should set timeout_enforced=false (got '${te_j}')"
+te_type="$(printf '%s' "${meta_j}" | jq -r '.timeout_enforced | type')"
+[ "${te_type}" = "boolean" ] || fail "(9) timeout_enforced type should be boolean (got '${te_type}')"
+env_j="$(printf '%s' "${meta_j}" | jq -r '.envelope_ref // ""')"
+diag_j="$(printf '%s' "${meta_j}" | jq -r '.diagnostics_ref // ""')"
+rm -f "${env_j}" "${diag_j}" "${prompt_j_ref}"
+
+# ── (10) ARC E2 G3: timeout>0 + cmd 부재 → adapter_unavailable fail-fast ──
+# claude_code adapter 가 LR_TIMEOUT_SEC>0 인데 PATH 에 timeout 없으면 66.
+# fake adapter 는 LR_TIMEOUT_SEC 무시 (테스트 결정성). 따라서 이 케이스는
+# claude_code adapter 로 일시 전환해 검증한다.
+# `timeout` 부재를 강제하기 위해 `command` builtin 을 함수로 shadow 한다 —
+# PATH 조작 시 jq/sh 등 다른 의존성도 함께 잃어 lr_call 자체가 망가지므로
+# 본 테스트에는 부적합. (PATH 제거는 OS-별로도 비결정적)
+prompt_t_ref="$(mktemp -t lrport-prompt-t.XXXXXX)"
+printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-10\n\nbody' >"${prompt_t_ref}"
+(
+  set +u
+  unset -f lr_invoke 2>/dev/null || true
+  . "${LLM_TEAM_ROOT}/adapters/llm_runner/claude_code.sh"
+  export LLM_TEAM_CLAUDE_CMD="true"
+  command() {
+    if [ "$1" = "-v" ] && [ "$2" = "timeout" ]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+  meta_t="$(lr_call "po" "Compose-PO" "m-port-10" "${prompt_t_ref}" "" "5" "idem-port-10" 2>/dev/null)"
+  exit_t="$(printf '%s' "${meta_t}" | jq -r '.exit_status // ""')"
+  if [ "${exit_t}" != "adapter_unavailable" ]; then
+    echo "FAIL: (10) timeout>0 + 'timeout' cmd absent should fail-fast as adapter_unavailable, got '${exit_t}'" >&2
+    exit 1
+  fi
+  diag_t="$(printf '%s' "${meta_t}" | jq -r '.diagnostics_ref // ""')"
+  if ! { [ -f "${diag_t}" ] && grep -q "'timeout' cmd not found" "${diag_t}"; }; then
+    echo "FAIL: (10) fail-fast diagnostics missing message" >&2
+    exit 1
+  fi
+  env_t="$(printf '%s' "${meta_t}" | jq -r '.envelope_ref // ""')"
+  rm -f "${env_t}" "${diag_t}"
+  exit 0
+) || failures=$((failures + 1))
+rm -f "${prompt_t_ref}"
+# Restore the fake adapter for any later cases (binding via env).
+. "${LLM_TEAM_ROOT}/adapters/llm_runner/fake.sh"
+
+# ── (11) ARC E2: idempotency_key echo (deterministic by caller) ──────────
+# Wrapper 는 caller 가 넘긴 key 를 그대로 echo. 같은 key 두 번 호출 시 같은 key
+# 가 메타에 반영됨을 확인 (caller-side determinism 의 wrapper 측 확인).
+prompt_i_ref="$(mktemp -t lrport-prompt-i.XXXXXX)"
+printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-11\n\nbody' >"${prompt_i_ref}"
+meta_i1="$(lr_call "po" "Compose-PO" "m-port-11" "${prompt_i_ref}" "" "0" "idem-fixed" 2>/dev/null)"
+meta_i2="$(lr_call "po" "Compose-PO" "m-port-11" "${prompt_i_ref}" "" "0" "idem-fixed" 2>/dev/null)"
+key1="$(printf '%s' "${meta_i1}" | jq -r '.idempotency_key')"
+key2="$(printf '%s' "${meta_i2}" | jq -r '.idempotency_key')"
+[ "${key1}" = "idem-fixed" ] && [ "${key2}" = "idem-fixed" ] \
+  || fail "(11) idempotency_key echo not stable: '${key1}' vs '${key2}'"
+env_i1="$(printf '%s' "${meta_i1}" | jq -r '.envelope_ref // ""')"
+diag_i1="$(printf '%s' "${meta_i1}" | jq -r '.diagnostics_ref // ""')"
+env_i2="$(printf '%s' "${meta_i2}" | jq -r '.envelope_ref // ""')"
+diag_i2="$(printf '%s' "${meta_i2}" | jq -r '.diagnostics_ref // ""')"
+rm -f "${env_i1}" "${diag_i1}" "${env_i2}" "${diag_i2}" "${prompt_i_ref}"
 
 if [ "${failures}" -gt 0 ]; then
   echo "FAIL: ${failures} llm_runner port check(s) failed" >&2

--- a/tests/lib/test-llm-runner-port.sh
+++ b/tests/lib/test-llm-runner-port.sh
@@ -217,6 +217,9 @@ rm -f "${env_j}" "${diag_j}" "${prompt_j_ref}"
 # `timeout` 부재를 강제하기 위해 `command` builtin 을 함수로 shadow 한다 —
 # PATH 조작 시 jq/sh 등 다른 의존성도 함께 잃어 lr_call 자체가 망가지므로
 # 본 테스트에는 부적합. (PATH 제거는 OS-별로도 비결정적)
+# 주의: 함수 shadow 는 macOS/bash 에서 동작. POSIX 셸 (`set -o posix`) 또는
+# 다른 dash/ash 호환 셸에서는 builtin precedence 가 달라 비결정적일 수 있다.
+# 본 테스트는 본 프로젝트의 표준 실행 환경(bash on macOS/Linux) 만 검증한다.
 prompt_t_ref="$(mktemp -t lrport-prompt-t.XXXXXX)"
 printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-10\n\nbody' >"${prompt_t_ref}"
 (
@@ -247,6 +250,34 @@ printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-10\n\nb
 ) || failures=$((failures + 1))
 rm -f "${prompt_t_ref}"
 # Restore the fake adapter for any later cases (binding via env).
+. "${LLM_TEAM_ROOT}/adapters/llm_runner/fake.sh"
+
+# ── (10b) ARC E2: LR_TIMEOUT_SEC strict numeric (review feedback) ────────
+# 운영자 typo 예: "30s". claude_code adapter 가 silent 0-fallback 하지 않고
+# 66 fail-fast — "no silent timeout skip" 정책 일관성.
+prompt_tn_ref="$(mktemp -t lrport-prompt-tn.XXXXXX)"
+printf '%s' $'# Role: po\n# Operation: Compose-PO\n# Manifest-id: m-port-10b\n\nbody' >"${prompt_tn_ref}"
+(
+  set +u
+  unset -f lr_invoke 2>/dev/null || true
+  . "${LLM_TEAM_ROOT}/adapters/llm_runner/claude_code.sh"
+  export LLM_TEAM_CLAUDE_CMD="true"
+  meta_tn="$(lr_call "po" "Compose-PO" "m-port-10b" "${prompt_tn_ref}" "" "30s" "idem-port-10b" 2>/dev/null)"
+  exit_tn="$(printf '%s' "${meta_tn}" | jq -r '.exit_status // ""')"
+  if [ "${exit_tn}" != "adapter_unavailable" ]; then
+    echo "FAIL: (10b) non-numeric LR_TIMEOUT_SEC '30s' should fail-fast as adapter_unavailable, got '${exit_tn}'" >&2
+    exit 1
+  fi
+  diag_tn="$(printf '%s' "${meta_tn}" | jq -r '.diagnostics_ref // ""')"
+  if ! { [ -f "${diag_tn}" ] && grep -q "non-negative integer" "${diag_tn}"; }; then
+    echo "FAIL: (10b) fail-fast diagnostics missing validation message" >&2
+    exit 1
+  fi
+  env_tn="$(printf '%s' "${meta_tn}" | jq -r '.envelope_ref // ""')"
+  rm -f "${env_tn}" "${diag_tn}"
+  exit 0
+) || failures=$((failures + 1))
+rm -f "${prompt_tn_ref}"
 . "${LLM_TEAM_ROOT}/adapters/llm_runner/fake.sh"
 
 # ── (11) ARC E2: idempotency_key echo (deterministic by caller) ──────────


### PR DESCRIPTION
## Summary

`docs/architecture/` 4 케이스 정렬. 1차 draft 의 docs-only 정정(A+B+F) 에 더해, **변경 비용 기준이 아닌 기술적 이상성 기준**으로 ARC E2 (`lr_call` 7-arg signature) 를 함께 닫아 port 추상 누수를 차단.

- **A** `daemons.md` §Daemon Lifecycle: atomic startup 책임을 `scripts/cli/daemon.sh` (preflight·atomic fork·sibling rollback·system-scoped ledger) 와 `scheduler/daemon.sh` (per-process lockdir·stale-pid·SIGTERM) 두 sub-heading 으로 분리.
- **B** `agent-runner-adapters.md` §5: contract intent 와 현재 미구현(TBD) 두 절로 분리, single source 는 `adapter-inventory.md` §5 Open Items 로 cross-link.
- **F** minor drift 정정: `tools.md` `nf_send` → `nt_send`; `agent-runner-adapters.md` `lib/output.sh` → `lib/ports/llm_runner.sh` `lr_classify_exit`.
- **ARC E2** `lr_call` 7 자리 인자 시그니처: `<role> <operation> <manifest_id> <prompt_ref> <agent_cwd> <timeout_sec> <idempotency_key>`. wrapper 가 prompt 헤더와 인자 일치성 검증 (불일치 시 `adapter_unavailable` fail-fast). `claude_code.sh` adapter 가 `LR_TIMEOUT_SEC>0` 시 `timeout` 명령으로 wrap, `timeout` 부재 시 silent skip 하지 않고 66 fail-fast (#ARC-ADAPTER-SUBSTITUTION 의 "동일 timeout 동작" 보장). caller `scheduler/runner.sh` 가 deterministic `idempotency_key`(`role|operation|manifest_id|attempt` SHA-256[:16]) 산출 후 호출. wrapper JSON output 에 `role/operation/manifest_id/idempotency_key/timeout_enforced` 5 키 추가.

draft archive: `.human/archive/2026-05-architecture-audit/architecture-cross-doc-drift.md` (gitignored, local-only).

## Design notes (외부 리뷰 반영)

- **timeout 강제는 adapter 책임** — wrapper 가 sourced bash function 인 `lr_invoke` 를 외부 `timeout` 로 wrap 불가능. adapter 가 `LR_TIMEOUT_SEC` env 를 읽어 외부 명령 호출 시점에 자체 wrap.
- **timeout cmd 부재 silent skip 금지** — `LR_TIMEOUT_SEC>0` 인데 `command -v timeout` 실패 → 66 + stderr (port 추상이 OS-별 비결정성으로 누수되지 않도록).
- **idempotency_key 는 caller deterministic 산출** — interface placeholder 가 아니라 실제 wiring. 같은 (role/operation/manifest_id/attempt) 호출은 같은 key, retry 는 attempt 가 달라 자연히 다른 key.
- **헤더↔인자 일치성 검증** — fake adapter 가 prompt 헤더 기반으로 fixture 를 잡으므로, 인자만 다르고 헤더가 같은 silent divergence 가 있으면 분포 비교 invariant 위반. 불일치 시 어댑터 호출 전에 차단.
- **wrapper 의 `timeout_enforced` 는 의도만 표기** — 실제 wrap 여부는 adapter 의 책임이며 caller 는 `exit_status=timeout` 으로 확인.

## Test Plan

- [x] `bash tests/lib/test-llm-runner-port.sh` — 기존 7 케이스 + 신규 4 케이스 (G5 헤더 불일치, JSON 스키마, G3 timeout cmd 부재, idempotency_key echo)
- [x] `bash tests/lib/test-port-conformance.sh`
- [x] `bash tests/scheduler/test-runner-pipeline.sh` (7 시나리오)
- [x] `bash tests/scheduler/test-runner-cwd.sh`
- [x] `bash tests/adapters/test-llm_runner-fake.sh`
- [x] `bash tests/e2e/full-flow.sh` (10 step)
- [x] PR-1 verification grep: `grep -rn "nf_send" docs/` = 0 행, `grep -n "lib/output\.sh" docs/architecture/agent-runner-adapters.md` = 0 행
- [x] PR-4 verification grep: `grep -rn "lr_call " . --include="*.sh"` 호출 모두 7-arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)