### PR TITLE
Phase 1b: envelope + manifest + session schemas

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -348,22 +348,22 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | `AGC-SCOPE` | active | contract authority | n/a | original |
 | `AGC-PHASES` | spec-only | contract prose | always_hard (enum 검증) | 2026-05-05-loop (4 phase 로 격하) |
 | `AGC-AGENT-PROFILES` | spec-only | contract prose | always_hard (enum 검증) | phase-pivot |
-| `AGC-CONTRIBUTION` | spec-only | contract prose | always_hard (enum 검증) | 2026-05-05-loop (enum 정정) |
+| `AGC-CONTRIBUTION` | partial | `src/domain/schema/contribution.ts` (`ContributionKind`, `OutputKind`, `FinalVerdict`, `ParentLoop`, `AgentProfileId`, `AgentRoleInSession`, `TddPhase` zod enums) | always_hard (enum 검증) | 2026-05-05-loop (enum 정정) |
 | `AGC-CALL-BOUNDARY` | partial | `application/agent_io.sh`, `lib/ports/*` | always_hard (caller_only_operational_write) | 2026-05-05-loop (turn 단위로 재정의) |
 | `AGC-SESSION-INPUT` ★ | spec-only | contract prose | always_hard (manifest_external_read_write) | 2026-05-05-loop |
 | `AGC-PROMPT-SERIALIZATION` ★ | spec-only | contract prose. prompt builder catch-up (`docs/architecture/prompt-build-pipeline.md`) | always_hard (4-part layout + header echo 7 필드) | 2026-05-05-loop |
 | `AGC-NEXT-ACTION-REQUEST` ★ | spec-only | contract prose | always_hard (direct_invocation_forbidden, decision_reason 필수) | 2026-05-05-loop |
 | `AGC-TURN-ORDERING` ★ | spec-only | contract prose + `dialogue_coordinator.sh` (Stage 2) | always_hard (priority + fairness) | 2026-05-05-loop |
 | `AGC-CONFLICT-RESOLUTION` ★ | spec-only | contract prose + `dialogue_coordinator.sh` (Stage 2) | always_hard (re-dispatch / human escalation) | 2026-05-05-loop |
-| `AGC-CONTEXT-MANIFEST` | partial | `lib/context.sh`, `scheduler/runner.sh` | always_hard (manifest_external_read_write) | 2026-05-05-loop (turn manifest 추가) |
+| `AGC-CONTEXT-MANIFEST` | partial | `src/domain/schema/manifest.ts` (`ContextManifest`, `ManifestEntry`, `FetchScope`), `src/application/manifest-builder.ts` (`ManifestBuilder.build` + `recheckPins` via `RevisionPinResolver` port) | always_hard (manifest_external_read_write) | 2026-05-05-loop (turn manifest 추가) |
 | `AGC-CONTEXT-BUDGET` ★ | spec-only | contract prose. cap 적용은 Caller (Stage 2) | always_hard (overflow → invalid envelope) | 2026-05-05-loop |
-| `AGC-OUTPUT` | spec-only | contract prose. legacy helper(`lib/output.sh`)는 후속 PR 에서 catch-up | always_hard (enum + envelope shape) | 2026-05-05-loop (envelope schema 전면 교체) |
-| `AGC-OUTPUT-RUNTIME-ENRICH` | spec-only | contract prose | always_hard | 2026-05-05-loop (3-scope idempotency 매핑) |
+| `AGC-OUTPUT` | partial | `src/domain/schema/envelope.ts` (`AgentAuthoredEnvelope` pre-enrichment + `Envelope` canonical shapes), `src/application/envelope.ts` (`parseAgentAuthored` + `validateEnvelope`) | always_hard (enum + envelope shape) | 2026-05-05-loop (envelope schema 전면 교체) |
+| `AGC-OUTPUT-RUNTIME-ENRICH` | partial | `src/application/envelope.ts` (`enrichEnvelope` injects `idempotency_key` + `runtime_metadata`, rejects key collisions and agent-authored caller-only fields) | always_hard | 2026-05-05-loop (3-scope idempotency 매핑) |
 | `AGC-LLM-NEUTRALITY` ★ | spec-only | contract prose. adapter normalize 책임 (`adapters/llm_runner/*`) | always_hard (provider-native → envelope normalize) | 2026-05-05-loop |
-| `AGC-CONTRIBUTION-OUTPUTS` | spec-only | contract prose | always_hard (output_kind 매트릭스 검증) | 2026-05-05-loop |
+| `AGC-CONTRIBUTION-OUTPUTS` | partial | `src/application/envelope-extended-validator.ts` (data-driven (parent_loop, phase_or_purpose, contribution_kind) → output_kind / verdict.result matrix) | always_hard (output_kind 매트릭스 검증) | 2026-05-05-loop |
 | `AGC-WORKSPACE` | partial | `adapters/workspace/*`, `application/caller_dispatch.sh` | stage_graded:scope_violation=warn (Stage 3b block) | 2026-05-05-loop (inner scope enforcement) |
 | `AGC-ISSUE-BODY` | spec-only | `docs/architecture/agent-output-format-mapping.md` | n/a (rendering 규약) | original |
-| `AGC-INVALID` | partial | `application/agent_io.sh`, `lib/output.sh` | always_hard | 2026-05-05-loop (TDD strict / session_id 충돌 추가) |
+| `AGC-INVALID` | partial | `src/application/envelope.ts` (`AGC_INVALID_REASONS` enum, `AgcInvalidError`, parser/enricher/matrix classification surface). TDD strict / session_id collision / scope_violation 분기는 phase 2+ catch-up | always_hard | 2026-05-05-loop (TDD strict / session_id 충돌 추가) |
 
 ### State and Operation
 
@@ -376,8 +376,8 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | `SOC-SLICE-LIFECYCLE` ★ | spec-only | `lib/slice.sh` (Stage 2) | always_hard (state machine) | 2026-05-05-loop |
 | `SOC-SLICE-DEPENDENCIES` ★ | spec-only | `lib/slice.sh` + Planning lead artifact validation (Stage 2) | always_hard (cycle detection) | 2026-05-05-loop |
 | `SOC-SLICE-CLASS` ★ | spec-only | `lib/slice.sh` + escalation rule lookup (Stage 4) | always_hard (escalation 평가) | 2026-05-05-loop |
-| `SOC-SESSION-LIFECYCLE` ★ | spec-only | `lib/session.sh`, `dialogue_coordinator.sh` (Stage 2) | always_hard (state machine) | 2026-05-05-loop |
-| `SOC-SESSION-TERMINATION` ★ | spec-only | `dialogue_coordinator.sh` (Stage 2) | stage_graded:required_evidence_unmet=warn (Stage 3b block) | 2026-05-05-loop |
+| `SOC-SESSION-LIFECYCLE` ★ | partial | `src/domain/schema/dialogue-session.ts` (`DialogueSession` 5-state schema + `Participant`), `src/domain/schema/session-turn.ts` (`SessionTurn` + `CallerRoutingDecision`). dialogue coordinator dispatch 는 phase 3 | always_hard (state machine) | 2026-05-05-loop |
+| `SOC-SESSION-TERMINATION` ★ | partial | `src/domain/schema/dialogue-session.ts` (`SessionTermination` block: `FinalizationRule`, `RequiredEvidence`, `CompositeRule`). evaluator 는 phase 3 (`termination-evaluator.ts`) | stage_graded:required_evidence_unmet=warn (Stage 3b block) | 2026-05-05-loop |
 | `SOC-SLICE-MERGE` ★ | spec-only | `lib/slice_merge.sh` (Stage 2) | always_hard (state machine) | 2026-05-05-loop |
 | `SOC-DUAL-MILESTONE-BRANCH` ★ | spec-only | trunk 정책 (`SOC-MERGE-POLICY` 와 결합) | always_hard | 2026-05-05-loop |
 | `SOC-CROSS-MILESTONE-REFERENCE` ★ | spec-only | `application/dialogue_coordinator.sh` 의 cross-slot stale 감지 (Stage 4) | stage_graded:telemetry_enrichment_missing=warn | 2026-05-05-loop |
@@ -404,7 +404,7 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | `RGC-DUAL-GATE-QUEUE` ★ | spec-only | `dual_track_scheduler.sh` (Stage 4) | always_hard (FIFO + idempotency) | 2026-05-05-loop |
 | `RGC-RECOVERY` | spec-only | `application/recovery.sh` (legacy-only catch-up needed) | always_hard | 2026-05-05-loop (loop-aware trigger) |
 | `RGC-FAILURE` | partial | `application/recovery.sh`, `scripts/cli/daemon.sh` | always_hard | 2026-05-05-loop (retry/escalation 운영 정책 매핑) |
-| `RGC-VERIFICATION` | active | `application/verification_runner.sh` + (Stage 2) `metric_run` 추가 | always_hard (deterministic_verification_authority) | 2026-05-05-loop (VerificationRun + MetricRun + required_evidence) |
+| `RGC-VERIFICATION` | partial | `src/domain/schema/verification.ts` (`VerificationRun` + `MetricRun` schemas). 실행자 (`application/verification-runner.ts`) 는 phase 2 | always_hard (deterministic_verification_authority) | 2026-05-05-loop (VerificationRun + MetricRun + required_evidence) |
 | `RGC-HUMAN-CONTRIBUTION` | spec-only | `application/human_signal.sh` (legacy-only catch-up needed) | always_hard (required human contribution) | 2026-05-05-loop (feature slice 한정 scope) |
 | `RGC-LEDGER` | partial | `src/domain/schema/ledger.ts` (필수 필드 schema), `src/application/ledger.ts` (`FileLedger.appendTransition` + audit_hash chain), `src/domain/audit-hash.ts` (sha256 canonical-json [prevHash, row]) | always_hard (필수 필드) | 2026-05-05-loop (slice/session/turn/loop_kind/action_kind/final_verdict 추가) |
 | `RGC-PAUSE` | active | `lib/signals.sh`, `scripts/cli/control.sh`, `application/human_signal.sh` | always_hard | original |

--- a/src/application/envelope-extended-validator.ts
+++ b/src/application/envelope-extended-validator.ts
@@ -1,0 +1,215 @@
+import type { Envelope } from "../domain/schema/envelope.js";
+
+/**
+ * AGC-CONTRIBUTION-OUTPUTS matrix (data-driven so phase 3+ extensions are
+ * lookup additions rather than code changes).
+ *
+ * Two-axis layout:
+ * - `LOOP_PURPOSE_ROWS`: parent_loop × phase_or_purpose × contribution_kind
+ * - `ANY_LOOP_ROWS`: contribution_kind only (matches across any loop)
+ *
+ * `failure` output_kind is allowed in any combination provided the `failure`
+ * block is present — handled before the matrix lookup.
+ */
+
+export type ExtendedValidationResult =
+  | { ok: true }
+  | { ok: false; reason: ExtendedInvalidReason; detail: string };
+
+export type ExtendedInvalidReason =
+  | "matrix_violation"
+  | "missing_required_envelope_field"
+  | "phase_or_purpose_outside_loop";
+
+interface MatrixRow {
+  parent_loop: "outer" | "middle" | "inner";
+  phase_or_purpose: string;
+  contribution_kind:
+    | "lead_draft"
+    | "review_verdict"
+    | "human_approval"
+    | "session_outcome"
+    | "proposal";
+  allowed_output_kinds: string[];
+  /**
+   * `null` means a verdict is forbidden in this combination.
+   * Otherwise verdict.result must be one of the listed values.
+   */
+  allowed_verdict_results: string[] | null;
+}
+
+const LOOP_PURPOSE_ROWS: MatrixRow[] = [
+  {
+    parent_loop: "outer",
+    phase_or_purpose: "Discovery",
+    contribution_kind: "lead_draft",
+    allowed_output_kinds: ["spec_proposal"],
+    allowed_verdict_results: null,
+  },
+  {
+    parent_loop: "outer",
+    phase_or_purpose: "Specification",
+    contribution_kind: "lead_draft",
+    allowed_output_kinds: ["spec_proposal"],
+    allowed_verdict_results: null,
+  },
+  {
+    parent_loop: "outer",
+    phase_or_purpose: "Planning",
+    contribution_kind: "lead_draft",
+    allowed_output_kinds: ["slice_decomposition"],
+    allowed_verdict_results: null,
+  },
+  {
+    parent_loop: "outer",
+    phase_or_purpose: "Validation",
+    contribution_kind: "lead_draft",
+    allowed_output_kinds: ["milestone_package"],
+    allowed_verdict_results: ["PASS", "FAIL", "STALE"],
+  },
+  {
+    parent_loop: "middle",
+    phase_or_purpose: "review",
+    contribution_kind: "review_verdict",
+    allowed_output_kinds: ["verdict"],
+    allowed_verdict_results: ["approve", "request_changes"],
+  },
+  {
+    parent_loop: "inner",
+    phase_or_purpose: "tdd_build",
+    contribution_kind: "lead_draft",
+    allowed_output_kinds: ["patch"],
+    allowed_verdict_results: null,
+  },
+];
+
+const ANY_LOOP_ROWS: Pick<
+  MatrixRow,
+  "contribution_kind" | "allowed_output_kinds" | "allowed_verdict_results"
+>[] = [
+  {
+    contribution_kind: "human_approval",
+    allowed_output_kinds: ["verdict"],
+    allowed_verdict_results: ["approve", "reject"],
+  },
+  {
+    contribution_kind: "proposal",
+    allowed_output_kinds: ["proposal_artifact"],
+    allowed_verdict_results: null,
+  },
+  {
+    contribution_kind: "session_outcome",
+    allowed_output_kinds: ["verdict", "milestone_package"],
+    allowed_verdict_results: null,
+  },
+];
+
+const VALID_PHASE_BY_LOOP: Record<Envelope["parent_loop"], string[]> = {
+  outer: ["Discovery", "Specification", "Planning", "Validation"],
+  middle: ["review", "merge"],
+  inner: ["tdd_build"],
+};
+
+export function extendedValidate(env: Envelope): ExtendedValidationResult {
+  if (!VALID_PHASE_BY_LOOP[env.parent_loop].includes(env.phase_or_purpose)) {
+    return {
+      ok: false,
+      reason: "phase_or_purpose_outside_loop",
+      detail: `phase_or_purpose=${env.phase_or_purpose} not allowed for parent_loop=${env.parent_loop}`,
+    };
+  }
+
+  if (env.output_kind === "failure") {
+    if (env.failure == null) {
+      return {
+        ok: false,
+        reason: "missing_required_envelope_field",
+        detail: "output_kind=failure requires the `failure` block",
+      };
+    }
+    return { ok: true };
+  }
+
+  if (env.parent_loop === "middle" || env.parent_loop === "inner") {
+    if (env.slice_id == null) {
+      return {
+        ok: false,
+        reason: "missing_required_envelope_field",
+        detail: `slice_id required for parent_loop=${env.parent_loop}`,
+      };
+    }
+    if (env.slice_kind == null) {
+      return {
+        ok: false,
+        reason: "missing_required_envelope_field",
+        detail: `slice_kind required for parent_loop=${env.parent_loop}`,
+      };
+    }
+  }
+  if (env.parent_loop === "inner" && env.tdd_phase == null) {
+    return {
+      ok: false,
+      reason: "missing_required_envelope_field",
+      detail: "tdd_phase required for parent_loop=inner",
+    };
+  }
+
+  const anyRow = ANY_LOOP_ROWS.find(
+    (r) => r.contribution_kind === env.contribution_kind,
+  );
+  if (anyRow) {
+    return checkOutputAndVerdict(env, anyRow);
+  }
+
+  const row = LOOP_PURPOSE_ROWS.find(
+    (r) =>
+      r.parent_loop === env.parent_loop &&
+      r.phase_or_purpose === env.phase_or_purpose &&
+      r.contribution_kind === env.contribution_kind,
+  );
+  if (!row) {
+    return {
+      ok: false,
+      reason: "matrix_violation",
+      detail: `(parent_loop=${env.parent_loop}, phase_or_purpose=${env.phase_or_purpose}, contribution_kind=${env.contribution_kind}) is not an AGC-CONTRIBUTION-OUTPUTS row`,
+    };
+  }
+  return checkOutputAndVerdict(env, row);
+}
+
+function checkOutputAndVerdict(
+  env: Envelope,
+  row: Pick<
+    MatrixRow,
+    "contribution_kind" | "allowed_output_kinds" | "allowed_verdict_results"
+  >,
+): ExtendedValidationResult {
+  if (!row.allowed_output_kinds.includes(env.output_kind)) {
+    return {
+      ok: false,
+      reason: "matrix_violation",
+      detail: `(${row.contribution_kind}, output_kind=${env.output_kind}) not allowed; expected one of [${row.allowed_output_kinds.join(", ")}]`,
+    };
+  }
+  if (row.allowed_verdict_results == null) {
+    if (env.verdict != null) {
+      return {
+        ok: false,
+        reason: "matrix_violation",
+        detail: `verdict not allowed for contribution_kind=${row.contribution_kind}`,
+      };
+    }
+    return { ok: true };
+  }
+  if (
+    env.verdict == null ||
+    !row.allowed_verdict_results.includes(env.verdict.result)
+  ) {
+    return {
+      ok: false,
+      reason: "matrix_violation",
+      detail: `verdict.result must be one of [${row.allowed_verdict_results.join(", ")}]`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/application/envelope-extended-validator.ts
+++ b/src/application/envelope-extended-validator.ts
@@ -6,10 +6,17 @@ import type { Envelope } from "../domain/schema/envelope.js";
  *
  * Two-axis layout:
  * - `LOOP_PURPOSE_ROWS`: parent_loop × phase_or_purpose × contribution_kind
- * - `ANY_LOOP_ROWS`: contribution_kind only (matches across any loop)
+ * - `ANY_LOOP_ROWS`: contribution_kind only (matches across any loop).
+ *   Includes `human_approval`, `proposal`, and `session_outcome`. The latter
+ *   is Caller-only at the AGC-OUTPUT layer (Inv #4) — `application/
+ *   envelope.ts#parseAgentAuthored` rejects it before this matrix runs, so
+ *   only Caller-built canonical envelopes reach the row.
  *
- * `failure` output_kind is allowed in any combination provided the `failure`
- * block is present — handled before the matrix lookup.
+ * `failure` output_kind is allowed in any combination provided the
+ * `failure` block is present — but the loop-conditional fields
+ * (`slice_id`, `slice_kind`, `tdd_phase`) are still validated first, since
+ * AGC-OUTPUT lists them as conditional on `parent_loop` alone (independent
+ * of `output_kind`).
  */
 
 export type ExtendedValidationResult =
@@ -119,17 +126,10 @@ export function extendedValidate(env: Envelope): ExtendedValidationResult {
     };
   }
 
-  if (env.output_kind === "failure") {
-    if (env.failure == null) {
-      return {
-        ok: false,
-        reason: "missing_required_envelope_field",
-        detail: "output_kind=failure requires the `failure` block",
-      };
-    }
-    return { ok: true };
-  }
-
+  // AGC-OUTPUT slice_id / slice_kind / tdd_phase invariants apply regardless
+  // of output_kind — including `failure`. A failure envelope still has to
+  // identify the caller / session context it failed in. The failure
+  // short-circuit comes AFTER conditional-field validation, not before.
   if (env.parent_loop === "middle" || env.parent_loop === "inner") {
     if (env.slice_id == null) {
       return {
@@ -152,6 +152,17 @@ export function extendedValidate(env: Envelope): ExtendedValidationResult {
       reason: "missing_required_envelope_field",
       detail: "tdd_phase required for parent_loop=inner",
     };
+  }
+
+  if (env.output_kind === "failure") {
+    if (env.failure == null) {
+      return {
+        ok: false,
+        reason: "missing_required_envelope_field",
+        detail: "output_kind=failure requires the `failure` block",
+      };
+    }
+    return { ok: true };
   }
 
   const anyRow = ANY_LOOP_ROWS.find(

--- a/src/application/envelope.ts
+++ b/src/application/envelope.ts
@@ -6,6 +6,10 @@ import {
   type Envelope as EnvelopeT,
 } from "../domain/schema/envelope.js";
 import { extendedValidate } from "./envelope-extended-validator.js";
+import {
+  idempotencyKey,
+  type IdempotencyParts,
+} from "./idempotency.js";
 
 /**
  * AGC-OUTPUT envelope parser, runtime enricher, and post-enrichment matrix
@@ -42,6 +46,7 @@ export const AGC_INVALID_REASONS = [
   "context_budget_truncation",
   "agent_authored_runtime_metadata",
   "agent_authored_idempotency_key",
+  "agent_authored_session_outcome",
 ] as const;
 export type AgcInvalidReason = (typeof AGC_INVALID_REASONS)[number];
 
@@ -106,11 +111,27 @@ export function parseAgentAuthored(
       detail: zodMessage(parsed.error),
     };
   }
+  // AGC-CONTRIBUTION: `session_outcome` is Caller-only — agents must not
+  // produce it. Inv #4 (Caller-only operational write).
+  if (parsed.data.contribution_kind === "session_outcome") {
+    return {
+      ok: false,
+      reason: "agent_authored_session_outcome",
+      detail:
+        "Agent must not produce contribution_kind=session_outcome (AGC-CONTRIBUTION: Caller-only)",
+    };
+  }
   return { ok: true, value: parsed.data };
 }
 
 export interface EnrichmentInputs {
-  idempotency_key: string;
+  /**
+   * SOC-IDEMPOTENCY parts. The compositor in `application/idempotency.ts`
+   * deterministically derives the canonical envelope idempotency_key — we
+   * do not accept arbitrary strings, since that would bypass the SOC-
+   * IDEMPOTENCY 3-scope authority and break replay determinism.
+   */
+  idempotency: IdempotencyParts;
   runtime_metadata: Record<string, unknown>;
 }
 
@@ -140,9 +161,10 @@ export function enrichEnvelope(
       };
     }
   }
+  const composedKey = idempotencyKey(inputs.idempotency);
   const parsed = Envelope.safeParse({
     ...agent,
-    idempotency_key: inputs.idempotency_key,
+    idempotency_key: composedKey,
     runtime_metadata: inputs.runtime_metadata,
   });
   if (!parsed.success) {

--- a/src/application/envelope.ts
+++ b/src/application/envelope.ts
@@ -1,0 +1,172 @@
+import { ZodError } from "zod";
+import {
+  AgentAuthoredEnvelope,
+  Envelope,
+  type AgentAuthoredEnvelope as AgentAuthoredEnvelopeT,
+  type Envelope as EnvelopeT,
+} from "../domain/schema/envelope.js";
+import { extendedValidate } from "./envelope-extended-validator.js";
+
+/**
+ * AGC-OUTPUT envelope parser, runtime enricher, and post-enrichment matrix
+ * validator. Together with `envelope-extended-validator.ts` this module is
+ * the single seam that classifies AGC-INVALID reasons.
+ *
+ * Flow per AGC-OUTPUT-RUNTIME-ENRICH:
+ *   raw_text → parseAgentAuthored
+ *            → enrichEnvelope({idempotency_key, runtime_metadata})
+ *            → validateEnvelope (matrix lookup)
+ */
+
+export const AGC_INVALID_REASONS = [
+  "schema_violation",
+  "manifest_outside_read",
+  "missing_required_envelope_field",
+  "missing_revision_pins",
+  "enum_outside",
+  "matrix_violation",
+  "phase_or_purpose_outside_loop",
+  "session_turn_collision",
+  "scope_violation",
+  "tdd_strict_violation",
+  "legacy_field_present",
+  "operational_side_effect",
+  "secret_leak",
+  "enrich_key_collision",
+  "issue_body_layer_mixed",
+  "prompt_layout_violation",
+  "header_echo_mismatch",
+  "decision_reason_missing",
+  "turn_ordering_violation",
+  "verdict_overwrite",
+  "context_budget_truncation",
+  "agent_authored_runtime_metadata",
+  "agent_authored_idempotency_key",
+] as const;
+export type AgcInvalidReason = (typeof AGC_INVALID_REASONS)[number];
+
+export class AgcInvalidError extends Error {
+  readonly reason: AgcInvalidReason;
+  readonly detail: string;
+  constructor(reason: AgcInvalidReason, detail: string) {
+    super(`AGC-INVALID:${reason}: ${detail}`);
+    this.reason = reason;
+    this.detail = detail;
+  }
+}
+
+export type Ok<T> = { ok: true; value: T };
+export type Fail = { ok: false; reason: AgcInvalidReason; detail: string };
+export type ParseOutcome<T> = Ok<T> | Fail;
+
+const LEGACY_FIELDS = ["agent_role", "operation", "phase_run_id"] as const;
+const CALLER_ONLY_FIELDS = ["idempotency_key", "runtime_metadata"] as const;
+
+/**
+ * Pre-enrichment parser. Validates Agent-authored shape and rejects envelopes
+ * containing Caller-only fields or deprecated legacy fields.
+ */
+export function parseAgentAuthored(
+  raw: unknown,
+): ParseOutcome<AgentAuthoredEnvelopeT> {
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      ok: false,
+      reason: "schema_violation",
+      detail: "envelope must be a JSON object",
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+  for (const f of CALLER_ONLY_FIELDS) {
+    if (f in obj) {
+      return {
+        ok: false,
+        reason:
+          f === "idempotency_key"
+            ? "agent_authored_idempotency_key"
+            : "agent_authored_runtime_metadata",
+        detail: `Agent must not produce \`${f}\` (AGC-OUTPUT-RUNTIME-ENRICH)`,
+      };
+    }
+  }
+  for (const f of LEGACY_FIELDS) {
+    if (f in obj) {
+      return {
+        ok: false,
+        reason: "legacy_field_present",
+        detail: `legacy field \`${f}\` is forbidden`,
+      };
+    }
+  }
+  const parsed = AgentAuthoredEnvelope.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: "schema_violation",
+      detail: zodMessage(parsed.error),
+    };
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export interface EnrichmentInputs {
+  idempotency_key: string;
+  runtime_metadata: Record<string, unknown>;
+}
+
+/**
+ * Caller enrichment. Adds idempotency_key + runtime_metadata, and runs
+ * post-enrichment schema validation.
+ *
+ * Caller-side construction means key-collision with Agent fields is
+ * impossible (Agent envelope was already rejected if those keys were
+ * present). However the caller may still pass a runtime_metadata key that
+ * shadows a top-level envelope field name — we surface that as
+ * `enrich_key_collision`.
+ */
+export function enrichEnvelope(
+  agent: AgentAuthoredEnvelopeT,
+  inputs: EnrichmentInputs,
+): ParseOutcome<EnvelopeT> {
+  const reservedKeys = new Set(Object.keys(agent));
+  reservedKeys.add("idempotency_key");
+  reservedKeys.add("runtime_metadata");
+  for (const key of Object.keys(inputs.runtime_metadata)) {
+    if (reservedKeys.has(key)) {
+      return {
+        ok: false,
+        reason: "enrich_key_collision",
+        detail: `runtime_metadata key \`${key}\` collides with an envelope field`,
+      };
+    }
+  }
+  const parsed = Envelope.safeParse({
+    ...agent,
+    idempotency_key: inputs.idempotency_key,
+    runtime_metadata: inputs.runtime_metadata,
+  });
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: "schema_violation",
+      detail: zodMessage(parsed.error),
+    };
+  }
+  return { ok: true, value: parsed.data };
+}
+
+/**
+ * Post-enrichment matrix validator. Pairs with `parseAgentAuthored` +
+ * `enrichEnvelope` to give the full AGC-INVALID classification surface.
+ */
+export function validateEnvelope(env: EnvelopeT): ParseOutcome<EnvelopeT> {
+  const r = extendedValidate(env);
+  if (r.ok) return { ok: true, value: env };
+  return { ok: false, reason: r.reason, detail: r.detail };
+}
+
+function zodMessage(err: ZodError): string {
+  return err.errors
+    .map((e) => `${e.path.join(".") || "<root>"}: ${e.message}`)
+    .join("; ");
+}

--- a/src/application/idempotency.ts
+++ b/src/application/idempotency.ts
@@ -1,0 +1,106 @@
+/**
+ * SOC-IDEMPOTENCY 3-scope idempotency-key compositor — single authority.
+ *
+ * Used by both:
+ *   - `application/ledger.ts` when appending transition rows.
+ *   - `application/envelope.ts` when enriching an Agent envelope into the
+ *     canonical AGC-OUTPUT envelope (the envelope's `idempotency_key`
+ *     field is required by AGC-OUTPUT-RUNTIME-ENRICH).
+ *
+ * Determinism: given the same `IdempotencyParts`, this function returns the
+ * same string, byte-for-byte. Callers must NOT pass arbitrary strings as
+ * idempotency keys — that would skip the canonical composition and break
+ * the SOC-IDEMPOTENCY guarantees.
+ */
+
+export type IdempotencyScope =
+  | "per_turn"
+  | "per_session_outcome"
+  | "per_merge"
+  | "intake"
+  | "slot_promotion"
+  | "verification"
+  | "recover"
+  | "external_observation"
+  | "signal_apply"
+  | "pause_resume";
+
+export interface PerTurnIdempotencyParts {
+  session_id: string;
+  turn_index: number;
+  agent_profile_id: string;
+  manifest_id: string;
+  input_revision_pins: readonly string[];
+}
+
+export interface PerSessionOutcomeIdempotencyParts {
+  session_id: string;
+  final_verdict: string;
+  finalization_decision: string;
+  workspace_revision_pin_at_convergence: string | null;
+}
+
+export interface PerMergeIdempotencyParts {
+  slice_merge_id: string;
+  pre_merge_workspace_revision: string;
+  trunk_base_revision_at_merge_attempt: string;
+}
+
+export type IdempotencyParts =
+  | { scope: "per_turn"; parts: PerTurnIdempotencyParts }
+  | { scope: "per_session_outcome"; parts: PerSessionOutcomeIdempotencyParts }
+  | { scope: "per_merge"; parts: PerMergeIdempotencyParts }
+  | {
+      scope: Exclude<
+        IdempotencyScope,
+        "per_turn" | "per_session_outcome" | "per_merge"
+      >;
+      parts: Record<string, string | number | null | undefined | readonly string[]>;
+    };
+
+export function idempotencyKey(input: IdempotencyParts): string {
+  switch (input.scope) {
+    case "per_turn": {
+      const p = input.parts;
+      const pins = [...p.input_revision_pins].sort().join(",");
+      return [
+        "per_turn",
+        p.session_id,
+        p.turn_index,
+        p.agent_profile_id,
+        p.manifest_id,
+        pins,
+      ].join("|");
+    }
+    case "per_session_outcome": {
+      const p = input.parts;
+      return [
+        "per_session_outcome",
+        p.session_id,
+        p.final_verdict,
+        p.finalization_decision,
+        p.workspace_revision_pin_at_convergence ?? "",
+      ].join("|");
+    }
+    case "per_merge": {
+      const p = input.parts;
+      return [
+        "per_merge",
+        p.slice_merge_id,
+        p.pre_merge_workspace_revision,
+        p.trunk_base_revision_at_merge_attempt,
+      ].join("|");
+    }
+    default: {
+      const parts = Object.entries(input.parts)
+        .map(
+          ([k, v]) =>
+            [k, Array.isArray(v) ? [...v].sort().join(",") : v ?? ""] as const,
+        )
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join("&");
+      return [input.scope, parts].join("|");
+    }
+  }
+}

--- a/src/application/ledger.ts
+++ b/src/application/ledger.ts
@@ -5,103 +5,27 @@ import {
 import { LedgerRow } from "../domain/schema/ledger.js";
 import type { LoggerPort } from "../ports/logger.js";
 import type { StorePort } from "../ports/store.js";
+import {
+  idempotencyKey as composeIdempotencyKey,
+  type IdempotencyParts,
+  type IdempotencyScope,
+  type PerMergeIdempotencyParts,
+  type PerSessionOutcomeIdempotencyParts,
+  type PerTurnIdempotencyParts,
+} from "./idempotency.js";
 import { LEDGER_TRANSITIONS_PATH } from "./persistence-layout.js";
 
-export type IdempotencyScope =
-  | "per_turn"
-  | "per_session_outcome"
-  | "per_merge"
-  | "intake"
-  | "slot_promotion"
-  | "verification"
-  | "recover"
-  | "external_observation"
-  | "signal_apply"
-  | "pause_resume";
-
-export interface PerTurnIdempotencyParts {
-  session_id: string;
-  turn_index: number;
-  agent_profile_id: string;
-  manifest_id: string;
-  input_revision_pins: readonly string[];
-}
-
-export interface PerSessionOutcomeIdempotencyParts {
-  session_id: string;
-  final_verdict: string;
-  finalization_decision: string;
-  workspace_revision_pin_at_convergence: string | null;
-}
-
-export interface PerMergeIdempotencyParts {
-  slice_merge_id: string;
-  pre_merge_workspace_revision: string;
-  trunk_base_revision_at_merge_attempt: string;
-}
-
-export type IdempotencyParts =
-  | { scope: "per_turn"; parts: PerTurnIdempotencyParts }
-  | { scope: "per_session_outcome"; parts: PerSessionOutcomeIdempotencyParts }
-  | { scope: "per_merge"; parts: PerMergeIdempotencyParts }
-  | {
-      scope: Exclude<
-        IdempotencyScope,
-        "per_turn" | "per_session_outcome" | "per_merge"
-      >;
-      parts: Record<string, string | number | null | undefined | readonly string[]>;
-    };
-
-/**
- * SOC-IDEMPOTENCY 3-scope idempotency key compositor.
- * Caller enrichment is the single authority that produces these keys.
- */
-export function idempotencyKey(input: IdempotencyParts): string {
-  switch (input.scope) {
-    case "per_turn": {
-      const p = input.parts;
-      const pins = [...p.input_revision_pins].sort().join(",");
-      return [
-        "per_turn",
-        p.session_id,
-        p.turn_index,
-        p.agent_profile_id,
-        p.manifest_id,
-        pins,
-      ].join("|");
-    }
-    case "per_session_outcome": {
-      const p = input.parts;
-      return [
-        "per_session_outcome",
-        p.session_id,
-        p.final_verdict,
-        p.finalization_decision,
-        p.workspace_revision_pin_at_convergence ?? "",
-      ].join("|");
-    }
-    case "per_merge": {
-      const p = input.parts;
-      return [
-        "per_merge",
-        p.slice_merge_id,
-        p.pre_merge_workspace_revision,
-        p.trunk_base_revision_at_merge_attempt,
-      ].join("|");
-    }
-    default: {
-      const parts = Object.entries(input.parts)
-        .map(
-          ([k, v]) =>
-            [k, Array.isArray(v) ? [...v].sort().join(",") : v ?? ""] as const,
-        )
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([k, v]) => `${k}=${v}`)
-        .join("&");
-      return [input.scope, parts].join("|");
-    }
-  }
-}
+// Re-exports preserve the historical import surface (`from "./ledger.js"`)
+// for code that already depends on it. The single authority is
+// `application/idempotency.ts`.
+export {
+  composeIdempotencyKey as idempotencyKey,
+  type IdempotencyScope,
+  type PerTurnIdempotencyParts,
+  type PerSessionOutcomeIdempotencyParts,
+  type PerMergeIdempotencyParts,
+  type IdempotencyParts,
+};
 
 export class LedgerCorruptError extends Error {
   constructor(

--- a/src/application/manifest-builder.ts
+++ b/src/application/manifest-builder.ts
@@ -1,0 +1,93 @@
+import { newId } from "../domain/ids.js";
+import {
+  ContextManifest,
+  type ContextManifest as ContextManifestT,
+  type ManifestEntry,
+  type ManifestEntryObjectKind,
+  type FetchScope,
+  type ManifestPurpose,
+  type ManifestTarget,
+} from "../domain/schema/manifest.js";
+import type { ClockPort } from "../ports/clock.js";
+
+/**
+ * AGC-CONTEXT-MANIFEST builder.
+ *
+ * Revision pins are resolved by an injected port so that git-tree pins and
+ * persistent-store updated_at pins live behind a single seam (phase 2 will
+ * add the git adapter; the FS-store adapter is sufficient for design
+ * artefacts and tests).
+ *
+ * `recheckPins` returns the entries whose pins have drifted since manifest
+ * creation. `application/agent-io.ts` (phase 2) calls this immediately
+ * before persisting an envelope to enforce AGC-CONTEXT-MANIFEST's stale-
+ * detection invariant.
+ */
+
+export interface ManifestEntryDraft {
+  object_kind: ManifestEntryObjectKind;
+  object_id: string;
+  fetch_scope: FetchScope;
+  required: boolean;
+  purpose: string;
+}
+
+export interface RevisionPinResolver {
+  resolve(entry: ManifestEntryDraft): Promise<string>;
+}
+
+export interface BuildManifestInput {
+  session_id: string;
+  turn_index: number;
+  purpose: ManifestPurpose;
+  target: ManifestTarget;
+  drafts: ManifestEntryDraft[];
+}
+
+export class ManifestBuilder {
+  constructor(
+    private readonly resolver: RevisionPinResolver,
+    private readonly clock: ClockPort,
+  ) {}
+
+  async build(input: BuildManifestInput): Promise<ContextManifestT> {
+    const entries: ManifestEntry[] = [];
+    for (const d of input.drafts) {
+      entries.push({
+        object_kind: d.object_kind,
+        object_id: d.object_id,
+        fetch_scope: d.fetch_scope,
+        revision_pin: await this.resolver.resolve(d),
+        required: d.required,
+        purpose: d.purpose,
+      });
+    }
+    return ContextManifest.parse({
+      manifest_id: newId(this.clock.now()),
+      session_id: input.session_id,
+      turn_index: input.turn_index,
+      purpose: input.purpose,
+      target: input.target,
+      entries,
+      created_at: this.clock.isoNow(),
+    });
+  }
+
+  /** Returns the entries whose current pin differs from the recorded pin. */
+  async recheckPins(
+    manifest: ContextManifestT,
+  ): Promise<ManifestEntry[]> {
+    const stale: ManifestEntry[] = [];
+    for (const e of manifest.entries) {
+      const current = await this.resolver.resolve({
+        object_kind: e.object_kind,
+        object_id: e.object_id,
+        fetch_scope: e.fetch_scope,
+        required: e.required,
+        purpose: e.purpose,
+      });
+      if (current !== e.revision_pin) stale.push(e);
+    }
+    return stale;
+  }
+}

--- a/src/domain/schema/contribution.ts
+++ b/src/domain/schema/contribution.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+/**
+ * AGC-CONTRIBUTION enums and the related agent identity / output enums
+ * referenced by AGC-OUTPUT and AGC-CONTRIBUTION-OUTPUTS.
+ *
+ * - `ContributionKind`  — the 5-kind enum (legacy `rework_patch` / `evidence`
+ *   / `summary` were dropped per AGC-CONTRIBUTION).
+ * - `OutputKind`        — `failure` plus the artifact kinds enumerated by
+ *   AGC-OUTPUT.
+ * - `FinalVerdict`      — (state, final_verdict) tuple used by SOC-DISPATCH.
+ *   Includes `inner ABANDONED` reasons (no_progress / regression /
+ *   scope_violation) since SOC-SESSION-TERMINATION lists them in the same
+ *   table.
+ */
+
+export const ContributionKind = z.enum([
+  "lead_draft",
+  "review_verdict",
+  "human_approval",
+  "session_outcome",
+  "proposal",
+]);
+export type ContributionKind = z.infer<typeof ContributionKind>;
+
+export const AgentProfileId = z.enum([
+  "atlas",
+  "forge",
+  "sentinel",
+  "scout",
+  "human",
+]);
+export type AgentProfileId = z.infer<typeof AgentProfileId>;
+
+export const AgentRoleInSession = z.enum(["lead", "reviewer", "observer"]);
+export type AgentRoleInSession = z.infer<typeof AgentRoleInSession>;
+
+export const ParentLoop = z.enum(["outer", "middle", "inner"]);
+export type ParentLoop = z.infer<typeof ParentLoop>;
+
+export const TddPhase = z.enum(["red_green", "refactor"]);
+export type TddPhase = z.infer<typeof TddPhase>;
+
+export const OutputKind = z.enum([
+  "spec_proposal",
+  "task_plan",
+  "slice_decomposition",
+  "patch",
+  "verdict",
+  "milestone_package",
+  "proposal_artifact",
+  "failure",
+]);
+export type OutputKind = z.infer<typeof OutputKind>;
+
+export const FinalVerdict = z.enum([
+  "approve",
+  "request_changes",
+  "tests_green",
+  "spec_accept",
+  "spec_reject",
+  "plan_accept",
+  "validation_pass",
+  "validation_fail",
+  "validation_stale",
+  "no_progress",
+  "regression",
+  "scope_violation",
+]);
+export type FinalVerdict = z.infer<typeof FinalVerdict>;

--- a/src/domain/schema/dialogue-session.ts
+++ b/src/domain/schema/dialogue-session.ts
@@ -1,0 +1,147 @@
+import { z } from "zod";
+import { UlidString } from "../ids.js";
+import {
+  AgentProfileId,
+  AgentRoleInSession,
+  FinalVerdict,
+  ParentLoop,
+} from "./contribution.js";
+
+/**
+ * SOC-SESSION-LIFECYCLE / SOC-SESSION-TERMINATION schemas.
+ *
+ * `DialogueSession` is the 5-state aggregate. `SessionTermination` (rule
+ * + required_evidence + composite_rule) is a sub-block of the schema so
+ * the storage layout in `sessions/<id>/metadata.json` can hold the entire
+ * session config in one record.
+ */
+
+export const SessionState = z.enum([
+  "SESSION_OPEN",
+  "CONVERGED",
+  "TIMEOUT",
+  "ABANDONED",
+  "AWAITING_REVALIDATION",
+]);
+export type SessionState = z.infer<typeof SessionState>;
+
+export const SessionPurpose = z.enum([
+  "design",
+  "build",
+  "review",
+  "tdd_build",
+  "planning_decompose",
+  "validation",
+]);
+export type SessionPurpose = z.infer<typeof SessionPurpose>;
+
+export const FinalizationRule = z.enum([
+  "lead_only",
+  "unanimous_approve",
+  "quorum_then_lead",
+  "any_request_changes_blocks",
+  "timeout_only",
+]);
+export type FinalizationRule = z.infer<typeof FinalizationRule>;
+
+const MetricComparator = z.enum(["lte", "lt", "gte", "gt", "eq"]);
+const CoverageComparator = z.enum(["gte", "gt"]);
+
+export const RequiredEvidence = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("verification_green"),
+      acceptance_tests: z.array(z.string().min(1)).default(() => []),
+      deterministic_checks: z.array(z.string().min(1)).default(() => []),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("metric_threshold"),
+      metric_name: z.string().min(1),
+      comparator: MetricComparator,
+      value: z.number(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("interface_diff_clean"),
+      protected_apis: z.array(z.string().min(1)).default(() => []),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("coverage_threshold"),
+      comparator: CoverageComparator,
+      value: z.number(),
+    })
+    .strict(),
+]);
+export type RequiredEvidence = z.infer<typeof RequiredEvidence>;
+
+export const CompositeRule = z.enum([
+  "finalization_AND_evidence",
+  "evidence_only",
+  "finalization_only",
+]);
+export type CompositeRule = z.infer<typeof CompositeRule>;
+
+export const SessionTermination = z
+  .object({
+    finalization_rule: FinalizationRule,
+    required_evidence: z.array(RequiredEvidence).default(() => []),
+    composite_rule: CompositeRule,
+    quorum_min_approvals: z.number().int().positive().nullable().default(null),
+  })
+  .strict();
+export type SessionTermination = z.infer<typeof SessionTermination>;
+
+export const Participant = z
+  .object({
+    agent_profile_id: AgentProfileId,
+    role: AgentRoleInSession,
+  })
+  .strict();
+export type Participant = z.infer<typeof Participant>;
+
+export const SessionParentObjectKind = z.enum(["slice", "milestone"]);
+export type SessionParentObjectKind = z.infer<typeof SessionParentObjectKind>;
+
+export const FinalizationDecision = z.enum([
+  "finalization_rule",
+  "required_evidence",
+  "composite",
+]);
+export type FinalizationDecision = z.infer<typeof FinalizationDecision>;
+
+export const AbandonedReason = z.enum([
+  "no_progress",
+  "regression",
+  "scope_violation",
+]);
+export type AbandonedReason = z.infer<typeof AbandonedReason>;
+
+export const DialogueSession = z
+  .object({
+    session_id: UlidString,
+    parent_object_kind: SessionParentObjectKind,
+    parent_object_id: UlidString,
+    parent_loop: ParentLoop,
+    purpose: SessionPurpose,
+    participants: z.array(Participant).min(1),
+    session_termination: SessionTermination,
+    workspace_revision_pin: z.string().min(1),
+    current_turn_index: z.number().int().nonnegative(),
+    state: SessionState,
+    final_verdict: FinalVerdict.nullable().default(null),
+    abandoned_reason: AbandonedReason.nullable().default(null),
+    max_turns: z.number().int().positive(),
+    turn_log_ref: z.string().min(1).nullable().default(null),
+    spawned_contribution_id: UlidString.nullable().default(null),
+    finalization_decision: FinalizationDecision.nullable().default(null),
+    lease_token: z.string().min(1).nullable().default(null),
+    created_at: z.string().datetime(),
+    updated_at: z.string().datetime(),
+  })
+  .strict();
+export type DialogueSession = z.infer<typeof DialogueSession>;

--- a/src/domain/schema/dialogue-session.ts
+++ b/src/domain/schema/dialogue-session.ts
@@ -6,6 +6,7 @@ import {
   FinalVerdict,
   ParentLoop,
 } from "./contribution.js";
+import { MetricComparator } from "./verification.js";
 
 /**
  * SOC-SESSION-LIFECYCLE / SOC-SESSION-TERMINATION schemas.
@@ -44,7 +45,6 @@ export const FinalizationRule = z.enum([
 ]);
 export type FinalizationRule = z.infer<typeof FinalizationRule>;
 
-const MetricComparator = z.enum(["lte", "lt", "gte", "gt", "eq"]);
 const CoverageComparator = z.enum(["gte", "gt"]);
 
 export const RequiredEvidence = z.discriminatedUnion("kind", [

--- a/src/domain/schema/envelope.ts
+++ b/src/domain/schema/envelope.ts
@@ -104,7 +104,9 @@ const agentAuthoredShape = {
   contribution_kind: ContributionKind,
   parent_review_verdict_id: UlidString.nullable().default(null),
   output_kind: OutputKind,
-  object_id: z.string().min(1),
+  // AGC-OUTPUT: `object_id` 는 주 처리 대상 (slice / milestone / SliceMerge)
+  // 식별자. 셋 모두 Caller-issued ULID 이므로 schema 단에서 ULID refinement.
+  object_id: UlidString,
   manifest_id: UlidString,
   input_revision_pins: z.array(z.string().min(1)),
   summary: z.string().min(1),
@@ -117,6 +119,22 @@ const agentAuthoredShape = {
 export const AgentAuthoredEnvelope = z.object(agentAuthoredShape).strict();
 export type AgentAuthoredEnvelope = z.infer<typeof AgentAuthoredEnvelope>;
 
+/**
+ * Canonical post-enrichment envelope. Adds the two Caller-injected fields
+ * specified by AGC-OUTPUT-RUNTIME-ENRICH:
+ *   - `idempotency_key`: composed by `application/idempotency.ts` (the
+ *     SOC-IDEMPOTENCY 3-scope authority). Callers must NOT pass arbitrary
+ *     strings — `application/envelope.ts#enrichEnvelope` enforces this by
+ *     accepting `IdempotencyParts` rather than a free-form string.
+ *   - `runtime_metadata`: Caller-injected key-value bag. `application/
+ *     envelope.ts#enrichEnvelope` rejects keys that collide with envelope
+ *     fields.
+ *
+ * The `runtime_metadata` field carries an explicit empty-object default
+ * (`.default(() => ({}))`) — overriding the agent-authored shape's lack of
+ * default — so `Envelope.parse()` never produces an undefined runtime
+ * metadata bag.
+ */
 export const Envelope = z
   .object({
     ...agentAuthoredShape,

--- a/src/domain/schema/envelope.ts
+++ b/src/domain/schema/envelope.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+import { UlidString } from "../ids.js";
+import {
+  AgentProfileId,
+  AgentRoleInSession,
+  ContributionKind,
+  OutputKind,
+  ParentLoop,
+  TddPhase,
+} from "./contribution.js";
+import { SliceKind } from "./slice.js";
+
+/**
+ * AGC-OUTPUT envelope.
+ *
+ * Two layered shapes:
+ *
+ * - `AgentAuthoredEnvelope` — the subset Agents are allowed to produce.
+ *   Excludes `idempotency_key` and `runtime_metadata` (AGC-OUTPUT-RUNTIME-
+ *   ENRICH: those are Caller-only). `.strict()` rejects them at parse time.
+ *
+ * - `Envelope` — canonical post-enrichment envelope. Adds the two
+ *   Caller-injected fields. Schemas are exact-shape; matrix-level
+ *   constraints (parent_loop × contribution_kind × output_kind) are checked
+ *   by `application/envelope-extended-validator.ts` because they require
+ *   cross-field logic.
+ */
+
+export const VerdictResult = z.enum([
+  "approve",
+  "request_changes",
+  "tests_green",
+  "spec_accept",
+  "spec_reject",
+  "plan_accept",
+  "reject",
+  "PASS",
+  "FAIL",
+  "STALE",
+]);
+export type VerdictResult = z.infer<typeof VerdictResult>;
+
+export const Verdict = z
+  .object({
+    result: VerdictResult,
+    rationale: z.string().min(1).nullable().default(null),
+  })
+  .strict();
+export type Verdict = z.infer<typeof Verdict>;
+
+export const NextActionAddressedTo = z.union([
+  AgentProfileId,
+  z.literal("caller"),
+]);
+export type NextActionAddressedTo = z.infer<typeof NextActionAddressedTo>;
+
+export const NextActionEvidenceRequest = z
+  .object({
+    kind: z.string().min(1),
+    scope: z.string().min(1),
+  })
+  .strict();
+export type NextActionEvidenceRequest = z.infer<
+  typeof NextActionEvidenceRequest
+>;
+
+export const NextActionRequest = z
+  .object({
+    addressed_to: NextActionAddressedTo,
+    intent: z.string().min(1),
+    evidence_request: z.array(NextActionEvidenceRequest).default(() => []),
+    proposal_artifact_ref: z.string().min(1).nullable().default(null),
+  })
+  .strict();
+export type NextActionRequest = z.infer<typeof NextActionRequest>;
+
+export const FailureType = z.enum([
+  "need_context",
+  "invalid_output",
+  "no_progress",
+  "regression",
+  "scope_violation",
+]);
+export type FailureType = z.infer<typeof FailureType>;
+
+export const FailureBlock = z
+  .object({
+    type: FailureType,
+    rationale: z.string().min(1),
+  })
+  .strict();
+export type FailureBlock = z.infer<typeof FailureBlock>;
+
+const agentAuthoredShape = {
+  session_id: UlidString,
+  turn_index: z.number().int().nonnegative(),
+  parent_loop: ParentLoop,
+  phase_or_purpose: z.string().min(1),
+  slice_id: UlidString.nullable().default(null),
+  slice_kind: SliceKind.nullable().default(null),
+  tdd_phase: TddPhase.nullable().default(null),
+  agent_profile_id: AgentProfileId,
+  agent_role_in_session: AgentRoleInSession,
+  contribution_kind: ContributionKind,
+  parent_review_verdict_id: UlidString.nullable().default(null),
+  output_kind: OutputKind,
+  object_id: z.string().min(1),
+  manifest_id: UlidString,
+  input_revision_pins: z.array(z.string().min(1)),
+  summary: z.string().min(1),
+  artifacts: z.record(z.string(), z.unknown()).nullable().default(null),
+  verdict: Verdict.nullable().default(null),
+  next_action_request: NextActionRequest.nullable().default(null),
+  failure: FailureBlock.nullable().default(null),
+};
+
+export const AgentAuthoredEnvelope = z.object(agentAuthoredShape).strict();
+export type AgentAuthoredEnvelope = z.infer<typeof AgentAuthoredEnvelope>;
+
+export const Envelope = z
+  .object({
+    ...agentAuthoredShape,
+    idempotency_key: z.string().min(1),
+    runtime_metadata: z
+      .record(z.string(), z.unknown())
+      .default(() => ({})),
+  })
+  .strict();
+export type Envelope = z.infer<typeof Envelope>;

--- a/src/domain/schema/ledger.ts
+++ b/src/domain/schema/ledger.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { UlidString } from "../ids.js";
+import { ParentLoop } from "./contribution.js";
 import { LeaseKind } from "./lease.js";
 import { SliceKind } from "./slice.js";
 
@@ -15,7 +16,12 @@ export const LedgerObjectKind = z.enum([
 ]);
 export type LedgerObjectKind = z.infer<typeof LedgerObjectKind>;
 
-export const LedgerLoopKind = z.enum(["outer", "middle", "inner"]);
+/**
+ * The ledger row's `loop_kind` field uses the same {outer, middle, inner}
+ * enum as `AGC-OUTPUT.parent_loop`. Re-exported as `LedgerLoopKind` to
+ * preserve the existing import surface.
+ */
+export const LedgerLoopKind = ParentLoop;
 export type LedgerLoopKind = z.infer<typeof LedgerLoopKind>;
 
 export const LedgerOuterPhase = z.enum([

--- a/src/domain/schema/manifest.ts
+++ b/src/domain/schema/manifest.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { UlidString } from "../ids.js";
+
+/**
+ * AGC-CONTEXT-MANIFEST schema.
+ *
+ * Caller-issued ids (manifest_id, session_id) are ULID. `target.object_id`
+ * is also Caller-issued so it must be ULID. Per-entry `object_id` is loose
+ * (`z.string().min(1)`) because entries may reference external artefacts
+ * (e.g. `code_tree` whose id is a branch path, or external mirror payloads).
+ */
+
+export const FetchScope = z.enum([
+  "metadata",
+  "body",
+  "tree",
+  "body+comments",
+  "body+turn_log",
+]);
+export type FetchScope = z.infer<typeof FetchScope>;
+
+export const ManifestEntryObjectKind = z.enum([
+  "milestone",
+  "slice",
+  "slice_merge",
+  "dialogue_session",
+  "session_turn",
+  "verification_run",
+  "metric_run",
+  "refactor_proposal",
+  "spec_doc",
+  "code_tree",
+  "context_summary",
+  "decision",
+]);
+export type ManifestEntryObjectKind = z.infer<typeof ManifestEntryObjectKind>;
+
+export const ManifestEntry = z
+  .object({
+    object_kind: ManifestEntryObjectKind,
+    object_id: z.string().min(1),
+    fetch_scope: FetchScope,
+    revision_pin: z.string().min(1),
+    required: z.boolean(),
+    purpose: z.string().min(1),
+  })
+  .strict();
+export type ManifestEntry = z.infer<typeof ManifestEntry>;
+
+export const ManifestPurpose = z.enum([
+  "design",
+  "build",
+  "review",
+  "tdd_build",
+  "planning_decompose",
+  "validation",
+]);
+export type ManifestPurpose = z.infer<typeof ManifestPurpose>;
+
+export const ManifestTargetKind = z.enum([
+  "milestone",
+  "slice",
+  "slice_merge",
+]);
+export type ManifestTargetKind = z.infer<typeof ManifestTargetKind>;
+
+export const ManifestTarget = z
+  .object({
+    object_kind: ManifestTargetKind,
+    object_id: UlidString,
+  })
+  .strict();
+export type ManifestTarget = z.infer<typeof ManifestTarget>;
+
+export const ContextManifest = z
+  .object({
+    manifest_id: UlidString,
+    session_id: UlidString,
+    turn_index: z.number().int().nonnegative(),
+    purpose: ManifestPurpose,
+    target: ManifestTarget,
+    entries: z.array(ManifestEntry).default(() => []),
+    created_at: z.string().datetime(),
+  })
+  .strict();
+export type ContextManifest = z.infer<typeof ContextManifest>;

--- a/src/domain/schema/session-turn.ts
+++ b/src/domain/schema/session-turn.ts
@@ -1,15 +1,31 @@
 import { z } from "zod";
 import { UlidString } from "../ids.js";
 import { AgentProfileId } from "./contribution.js";
-import { Envelope } from "./envelope.js";
+import { Envelope, NextActionRequest } from "./envelope.js";
 
 /**
  * SessionTurn schema (SOC-SESSION-LIFECYCLE).
  *
- * `caller_routing_decision` is required when `next_action_request` is present
- * in the envelope (AGC-NEXT-ACTION-REQUEST decision_reason invariant); the
- * matrix validator in application/envelope-extended-validator enforces the
- * decision-reason invariant — the schema only models the field shape.
+ * Layout choices vs the contract pseudocode:
+ *
+ * - `output_envelope` is embedded inline (full canonical envelope), not a
+ *   separate ref. `docs/architecture/persistence-layout.md` §1 places
+ *   the envelope in `sessions/<id>/turns/<n>.json` alongside the SessionTurn
+ *   record, so the contract's `output_envelope_ref` slot is satisfied by
+ *   embedding rather than introducing a separate `envelopes/` directory.
+ *   `(session_id, turn_index)` is globally unique so the envelope does not
+ *   need its own id.
+ *
+ * - `next_action_request` is mirrored at the SessionTurn top level (in
+ *   addition to its position inside the envelope) so phase-3
+ *   dialogue-coordinator can route without traversing the envelope. It
+ *   must agree with `output_envelope.next_action_request` — phase-2
+ *   persistence will assert equality on write.
+ *
+ * - `caller_routing_decision` is required when `next_action_request` is
+ *   present (AGC-NEXT-ACTION-REQUEST decision_reason invariant); the
+ *   matrix validator in application/envelope-extended-validator enforces
+ *   the decision-reason invariant — the schema only models field shapes.
  */
 
 export const RoutingDecision = z.enum([
@@ -37,6 +53,7 @@ export const SessionTurn = z
     input_manifest_id: UlidString,
     input_turn_log_snapshot_ref: UlidString.nullable().default(null),
     output_envelope: Envelope,
+    next_action_request: NextActionRequest.nullable().default(null),
     caller_routing_decision: CallerRoutingDecision.nullable().default(null),
     workspace_commit: z.string().min(1).nullable().default(null),
     verification_result_ref: UlidString.nullable().default(null),

--- a/src/domain/schema/session-turn.ts
+++ b/src/domain/schema/session-turn.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { UlidString } from "../ids.js";
+import { AgentProfileId } from "./contribution.js";
+import { Envelope } from "./envelope.js";
+
+/**
+ * SessionTurn schema (SOC-SESSION-LIFECYCLE).
+ *
+ * `caller_routing_decision` is required when `next_action_request` is present
+ * in the envelope (AGC-NEXT-ACTION-REQUEST decision_reason invariant); the
+ * matrix validator in application/envelope-extended-validator enforces the
+ * decision-reason invariant — the schema only models the field shape.
+ */
+
+export const RoutingDecision = z.enum([
+  "accepted",
+  "overridden",
+  "delayed",
+  "dropped",
+]);
+export type RoutingDecision = z.infer<typeof RoutingDecision>;
+
+export const CallerRoutingDecision = z
+  .object({
+    decision: RoutingDecision,
+    decision_reason: z.string().min(1),
+    resolved_addressed_to: z.string().min(1).nullable().default(null),
+  })
+  .strict();
+export type CallerRoutingDecision = z.infer<typeof CallerRoutingDecision>;
+
+export const SessionTurn = z
+  .object({
+    session_id: UlidString,
+    turn_index: z.number().int().nonnegative(),
+    agent_profile_id: AgentProfileId,
+    input_manifest_id: UlidString,
+    input_turn_log_snapshot_ref: UlidString.nullable().default(null),
+    output_envelope: Envelope,
+    caller_routing_decision: CallerRoutingDecision.nullable().default(null),
+    workspace_commit: z.string().min(1).nullable().default(null),
+    verification_result_ref: UlidString.nullable().default(null),
+    recorded_at: z.string().datetime(),
+  })
+  .strict();
+export type SessionTurn = z.infer<typeof SessionTurn>;

--- a/src/domain/schema/verification.ts
+++ b/src/domain/schema/verification.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { UlidString } from "../ids.js";
+
+/**
+ * RGC-VERIFICATION schemas.
+ *
+ * VerificationRun is the deterministic-evidence record (build/test/lint/type
+ * check / interface diff). MetricRun is the metric-threshold record
+ * (refactor metrics). Both are evidence inputs to SOC-SESSION-TERMINATION's
+ * `required_evidence` evaluation.
+ */
+
+export const VerificationResult = z.enum(["pass", "fail", "error"]);
+export type VerificationResult = z.infer<typeof VerificationResult>;
+
+export const FailedTest = z
+  .object({
+    path: z.string().min(1),
+    name: z.string().min(1),
+    message: z.string().min(1).nullable().default(null),
+  })
+  .strict();
+export type FailedTest = z.infer<typeof FailedTest>;
+
+export const VerificationRun = z
+  .object({
+    verification_run_id: UlidString,
+    target_id: z.string().min(1),
+    target_revision: z.string().min(1),
+    commands_or_checks: z.array(z.string().min(1)).default(() => []),
+    environment_fingerprint: z.string().min(1),
+    started_at: z.string().datetime(),
+    finished_at: z.string().datetime(),
+    result: VerificationResult,
+    failed_tests: z.array(FailedTest).default(() => []),
+    log_ref: z.string().min(1).nullable().default(null),
+  })
+  .strict();
+export type VerificationRun = z.infer<typeof VerificationRun>;
+
+export const MetricResult = z.enum(["met", "unmet"]);
+export type MetricResult = z.infer<typeof MetricResult>;
+
+export const MetricComparator = z.enum(["lte", "lt", "gte", "gt", "eq"]);
+export type MetricComparator = z.infer<typeof MetricComparator>;
+
+export const MetricRun = z
+  .object({
+    metric_run_id: UlidString,
+    target_id: z.string().min(1),
+    metric_name: z.string().min(1),
+    target_revision: z.string().min(1),
+    value: z.number(),
+    comparator: MetricComparator,
+    threshold: z.number(),
+    result: MetricResult,
+    started_at: z.string().datetime(),
+    finished_at: z.string().datetime(),
+  })
+  .strict();
+export type MetricRun = z.infer<typeof MetricRun>;

--- a/tests/application/envelope.test.ts
+++ b/tests/application/envelope.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGC_INVALID_REASONS,
+  AgcInvalidError,
+  enrichEnvelope,
+  parseAgentAuthored,
+  validateEnvelope,
+} from "../../src/application/envelope.js";
+
+const SESSION_ID = "01HZSE0000000000000000000A";
+const MANIFEST_ID = "01HZMA0000000000000000000A";
+const SLICE_ID = "01HZS00000000000000000000A";
+const M_ID = "01HZM00000000000000000000A";
+
+function innerTdd(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    session_id: SESSION_ID,
+    turn_index: 0,
+    parent_loop: "inner",
+    phase_or_purpose: "tdd_build",
+    slice_id: SLICE_ID,
+    slice_kind: "internal",
+    tdd_phase: "red_green",
+    agent_profile_id: "forge",
+    agent_role_in_session: "lead",
+    contribution_kind: "lead_draft",
+    output_kind: "patch",
+    object_id: SLICE_ID,
+    manifest_id: MANIFEST_ID,
+    input_revision_pins: ["abc1234"],
+    summary: "ok",
+    ...overrides,
+  };
+}
+
+function pipeline(raw: Record<string, unknown>) {
+  const parsed = parseAgentAuthored(raw);
+  if (!parsed.ok) return parsed;
+  const enriched = enrichEnvelope(parsed.value, {
+    idempotency_key: "k1",
+    runtime_metadata: {},
+  });
+  if (!enriched.ok) return enriched;
+  return validateEnvelope(enriched.value);
+}
+
+describe("parseAgentAuthored", () => {
+  it("accepts a valid inner tdd_build envelope", () => {
+    expect(parseAgentAuthored(innerTdd()).ok).toBe(true);
+  });
+
+  it("rejects non-object payloads", () => {
+    expect(parseAgentAuthored(null)).toMatchObject({ ok: false, reason: "schema_violation" });
+    expect(parseAgentAuthored([1, 2, 3])).toMatchObject({ ok: false, reason: "schema_violation" });
+    expect(parseAgentAuthored("string")).toMatchObject({ ok: false, reason: "schema_violation" });
+  });
+
+  it("rejects agent-authored idempotency_key", () => {
+    expect(parseAgentAuthored(innerTdd({ idempotency_key: "x" }))).toMatchObject({
+      ok: false,
+      reason: "agent_authored_idempotency_key",
+    });
+  });
+
+  it("rejects agent-authored runtime_metadata", () => {
+    expect(parseAgentAuthored(innerTdd({ runtime_metadata: {} }))).toMatchObject({
+      ok: false,
+      reason: "agent_authored_runtime_metadata",
+    });
+  });
+
+  it("rejects legacy agent_role / operation / phase_run_id", () => {
+    expect(parseAgentAuthored(innerTdd({ agent_role: "coder" }))).toMatchObject({
+      ok: false,
+      reason: "legacy_field_present",
+    });
+    expect(parseAgentAuthored(innerTdd({ operation: "merge" }))).toMatchObject({
+      ok: false,
+      reason: "legacy_field_present",
+    });
+    expect(parseAgentAuthored(innerTdd({ phase_run_id: "x" }))).toMatchObject({
+      ok: false,
+      reason: "legacy_field_present",
+    });
+  });
+
+  it("rejects deprecated contribution_kind enum (rework_patch)", () => {
+    expect(
+      parseAgentAuthored(innerTdd({ contribution_kind: "rework_patch" })),
+    ).toMatchObject({ ok: false, reason: "schema_violation" });
+  });
+});
+
+describe("enrichEnvelope", () => {
+  it("returns canonical envelope with idempotency_key + runtime_metadata", () => {
+    const a = parseAgentAuthored(innerTdd());
+    if (!a.ok) throw new Error("agent parse failed");
+    const r = enrichEnvelope(a.value, {
+      idempotency_key: "k1",
+      runtime_metadata: { workspace_commit: "deadbeef" },
+    });
+    if (!r.ok) throw new Error("enrich failed");
+    expect(r.value.idempotency_key).toBe("k1");
+    expect(r.value.runtime_metadata).toEqual({ workspace_commit: "deadbeef" });
+  });
+
+  it("rejects runtime_metadata key colliding with envelope field", () => {
+    const a = parseAgentAuthored(innerTdd());
+    if (!a.ok) throw new Error("agent parse failed");
+    const r = enrichEnvelope(a.value, {
+      idempotency_key: "k1",
+      runtime_metadata: { summary: "shadow" },
+    });
+    expect(r).toMatchObject({ ok: false, reason: "enrich_key_collision" });
+  });
+
+  it("rejects collision with envelope-level idempotency_key key in metadata", () => {
+    const a = parseAgentAuthored(innerTdd());
+    if (!a.ok) throw new Error("agent parse failed");
+    const r = enrichEnvelope(a.value, {
+      idempotency_key: "k1",
+      runtime_metadata: { idempotency_key: "x" },
+    });
+    expect(r).toMatchObject({ ok: false, reason: "enrich_key_collision" });
+  });
+});
+
+describe("validateEnvelope (AGC-CONTRIBUTION-OUTPUTS matrix)", () => {
+  it("accepts inner tdd_build lead_draft → patch", () => {
+    expect(pipeline(innerTdd()).ok).toBe(true);
+  });
+
+  it("accepts middle review review_verdict → verdict (approve)", () => {
+    const r = pipeline({
+      session_id: SESSION_ID,
+      turn_index: 1,
+      parent_loop: "middle",
+      phase_or_purpose: "review",
+      slice_id: SLICE_ID,
+      slice_kind: "internal",
+      agent_profile_id: "sentinel",
+      agent_role_in_session: "lead",
+      contribution_kind: "review_verdict",
+      output_kind: "verdict",
+      object_id: SLICE_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc1234"],
+      summary: "approved",
+      verdict: { result: "approve", rationale: "lgtm" },
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects inner tdd_build → milestone_package (matrix violation)", () => {
+    const r = pipeline(innerTdd({ output_kind: "milestone_package" }));
+    expect(r).toMatchObject({ ok: false, reason: "matrix_violation" });
+  });
+
+  it("rejects outer Validation lead_draft missing verdict", () => {
+    const r = pipeline({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Validation",
+      agent_profile_id: "sentinel",
+      agent_role_in_session: "lead",
+      contribution_kind: "lead_draft",
+      output_kind: "milestone_package",
+      object_id: M_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc"],
+      summary: "ok",
+    });
+    expect(r).toMatchObject({ ok: false, reason: "matrix_violation" });
+  });
+
+  it("accepts outer Validation lead_draft with verdict.result=PASS", () => {
+    const r = pipeline({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Validation",
+      agent_profile_id: "sentinel",
+      agent_role_in_session: "lead",
+      contribution_kind: "lead_draft",
+      output_kind: "milestone_package",
+      object_id: M_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc"],
+      summary: "ok",
+      verdict: { result: "PASS", rationale: "ac all green" },
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects phase_or_purpose=tdd_build under parent_loop=outer", () => {
+    const r = pipeline({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "tdd_build",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      contribution_kind: "lead_draft",
+      output_kind: "spec_proposal",
+      object_id: M_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc"],
+      summary: "ok",
+    });
+    expect(r).toMatchObject({ ok: false, reason: "phase_or_purpose_outside_loop" });
+  });
+
+  it("requires slice_id when parent_loop=middle|inner", () => {
+    const r = pipeline(innerTdd({ slice_id: null }));
+    expect(r).toMatchObject({ ok: false, reason: "missing_required_envelope_field" });
+  });
+
+  it("requires tdd_phase when parent_loop=inner", () => {
+    const r = pipeline(innerTdd({ tdd_phase: null }));
+    expect(r).toMatchObject({ ok: false, reason: "missing_required_envelope_field" });
+  });
+
+  it("output_kind=failure requires the failure block", () => {
+    expect(pipeline(innerTdd({ output_kind: "failure" }))).toMatchObject({
+      ok: false,
+      reason: "missing_required_envelope_field",
+    });
+    expect(
+      pipeline(
+        innerTdd({
+          output_kind: "failure",
+          failure: { type: "need_context", rationale: "manifest entry missing" },
+        }),
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("accepts proposal contribution under any loop", () => {
+    const r = pipeline(
+      innerTdd({
+        contribution_kind: "proposal",
+        output_kind: "proposal_artifact",
+        agent_profile_id: "scout",
+      }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects review_verdict with verdict.result outside enum", () => {
+    const r = pipeline({
+      session_id: SESSION_ID,
+      turn_index: 1,
+      parent_loop: "middle",
+      phase_or_purpose: "review",
+      slice_id: SLICE_ID,
+      slice_kind: "internal",
+      agent_profile_id: "sentinel",
+      agent_role_in_session: "lead",
+      contribution_kind: "review_verdict",
+      output_kind: "verdict",
+      object_id: SLICE_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc1234"],
+      summary: "x",
+      verdict: { result: "tests_green", rationale: "wrong context" },
+    });
+    expect(r).toMatchObject({ ok: false, reason: "matrix_violation" });
+  });
+});
+
+describe("AgcInvalidError + AGC_INVALID_REASONS", () => {
+  it("error wraps reason + detail", () => {
+    const err = new AgcInvalidError("schema_violation", "x");
+    expect(err.reason).toBe("schema_violation");
+    expect(err.message).toContain("AGC-INVALID:schema_violation");
+  });
+
+  it("AGC_INVALID_REASONS contains all reasons surfaced by parser/enricher/matrix", () => {
+    for (const r of [
+      "schema_violation",
+      "matrix_violation",
+      "missing_required_envelope_field",
+      "phase_or_purpose_outside_loop",
+      "agent_authored_idempotency_key",
+      "agent_authored_runtime_metadata",
+      "enrich_key_collision",
+      "legacy_field_present",
+    ] as const) {
+      expect(AGC_INVALID_REASONS).toContain(r);
+    }
+  });
+});

--- a/tests/application/envelope.test.ts
+++ b/tests/application/envelope.test.ts
@@ -6,11 +6,28 @@ import {
   parseAgentAuthored,
   validateEnvelope,
 } from "../../src/application/envelope.js";
+import type { IdempotencyParts } from "../../src/application/idempotency.js";
 
 const SESSION_ID = "01HZSE0000000000000000000A";
 const MANIFEST_ID = "01HZMA0000000000000000000A";
 const SLICE_ID = "01HZS00000000000000000000A";
 const M_ID = "01HZM00000000000000000000A";
+
+function perTurn(
+  overrides: Partial<IdempotencyParts extends { scope: "per_turn"; parts: infer P } ? P : never> = {},
+): IdempotencyParts {
+  return {
+    scope: "per_turn",
+    parts: {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      agent_profile_id: "forge",
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc1234"],
+      ...overrides,
+    },
+  };
+}
 
 function innerTdd(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -37,7 +54,7 @@ function pipeline(raw: Record<string, unknown>) {
   const parsed = parseAgentAuthored(raw);
   if (!parsed.ok) return parsed;
   const enriched = enrichEnvelope(parsed.value, {
-    idempotency_key: "k1",
+    idempotency: perTurn(),
     runtime_metadata: {},
   });
   if (!enriched.ok) return enriched;
@@ -89,26 +106,49 @@ describe("parseAgentAuthored", () => {
       parseAgentAuthored(innerTdd({ contribution_kind: "rework_patch" })),
     ).toMatchObject({ ok: false, reason: "schema_violation" });
   });
+
+  it("rejects contribution_kind=session_outcome (Caller-only per AGC-CONTRIBUTION)", () => {
+    expect(
+      parseAgentAuthored(
+        innerTdd({
+          contribution_kind: "session_outcome",
+          output_kind: "verdict",
+          verdict: { result: "tests_green", rationale: "passed" },
+        }),
+      ),
+    ).toMatchObject({ ok: false, reason: "agent_authored_session_outcome" });
+  });
 });
 
 describe("enrichEnvelope", () => {
-  it("returns canonical envelope with idempotency_key + runtime_metadata", () => {
+  it("composes idempotency_key from SOC-IDEMPOTENCY parts and injects runtime_metadata", () => {
     const a = parseAgentAuthored(innerTdd());
     if (!a.ok) throw new Error("agent parse failed");
     const r = enrichEnvelope(a.value, {
-      idempotency_key: "k1",
+      idempotency: perTurn(),
       runtime_metadata: { workspace_commit: "deadbeef" },
     });
     if (!r.ok) throw new Error("enrich failed");
-    expect(r.value.idempotency_key).toBe("k1");
+    expect(r.value.idempotency_key).toBe(
+      `per_turn|${SESSION_ID}|0|forge|${MANIFEST_ID}|abc1234`,
+    );
     expect(r.value.runtime_metadata).toEqual({ workspace_commit: "deadbeef" });
+  });
+
+  it("is deterministic — identical parts produce identical keys", () => {
+    const a = parseAgentAuthored(innerTdd());
+    if (!a.ok) throw new Error();
+    const r1 = enrichEnvelope(a.value, { idempotency: perTurn(), runtime_metadata: {} });
+    const r2 = enrichEnvelope(a.value, { idempotency: perTurn(), runtime_metadata: {} });
+    if (!r1.ok || !r2.ok) throw new Error();
+    expect(r1.value.idempotency_key).toBe(r2.value.idempotency_key);
   });
 
   it("rejects runtime_metadata key colliding with envelope field", () => {
     const a = parseAgentAuthored(innerTdd());
     if (!a.ok) throw new Error("agent parse failed");
     const r = enrichEnvelope(a.value, {
-      idempotency_key: "k1",
+      idempotency: perTurn(),
       runtime_metadata: { summary: "shadow" },
     });
     expect(r).toMatchObject({ ok: false, reason: "enrich_key_collision" });
@@ -118,7 +158,7 @@ describe("enrichEnvelope", () => {
     const a = parseAgentAuthored(innerTdd());
     if (!a.ok) throw new Error("agent parse failed");
     const r = enrichEnvelope(a.value, {
-      idempotency_key: "k1",
+      idempotency: perTurn(),
       runtime_metadata: { idempotency_key: "x" },
     });
     expect(r).toMatchObject({ ok: false, reason: "enrich_key_collision" });
@@ -236,6 +276,30 @@ describe("validateEnvelope (AGC-CONTRIBUTION-OUTPUTS matrix)", () => {
     ).toBe(true);
   });
 
+  it("output_kind=failure still requires loop-conditional fields (slice_id/slice_kind/tdd_phase)", () => {
+    // slice_id absent on inner failure must STILL be rejected — failure
+    // does not waive the AGC-OUTPUT loop-conditional invariants.
+    expect(
+      pipeline(
+        innerTdd({
+          slice_id: null,
+          output_kind: "failure",
+          failure: { type: "invalid_output", rationale: "x" },
+        }),
+      ),
+    ).toMatchObject({ ok: false, reason: "missing_required_envelope_field" });
+
+    expect(
+      pipeline(
+        innerTdd({
+          tdd_phase: null,
+          output_kind: "failure",
+          failure: { type: "invalid_output", rationale: "x" },
+        }),
+      ),
+    ).toMatchObject({ ok: false, reason: "missing_required_envelope_field" });
+  });
+
   it("accepts proposal contribution under any loop", () => {
     const r = pipeline(
       innerTdd({
@@ -284,6 +348,7 @@ describe("AgcInvalidError + AGC_INVALID_REASONS", () => {
       "phase_or_purpose_outside_loop",
       "agent_authored_idempotency_key",
       "agent_authored_runtime_metadata",
+      "agent_authored_session_outcome",
       "enrich_key_collision",
       "legacy_field_present",
     ] as const) {

--- a/tests/application/manifest-builder.test.ts
+++ b/tests/application/manifest-builder.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  ManifestBuilder,
+  type ManifestEntryDraft,
+  type RevisionPinResolver,
+} from "../../src/application/manifest-builder.js";
+import { isUlid } from "../../src/domain/ids.js";
+import { FixedClock } from "../../src/ports/clock.js";
+
+const SESSION_ID = "01HZSE0000000000000000000A";
+const SLICE_ID = "01HZS00000000000000000000A";
+
+class StaticResolver implements RevisionPinResolver {
+  constructor(private readonly pins: Map<string, string>) {}
+
+  async resolve(d: ManifestEntryDraft): Promise<string> {
+    const k = key(d);
+    const p = this.pins.get(k);
+    if (p == null) throw new Error(`no pin for ${k}`);
+    return p;
+  }
+
+  set(d: ManifestEntryDraft, pin: string): void {
+    this.pins.set(key(d), pin);
+  }
+}
+
+function key(d: ManifestEntryDraft): string {
+  return `${d.object_kind}:${d.object_id}`;
+}
+
+describe("ManifestBuilder.build", () => {
+  it("resolves revision pins for each draft and emits a ULID manifest_id", async () => {
+    const drafts: ManifestEntryDraft[] = [
+      {
+        object_kind: "slice",
+        object_id: SLICE_ID,
+        fetch_scope: "body+turn_log",
+        required: true,
+        purpose: "primary",
+      },
+      {
+        object_kind: "code_tree",
+        object_id: "feat/abc",
+        fetch_scope: "tree",
+        required: false,
+        purpose: "self-fetch",
+      },
+    ];
+    const resolver = new StaticResolver(
+      new Map([
+        [key(drafts[0]!), "pin-slice-1"],
+        [key(drafts[1]!), "pin-tree-1"],
+      ]),
+    );
+    const clock = new FixedClock(1_700_000_000_000);
+    const b = new ManifestBuilder(resolver, clock);
+    const m = await b.build({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      purpose: "tdd_build",
+      target: { object_kind: "slice", object_id: SLICE_ID },
+      drafts,
+    });
+    expect(isUlid(m.manifest_id)).toBe(true);
+    expect(m.entries.length).toBe(2);
+    expect(m.entries[0]?.revision_pin).toBe("pin-slice-1");
+    expect(m.entries[1]?.revision_pin).toBe("pin-tree-1");
+    expect(m.created_at).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  it("preserves draft order in entries", async () => {
+    const drafts: ManifestEntryDraft[] = [
+      { object_kind: "slice", object_id: SLICE_ID, fetch_scope: "body", required: true, purpose: "p1" },
+      { object_kind: "decision", object_id: "01HZD00000000000000000000A", fetch_scope: "body", required: false, purpose: "p2" },
+    ];
+    const resolver = new StaticResolver(
+      new Map([
+        [key(drafts[0]!), "a"],
+        [key(drafts[1]!), "b"],
+      ]),
+    );
+    const b = new ManifestBuilder(resolver, new FixedClock(0));
+    const m = await b.build({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      purpose: "tdd_build",
+      target: { object_kind: "slice", object_id: SLICE_ID },
+      drafts,
+    });
+    expect(m.entries.map((e) => e.object_kind)).toEqual(["slice", "decision"]);
+  });
+});
+
+describe("ManifestBuilder.recheckPins", () => {
+  it("returns the entries whose pin has drifted", async () => {
+    const drafts: ManifestEntryDraft[] = [
+      { object_kind: "slice", object_id: SLICE_ID, fetch_scope: "body", required: true, purpose: "p" },
+      { object_kind: "code_tree", object_id: "feat/abc", fetch_scope: "tree", required: false, purpose: "p" },
+    ];
+    const resolver = new StaticResolver(
+      new Map([
+        [key(drafts[0]!), "v1"],
+        [key(drafts[1]!), "v1"],
+      ]),
+    );
+    const b = new ManifestBuilder(resolver, new FixedClock(0));
+    const m = await b.build({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      purpose: "tdd_build",
+      target: { object_kind: "slice", object_id: SLICE_ID },
+      drafts,
+    });
+    expect((await b.recheckPins(m)).length).toBe(0);
+
+    resolver.set(drafts[1]!, "v2");
+    const stale = await b.recheckPins(m);
+    expect(stale.length).toBe(1);
+    expect(stale[0]?.object_kind).toBe("code_tree");
+  });
+});

--- a/tests/conformance/phase-1b.test.ts
+++ b/tests/conformance/phase-1b.test.ts
@@ -12,9 +12,23 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { ContributionKind, OutputKind } from "../../src/domain/schema/contribution.js";
-import { SessionState } from "../../src/domain/schema/dialogue-session.js";
-import { FetchScope } from "../../src/domain/schema/manifest.js";
+import {
+  ContributionKind,
+  OutputKind,
+  ParentLoop,
+  FinalVerdict,
+} from "../../src/domain/schema/contribution.js";
+import {
+  CompositeRule,
+  FinalizationRule,
+  SessionState,
+} from "../../src/domain/schema/dialogue-session.js";
+import { FetchScope, ManifestPurpose } from "../../src/domain/schema/manifest.js";
+import { RoutingDecision } from "../../src/domain/schema/session-turn.js";
+import {
+  FailureType,
+} from "../../src/domain/schema/envelope.js";
+import { MetricComparator } from "../../src/domain/schema/verification.js";
 
 const REPO_ROOT = resolve(__dirname, "../..");
 const README = resolve(REPO_ROOT, "docs/contracts/README.md");
@@ -116,6 +130,24 @@ function findEnvelopeRow(section: string, field: string): string {
   return m[0];
 }
 
+/**
+ * Bidirectional drift gate: schema ↔ contract enum sets must match exactly.
+ * Every contract-listed literal must appear in the schema, AND every schema
+ * literal must appear in the contract — silent additions on either side
+ * fail the gate.
+ */
+function assertBidirectionalEnum(
+  schemaOptions: readonly string[],
+  contractLiterals: readonly string[],
+  label: string,
+): void {
+  const schemaSet = new Set(schemaOptions);
+  const contractSet = new Set(contractLiterals);
+  expect(schemaSet, `${label}: schema has unexpected literal`).toEqual(
+    contractSet,
+  );
+}
+
 describe("Phase 1b — AGC-OUTPUT envelope enum sync (schema ↔ contract)", () => {
   const contract = readFileSync(AGENT_CONTRACT, "utf8");
   const section = agcOutputSection(contract);
@@ -125,17 +157,7 @@ describe("Phase 1b — AGC-OUTPUT envelope enum sync (schema ↔ contract)", () 
     const fields = extractEnumFromRow(row).filter(
       (v) => !v.startsWith("#") && !v.startsWith("docs/"),
     );
-    const expected = [
-      "lead_draft",
-      "review_verdict",
-      "human_approval",
-      "session_outcome",
-      "proposal",
-    ];
-    for (const v of expected) {
-      expect(fields, `contribution_kind missing literal ${v}`).toContain(v);
-    }
-    expect(new Set(ContributionKind.options)).toEqual(new Set(expected));
+    assertBidirectionalEnum(ContributionKind.options, fields, "contribution_kind");
   });
 
   it("output_kind enum matches contract", () => {
@@ -143,58 +165,149 @@ describe("Phase 1b — AGC-OUTPUT envelope enum sync (schema ↔ contract)", () 
     const fields = extractEnumFromRow(row).filter(
       (v) => !v.startsWith("#") && !v.startsWith("docs/"),
     );
-    const expected = [
-      "spec_proposal",
-      "task_plan",
-      "slice_decomposition",
-      "patch",
-      "verdict",
-      "milestone_package",
-      "proposal_artifact",
-      "failure",
-    ];
-    for (const v of expected) {
-      expect(fields, `output_kind missing literal ${v}`).toContain(v);
-    }
-    expect(new Set(OutputKind.options)).toEqual(new Set(expected));
+    assertBidirectionalEnum(OutputKind.options, fields, "output_kind");
+  });
+
+  it("parent_loop enum matches contract", () => {
+    const row = findEnvelopeRow(section, "parent_loop");
+    const fields = extractEnumFromRow(row);
+    assertBidirectionalEnum(ParentLoop.options, fields, "parent_loop");
   });
 });
 
 describe("Phase 1b — AGC-CONTEXT-MANIFEST fetch_scope enum sync", () => {
   it("FetchScope schema enum matches the contract enum table", () => {
     const contract = readFileSync(AGENT_CONTRACT, "utf8");
-    // Contract Fetch Scope table rows:
-    //   | `metadata` | ... | `body` | ... | `tree` | ... | `body+comments` | ... | `body+turn_log` | ...
     const expected = ["metadata", "body", "tree", "body+comments", "body+turn_log"];
     for (const v of expected) {
-      // Each value appears wrapped in backticks in the table
       expect(contract).toContain(`\`${v}\``);
     }
-    expect(new Set(FetchScope.options)).toEqual(new Set(expected));
+    assertBidirectionalEnum(FetchScope.options, expected, "fetch_scope");
+  });
+
+  it("ManifestPurpose schema matches AGC-SESSION-INPUT purpose enum", () => {
+    const contract = readFileSync(AGENT_CONTRACT, "utf8");
+    const expected = [
+      "design",
+      "build",
+      "review",
+      "tdd_build",
+      "planning_decompose",
+      "validation",
+    ];
+    for (const v of expected) expect(contract).toContain(v);
+    assertBidirectionalEnum(ManifestPurpose.options, expected, "manifest purpose");
   });
 });
 
-describe("Phase 1b — SOC-SESSION-LIFECYCLE state enum sync", () => {
-  it("SessionState schema matches the 5-state contract enumeration", () => {
-    const soc = readFileSync(SOC_CONTRACT, "utf8");
-    for (const s of [
+describe("Phase 1b — SOC-SESSION-LIFECYCLE / TERMINATION enum sync", () => {
+  const soc = readFileSync(SOC_CONTRACT, "utf8");
+
+  it("SessionState matches the 5-state contract enumeration", () => {
+    const expected = [
       "SESSION_OPEN",
       "CONVERGED",
       "TIMEOUT",
       "ABANDONED",
       "AWAITING_REVALIDATION",
-    ]) {
-      expect(soc).toContain(s);
+    ];
+    for (const s of expected) expect(soc).toContain(s);
+    assertBidirectionalEnum(SessionState.options, expected, "SessionState");
+  });
+
+  it("FinalizationRule matches SOC-SESSION-TERMINATION", () => {
+    const expected = [
+      "lead_only",
+      "unanimous_approve",
+      "quorum_then_lead",
+      "any_request_changes_blocks",
+      "timeout_only",
+    ];
+    for (const v of expected) expect(soc).toContain(v);
+    assertBidirectionalEnum(FinalizationRule.options, expected, "FinalizationRule");
+  });
+
+  it("CompositeRule matches SOC-SESSION-TERMINATION", () => {
+    const expected = [
+      "finalization_AND_evidence",
+      "evidence_only",
+      "finalization_only",
+    ];
+    for (const v of expected) expect(soc).toContain(v);
+    assertBidirectionalEnum(CompositeRule.options, expected, "CompositeRule");
+  });
+
+  it("FinalVerdict matches SOC-SESSION-TERMINATION final_verdict table", () => {
+    const expected = [
+      "approve",
+      "request_changes",
+      "tests_green",
+      "spec_accept",
+      "spec_reject",
+      "plan_accept",
+      "validation_pass",
+      "validation_fail",
+      "validation_stale",
+      "no_progress",
+      "regression",
+      "scope_violation",
+    ];
+    for (const v of expected) expect(soc).toContain(`\`${v}\``);
+    assertBidirectionalEnum(FinalVerdict.options, expected, "FinalVerdict");
+  });
+});
+
+describe("Phase 1b — RoutingDecision / FailureType / MetricComparator enum sync", () => {
+  it("RoutingDecision matches AGC-NEXT-ACTION-REQUEST", () => {
+    const contract = readFileSync(AGENT_CONTRACT, "utf8");
+    const expected = ["accepted", "overridden", "delayed", "dropped"];
+    for (const v of expected) expect(contract).toContain(`\`${v}\``);
+    assertBidirectionalEnum(RoutingDecision.options, expected, "RoutingDecision");
+  });
+
+  it("FailureType matches AGC-LLM-NEUTRALITY / AGC-INVALID failure.type usages", () => {
+    const contract = readFileSync(AGENT_CONTRACT, "utf8");
+    // need_context / invalid_output explicitly listed in AGC-LLM-NEUTRALITY.
+    // no_progress / regression / scope_violation are abandoned_reason values
+    // mapped through SOC-SESSION-TERMINATION to failure.type for inner ABANDONED.
+    // Contract embeds these as `failure.type=<value>` in backticks.
+    for (const v of ["need_context", "invalid_output"]) {
+      expect(contract).toContain(`failure.type=${v}`);
     }
-    expect(new Set(SessionState.options)).toEqual(
+    expect(new Set(FailureType.options)).toEqual(
       new Set([
-        "SESSION_OPEN",
-        "CONVERGED",
-        "TIMEOUT",
-        "ABANDONED",
-        "AWAITING_REVALIDATION",
+        "need_context",
+        "invalid_output",
+        "no_progress",
+        "regression",
+        "scope_violation",
       ]),
     );
+  });
+
+  it("MetricComparator is the single shared enum across schemas", () => {
+    expect(new Set(MetricComparator.options)).toEqual(
+      new Set(["lte", "lt", "gte", "gt", "eq"]),
+    );
+  });
+});
+
+describe("Phase 1b — AGC-INVALID reason regression gate", () => {
+  it("envelope.ts exports the canonical reason set used by parser/enricher/matrix", async () => {
+    const mod = await import("../../src/application/envelope.js");
+    for (const r of [
+      "schema_violation",
+      "matrix_violation",
+      "missing_required_envelope_field",
+      "phase_or_purpose_outside_loop",
+      "agent_authored_idempotency_key",
+      "agent_authored_runtime_metadata",
+      "agent_authored_session_outcome",
+      "enrich_key_collision",
+      "legacy_field_present",
+    ] as const) {
+      expect(mod.AGC_INVALID_REASONS).toContain(r);
+    }
   });
 });
 

--- a/tests/conformance/phase-1b.test.ts
+++ b/tests/conformance/phase-1b.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Phase 1b contract conformance.
+ *
+ * Asserts that:
+ * 1. The contract README's CONTRACT-CONFORMANCE matrix points at TS surfaces
+ *    that exist for every anchor this phase is responsible for.
+ * 2. The schema enums (AGC-OUTPUT.output_kind, AGC-CONTRIBUTION.contribution_kind,
+ *    AGC-CONTEXT-MANIFEST.fetch_scope, SOC-SESSION-LIFECYCLE.SessionState)
+ *    contain exactly the enum literals enumerated in the contract markdown.
+ *    Drift in either direction is a contract↔code mismatch.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { ContributionKind, OutputKind } from "../../src/domain/schema/contribution.js";
+import { SessionState } from "../../src/domain/schema/dialogue-session.js";
+import { FetchScope } from "../../src/domain/schema/manifest.js";
+
+const REPO_ROOT = resolve(__dirname, "../..");
+const README = resolve(REPO_ROOT, "docs/contracts/README.md");
+const AGENT_CONTRACT = resolve(
+  REPO_ROOT,
+  "docs/contracts/agent-and-context-contract.md",
+);
+const SOC_CONTRACT = resolve(
+  REPO_ROOT,
+  "docs/contracts/state-and-operation-contract.md",
+);
+
+const PHASE_1B_ANCHORS = [
+  "AGC-CONTRIBUTION",
+  "AGC-CONTEXT-MANIFEST",
+  "AGC-OUTPUT",
+  "AGC-OUTPUT-RUNTIME-ENRICH",
+  "AGC-CONTRIBUTION-OUTPUTS",
+  "AGC-INVALID",
+  "SOC-SESSION-LIFECYCLE",
+  "SOC-SESSION-TERMINATION",
+  "RGC-VERIFICATION",
+];
+
+function findRowForAnchor(readme: string, anchor: string): string {
+  const re = new RegExp(`\\|\\s*\`${anchor}\`[^\n]*\\|`);
+  const m = readme.match(re);
+  if (!m) throw new Error(`anchor ${anchor} not found in README matrix`);
+  return m[0];
+}
+
+function extractTsPaths(matrixRow: string): string[] {
+  const paths = new Set<string>();
+  const re = /`(src\/[^`\s]+\.ts)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(matrixRow)) != null) {
+    if (m[1]) paths.add(m[1]);
+  }
+  return [...paths];
+}
+
+describe("Phase 1b — contract conformance matrix", () => {
+  const readme = readFileSync(README, "utf8");
+  for (const anchor of PHASE_1B_ANCHORS) {
+    it(`${anchor} row references at least one src/**/*.ts surface that exists`, () => {
+      const row = findRowForAnchor(readme, anchor);
+      const paths = extractTsPaths(row);
+      expect(
+        paths.length,
+        `${anchor} matrix row should cite at least one TS path`,
+      ).toBeGreaterThan(0);
+      for (const p of paths) {
+        expect(existsSync(resolve(REPO_ROOT, p)), `missing file: ${p}`).toBe(
+          true,
+        );
+      }
+    });
+  }
+});
+
+/**
+ * Extract a slash-separated enum list from a markdown table row whose
+ * third column matches `<value> / <value> / ... 중 하나` style.
+ * Returns the list of values (with surrounding backticks stripped).
+ */
+function extractEnumFromRow(rowText: string): string[] {
+  const cols = rowText.split("|").map((c) => c.trim());
+  // typical table row layout: ['', field, 'yes', body, '']
+  const body = cols[3] ?? "";
+  // values are wrapped in backticks: `lead_draft` / `review_verdict` / ...
+  const out = new Set<string>();
+  const re = /`([^`]+)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) != null) {
+    if (m[1]) out.add(m[1]);
+  }
+  return [...out];
+}
+
+/**
+ * Extract the AGC-OUTPUT section (between its anchor and the next anchor) so
+ * we can locate the canonical envelope-field rows without hitting the
+ * `AGC-CONTRIBUTION` table-header row earlier in the file.
+ */
+function agcOutputSection(contract: string): string {
+  const re = /<a id="AGC-OUTPUT"><\/a>[\s\S]*?(?=<a id="AGC-OUTPUT-RUNTIME-ENRICH">)/;
+  const m = contract.match(re);
+  if (!m) throw new Error("AGC-OUTPUT section not found");
+  return m[0];
+}
+
+function findEnvelopeRow(section: string, field: string): string {
+  // Envelope rows have shape: `| \`<field>\` | (yes|conditional|caller-enriched yes) | <body> |`
+  const re = new RegExp(
+    `\\|\\s*\`${field}\`\\s*\\|\\s*(?:yes|conditional|caller-enriched yes)\\s*\\|[^\\n]+`,
+  );
+  const m = section.match(re);
+  if (!m) throw new Error(`envelope row for ${field} not found in AGC-OUTPUT`);
+  return m[0];
+}
+
+describe("Phase 1b — AGC-OUTPUT envelope enum sync (schema ↔ contract)", () => {
+  const contract = readFileSync(AGENT_CONTRACT, "utf8");
+  const section = agcOutputSection(contract);
+
+  it("contribution_kind enum matches contract", () => {
+    const row = findEnvelopeRow(section, "contribution_kind");
+    const fields = extractEnumFromRow(row).filter(
+      (v) => !v.startsWith("#") && !v.startsWith("docs/"),
+    );
+    const expected = [
+      "lead_draft",
+      "review_verdict",
+      "human_approval",
+      "session_outcome",
+      "proposal",
+    ];
+    for (const v of expected) {
+      expect(fields, `contribution_kind missing literal ${v}`).toContain(v);
+    }
+    expect(new Set(ContributionKind.options)).toEqual(new Set(expected));
+  });
+
+  it("output_kind enum matches contract", () => {
+    const row = findEnvelopeRow(section, "output_kind");
+    const fields = extractEnumFromRow(row).filter(
+      (v) => !v.startsWith("#") && !v.startsWith("docs/"),
+    );
+    const expected = [
+      "spec_proposal",
+      "task_plan",
+      "slice_decomposition",
+      "patch",
+      "verdict",
+      "milestone_package",
+      "proposal_artifact",
+      "failure",
+    ];
+    for (const v of expected) {
+      expect(fields, `output_kind missing literal ${v}`).toContain(v);
+    }
+    expect(new Set(OutputKind.options)).toEqual(new Set(expected));
+  });
+});
+
+describe("Phase 1b — AGC-CONTEXT-MANIFEST fetch_scope enum sync", () => {
+  it("FetchScope schema enum matches the contract enum table", () => {
+    const contract = readFileSync(AGENT_CONTRACT, "utf8");
+    // Contract Fetch Scope table rows:
+    //   | `metadata` | ... | `body` | ... | `tree` | ... | `body+comments` | ... | `body+turn_log` | ...
+    const expected = ["metadata", "body", "tree", "body+comments", "body+turn_log"];
+    for (const v of expected) {
+      // Each value appears wrapped in backticks in the table
+      expect(contract).toContain(`\`${v}\``);
+    }
+    expect(new Set(FetchScope.options)).toEqual(new Set(expected));
+  });
+});
+
+describe("Phase 1b — SOC-SESSION-LIFECYCLE state enum sync", () => {
+  it("SessionState schema matches the 5-state contract enumeration", () => {
+    const soc = readFileSync(SOC_CONTRACT, "utf8");
+    for (const s of [
+      "SESSION_OPEN",
+      "CONVERGED",
+      "TIMEOUT",
+      "ABANDONED",
+      "AWAITING_REVALIDATION",
+    ]) {
+      expect(soc).toContain(s);
+    }
+    expect(new Set(SessionState.options)).toEqual(
+      new Set([
+        "SESSION_OPEN",
+        "CONVERGED",
+        "TIMEOUT",
+        "ABANDONED",
+        "AWAITING_REVALIDATION",
+      ]),
+    );
+  });
+});
+
+describe("Phase 1b — agent envelope module forbids legacy field names", () => {
+  it("src/application/envelope.ts lists agent_role / operation / phase_run_id as legacy", () => {
+    const body = readFileSync(
+      resolve(REPO_ROOT, "src/application/envelope.ts"),
+      "utf8",
+    );
+    expect(body).toContain("agent_role");
+    expect(body).toContain("operation");
+    expect(body).toContain("phase_run_id");
+  });
+});

--- a/tests/domain/schema-1b.test.ts
+++ b/tests/domain/schema-1b.test.ts
@@ -183,6 +183,12 @@ describe("AgentAuthoredEnvelope (AGC-OUTPUT pre-enrichment)", () => {
       AgentAuthoredEnvelope.parse(baseAgent({ session_id: "not-ulid" })),
     ).toThrow();
   });
+
+  it("rejects non-ULID object_id (AGC-OUTPUT primary target must be Caller-issued)", () => {
+    expect(() =>
+      AgentAuthoredEnvelope.parse(baseAgent({ object_id: "not-a-ulid" })),
+    ).toThrow();
+  });
 });
 
 describe("Envelope (AGC-OUTPUT canonical)", () => {
@@ -212,31 +218,35 @@ describe("Envelope (AGC-OUTPUT canonical)", () => {
 });
 
 describe("SessionTurn schema", () => {
+  function baseEnvelope(): Record<string, unknown> {
+    return {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "inner",
+      phase_or_purpose: "tdd_build",
+      slice_id: SLICE_ID,
+      slice_kind: "internal",
+      tdd_phase: "red_green",
+      agent_profile_id: "forge",
+      agent_role_in_session: "lead",
+      contribution_kind: "lead_draft",
+      output_kind: "patch",
+      object_id: SLICE_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc1234"],
+      summary: "first turn",
+      idempotency_key: "per_turn|sid|0|forge|mid|abc1234",
+      runtime_metadata: {},
+    };
+  }
+
   it("round-trips with embedded canonical envelope", () => {
     const turn = SessionTurn.parse({
       session_id: SESSION_ID,
       turn_index: 0,
       agent_profile_id: "forge",
       input_manifest_id: MANIFEST_ID,
-      output_envelope: {
-        session_id: SESSION_ID,
-        turn_index: 0,
-        parent_loop: "inner",
-        phase_or_purpose: "tdd_build",
-        slice_id: SLICE_ID,
-        slice_kind: "internal",
-        tdd_phase: "red_green",
-        agent_profile_id: "forge",
-        agent_role_in_session: "lead",
-        contribution_kind: "lead_draft",
-        output_kind: "patch",
-        object_id: SLICE_ID,
-        manifest_id: MANIFEST_ID,
-        input_revision_pins: ["abc1234"],
-        summary: "first turn",
-        idempotency_key: "k1",
-        runtime_metadata: {},
-      },
+      output_envelope: baseEnvelope(),
       caller_routing_decision: {
         decision: "dropped",
         decision_reason: "single-agent inner session, no next_action_request",
@@ -247,6 +257,29 @@ describe("SessionTurn schema", () => {
       recorded_at: ISO,
     });
     expect(turn.caller_routing_decision?.decision).toBe("dropped");
+    expect(turn.next_action_request).toBeNull();
+  });
+
+  it("supports top-level next_action_request mirror (SOC-SESSION-LIFECYCLE)", () => {
+    const turn = SessionTurn.parse({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      agent_profile_id: "forge",
+      input_manifest_id: MANIFEST_ID,
+      output_envelope: baseEnvelope(),
+      next_action_request: {
+        addressed_to: "sentinel",
+        intent: "review draft",
+      },
+      caller_routing_decision: {
+        decision: "accepted",
+        decision_reason: "sentinel is the middle-review reviewer",
+        resolved_addressed_to: "sentinel",
+      },
+      workspace_commit: null,
+      recorded_at: ISO,
+    });
+    expect(turn.next_action_request?.addressed_to).toBe("sentinel");
   });
 });
 

--- a/tests/domain/schema-1b.test.ts
+++ b/tests/domain/schema-1b.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import { DialogueSession, SessionState } from "../../src/domain/schema/dialogue-session.js";
+import {
+  AgentAuthoredEnvelope,
+  Envelope,
+} from "../../src/domain/schema/envelope.js";
+import { ContextManifest, FetchScope } from "../../src/domain/schema/manifest.js";
+import { SessionTurn } from "../../src/domain/schema/session-turn.js";
+import {
+  MetricRun,
+  VerificationRun,
+} from "../../src/domain/schema/verification.js";
+
+const SESSION_ID = "01HZSE0000000000000000000A";
+const MANIFEST_ID = "01HZMA0000000000000000000A";
+const SLICE_ID = "01HZS00000000000000000000A";
+const VRUN_ID = "01HZV00000000000000000000A";
+const MRUN_ID = "01HZK00000000000000000000A";
+const ISO = "2026-05-07T00:00:00.000Z";
+
+describe("ContextManifest schema (AGC-CONTEXT-MANIFEST)", () => {
+  it("round-trips a minimal manifest", () => {
+    const m = ContextManifest.parse({
+      manifest_id: MANIFEST_ID,
+      session_id: SESSION_ID,
+      turn_index: 0,
+      purpose: "tdd_build",
+      target: { object_kind: "slice", object_id: SLICE_ID },
+      entries: [
+        {
+          object_kind: "slice",
+          object_id: SLICE_ID,
+          fetch_scope: "body",
+          revision_pin: "abc1234",
+          required: true,
+          purpose: "primary input",
+        },
+      ],
+      created_at: ISO,
+    });
+    expect(m.entries.length).toBe(1);
+  });
+
+  it("rejects unknown fetch_scope", () => {
+    expect(() => FetchScope.parse("body+everything")).toThrow();
+  });
+
+  it("rejects non-ULID manifest_id", () => {
+    expect(() =>
+      ContextManifest.parse({
+        manifest_id: "not-a-ulid",
+        session_id: SESSION_ID,
+        turn_index: 0,
+        purpose: "tdd_build",
+        target: { object_kind: "slice", object_id: SLICE_ID },
+        entries: [],
+        created_at: ISO,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects unknown extra keys", () => {
+    expect(() =>
+      ContextManifest.parse({
+        manifest_id: MANIFEST_ID,
+        session_id: SESSION_ID,
+        turn_index: 0,
+        purpose: "tdd_build",
+        target: { object_kind: "slice", object_id: SLICE_ID },
+        entries: [],
+        created_at: ISO,
+        extra: "x",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("DialogueSession schema (SOC-SESSION-LIFECYCLE)", () => {
+  it("has all 5 states", () => {
+    expect(SessionState.options.length).toBe(5);
+    expect(SessionState.options).toContain("AWAITING_REVALIDATION");
+  });
+
+  it("round-trips an inner tdd_build session", () => {
+    const s = DialogueSession.parse({
+      session_id: SESSION_ID,
+      parent_object_kind: "slice",
+      parent_object_id: SLICE_ID,
+      parent_loop: "inner",
+      purpose: "tdd_build",
+      participants: [{ agent_profile_id: "forge", role: "lead" }],
+      session_termination: {
+        finalization_rule: "lead_only",
+        required_evidence: [
+          {
+            kind: "verification_green",
+            acceptance_tests: ["tests/foo.test.ts:bar"],
+            deterministic_checks: ["typecheck"],
+          },
+        ],
+        composite_rule: "evidence_only",
+      },
+      workspace_revision_pin: "abc1234",
+      current_turn_index: 0,
+      state: "SESSION_OPEN",
+      max_turns: 10,
+      created_at: ISO,
+      updated_at: ISO,
+    });
+    expect(s.spawned_contribution_id).toBeNull();
+    expect(s.session_termination.required_evidence.length).toBe(1);
+  });
+
+  it("rejects empty participants", () => {
+    expect(() =>
+      DialogueSession.parse({
+        session_id: SESSION_ID,
+        parent_object_kind: "slice",
+        parent_object_id: SLICE_ID,
+        parent_loop: "inner",
+        purpose: "tdd_build",
+        participants: [],
+        session_termination: {
+          finalization_rule: "lead_only",
+          required_evidence: [],
+          composite_rule: "evidence_only",
+        },
+        workspace_revision_pin: "abc1234",
+        current_turn_index: 0,
+        state: "SESSION_OPEN",
+        max_turns: 10,
+        created_at: ISO,
+        updated_at: ISO,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("AgentAuthoredEnvelope (AGC-OUTPUT pre-enrichment)", () => {
+  function baseAgent(
+    overrides: Partial<Record<string, unknown>> = {},
+  ): Record<string, unknown> {
+    return {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "inner",
+      phase_or_purpose: "tdd_build",
+      slice_id: SLICE_ID,
+      slice_kind: "internal",
+      tdd_phase: "red_green",
+      agent_profile_id: "forge",
+      agent_role_in_session: "lead",
+      contribution_kind: "lead_draft",
+      output_kind: "patch",
+      object_id: SLICE_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc1234"],
+      summary: "first turn",
+      ...overrides,
+    };
+  }
+
+  it("round-trips a minimal envelope", () => {
+    const e = AgentAuthoredEnvelope.parse(baseAgent());
+    expect(e.verdict).toBeNull();
+    expect(e.failure).toBeNull();
+  });
+
+  it("strips strict — rejects idempotency_key (caller-only)", () => {
+    expect(() =>
+      AgentAuthoredEnvelope.parse(baseAgent({ idempotency_key: "x" })),
+    ).toThrow();
+  });
+
+  it("strips strict — rejects runtime_metadata (caller-only)", () => {
+    expect(() =>
+      AgentAuthoredEnvelope.parse(baseAgent({ runtime_metadata: {} })),
+    ).toThrow();
+  });
+
+  it("rejects non-ULID session_id", () => {
+    expect(() =>
+      AgentAuthoredEnvelope.parse(baseAgent({ session_id: "not-ulid" })),
+    ).toThrow();
+  });
+});
+
+describe("Envelope (AGC-OUTPUT canonical)", () => {
+  it("round-trips canonical envelope with caller-enriched fields", () => {
+    const e = Envelope.parse({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "inner",
+      phase_or_purpose: "tdd_build",
+      slice_id: SLICE_ID,
+      slice_kind: "internal",
+      tdd_phase: "red_green",
+      agent_profile_id: "forge",
+      agent_role_in_session: "lead",
+      contribution_kind: "lead_draft",
+      output_kind: "patch",
+      object_id: SLICE_ID,
+      manifest_id: MANIFEST_ID,
+      input_revision_pins: ["abc1234"],
+      summary: "first turn",
+      idempotency_key: "scope=per_turn|sid=01HZSE0000000000000000000A|t=0|profile=forge|kind=lead_draft",
+      runtime_metadata: { workspace_commit: "deadbeef" },
+    });
+    expect(e.idempotency_key.length).toBeGreaterThan(0);
+    expect(e.runtime_metadata).toEqual({ workspace_commit: "deadbeef" });
+  });
+});
+
+describe("SessionTurn schema", () => {
+  it("round-trips with embedded canonical envelope", () => {
+    const turn = SessionTurn.parse({
+      session_id: SESSION_ID,
+      turn_index: 0,
+      agent_profile_id: "forge",
+      input_manifest_id: MANIFEST_ID,
+      output_envelope: {
+        session_id: SESSION_ID,
+        turn_index: 0,
+        parent_loop: "inner",
+        phase_or_purpose: "tdd_build",
+        slice_id: SLICE_ID,
+        slice_kind: "internal",
+        tdd_phase: "red_green",
+        agent_profile_id: "forge",
+        agent_role_in_session: "lead",
+        contribution_kind: "lead_draft",
+        output_kind: "patch",
+        object_id: SLICE_ID,
+        manifest_id: MANIFEST_ID,
+        input_revision_pins: ["abc1234"],
+        summary: "first turn",
+        idempotency_key: "k1",
+        runtime_metadata: {},
+      },
+      caller_routing_decision: {
+        decision: "dropped",
+        decision_reason: "single-agent inner session, no next_action_request",
+        resolved_addressed_to: null,
+      },
+      workspace_commit: "deadbeef",
+      verification_result_ref: VRUN_ID,
+      recorded_at: ISO,
+    });
+    expect(turn.caller_routing_decision?.decision).toBe("dropped");
+  });
+});
+
+describe("VerificationRun + MetricRun schemas (RGC-VERIFICATION)", () => {
+  it("VerificationRun round-trip", () => {
+    const v = VerificationRun.parse({
+      verification_run_id: VRUN_ID,
+      target_id: "demo",
+      target_revision: "deadbeef",
+      commands_or_checks: ["npm test", "npm run typecheck"],
+      environment_fingerprint: "node20-vitest2",
+      started_at: ISO,
+      finished_at: ISO,
+      result: "fail",
+      failed_tests: [
+        { path: "tests/foo.test.ts", name: "should bar", message: "expected 1, got 2" },
+      ],
+    });
+    expect(v.failed_tests.length).toBe(1);
+    expect(v.log_ref).toBeNull();
+  });
+
+  it("MetricRun round-trip", () => {
+    const m = MetricRun.parse({
+      metric_run_id: MRUN_ID,
+      target_id: "demo",
+      metric_name: "cyclomatic",
+      target_revision: "deadbeef",
+      value: 8,
+      comparator: "lte",
+      threshold: 10,
+      result: "met",
+      started_at: ISO,
+      finished_at: ISO,
+    });
+    expect(m.result).toBe("met");
+  });
+
+  it("rejects invalid result enum", () => {
+    expect(() =>
+      VerificationRun.parse({
+        verification_run_id: VRUN_ID,
+        target_id: "demo",
+        target_revision: "deadbeef",
+        commands_or_checks: [],
+        environment_fingerprint: "x",
+        started_at: ISO,
+        finished_at: ISO,
+        result: "skipped",
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1b 작업 — phase 2 의 inner cycle 이 즉시 사용할 schema/validator 토대를 박는다. **LLM 호출 / coordinator / runner 미진입**, schema + parser/enricher/matrix-validator 까지.

### 박힌 anchor (TS 진입)

| Anchor | 새 surface |
|---|---|
| `AGC-CONTRIBUTION` | \`src/domain/schema/contribution.ts\` (5-kind enum + 동반 enum 그룹) |
| \`AGC-CONTEXT-MANIFEST\` | \`src/domain/schema/manifest.ts\` + \`src/application/manifest-builder.ts\` (RevisionPinResolver port + recheckPins) |
| \`AGC-OUTPUT\` | \`src/domain/schema/envelope.ts\` (AgentAuthoredEnvelope strict / canonical Envelope), \`src/application/envelope.ts\` (parser + validator) |
| \`AGC-OUTPUT-RUNTIME-ENRICH\` | \`enrichEnvelope\` — idempotency_key + runtime_metadata 후주입 + key-collision 거부 |
| \`AGC-CONTRIBUTION-OUTPUTS\` | \`src/application/envelope-extended-validator.ts\` (data-driven 매트릭스) |
| \`AGC-INVALID\` | \`AGC_INVALID_REASONS\` enum + \`AgcInvalidError\` |
| \`SOC-SESSION-LIFECYCLE\` | \`src/domain/schema/dialogue-session.ts\` (5-state) + \`src/domain/schema/session-turn.ts\` |
| \`SOC-SESSION-TERMINATION\` | \`SessionTermination\` 블록 (rule × evidence × composite) |
| \`RGC-VERIFICATION\` | \`src/domain/schema/verification.ts\` (VerificationRun + MetricRun) |

### 핵심 invariant 준수

- **Inv #4 Caller-only operational write**: \`AgentAuthoredEnvelope\` 가 strict 로 \`idempotency_key\`/\`runtime_metadata\` 거부. 추가로 parser 가 \`"key" in obj\` 사전 검사로 *값* 이 undefined 인 경우도 잡아 명시적 이유 코드 (\`agent_authored_idempotency_key\` / \`agent_authored_runtime_metadata\`) 로 분류.
- **Legacy 잔존 차단**: \`agent_role\` / \`operation\` / \`phase_run_id\` 잔존 시 \`legacy_field_present\` 로 reject.
- **decision_reason 필수 (AGC-NEXT-ACTION-REQUEST)**: \`CallerRoutingDecision.decision_reason: z.string().min(1)\`.
- **Caller-issued ULID 강제**: 모든 Caller-issued id (manifest/session/turn snapshot/verification/metric) UlidString refinement.

### Phase-scoped conformance 테스트

\`tests/conformance/phase-1b.test.ts\`:

1. README CONTRACT-CONFORMANCE 매트릭스의 phase-1b anchor row → TS surface 가 실제 존재하는지.
2. 스키마 enum ↔ contract markdown 동기화: \`contribution_kind\`, \`output_kind\`, \`fetch_scope\`, \`SessionState\` — 양방향 drift 검출.
3. legacy 필드 이름 (\`agent_role\`/\`operation\`/\`phase_run_id\`) 가 envelope.ts 의 거부 리스트에 박혀 있는지.

### MVP 단순화

- \`SessionTermination.evaluate\` (정족수/composite rule 실행) 는 phase 3 \`termination-evaluator.ts\` 가 박는다 — schema 만.
- \`tdd_strict\` / scope_violation / decision_reason missing 등 phase-2+ 분류 사유는 \`AGC_INVALID_REASONS\` 에 enum 으로 자리만 잡고 실제 분류 로직은 phase 2 \`agent-io.ts\` 가 채운다.
- \`next_action_request.evidence_request\` 는 schema 만 — phase 3 dialogue-coordinator 가 routing 결정에 입력으로 사용.

## Test plan

- [x] \`npm run typecheck\` (zero error)
- [x] \`npm test\` — 25 files / 219 tests passing
- [x] \`npm run build\` — zero error
- [x] phase-1a conformance 테스트 회귀 없음
- [x] phase-1b conformance 통과 (14 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)