### PR TITLE
feat(phase-2): inner-only minimal cycle — forge solo TDD + workspace + verification

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -351,7 +351,7 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | `AGC-CONTRIBUTION` | partial | `src/domain/schema/contribution.ts` (`ContributionKind`, `OutputKind`, `FinalVerdict`, `ParentLoop`, `AgentProfileId`, `AgentRoleInSession`, `TddPhase` zod enums) | always_hard (enum 검증) | 2026-05-05-loop (enum 정정) |
 | `AGC-CALL-BOUNDARY` | partial | `application/agent_io.sh`, `lib/ports/*` | always_hard (caller_only_operational_write) | 2026-05-05-loop (turn 단위로 재정의) |
 | `AGC-SESSION-INPUT` ★ | spec-only | contract prose | always_hard (manifest_external_read_write) | 2026-05-05-loop |
-| `AGC-PROMPT-SERIALIZATION` ★ | spec-only | contract prose. prompt builder catch-up (`docs/architecture/prompt-build-pipeline.md`) | always_hard (4-part layout + header echo 7 필드) | 2026-05-05-loop |
+| `AGC-PROMPT-SERIALIZATION` ★ | partial | `src/application/prompt-compose.ts` (frontmatter 7 필드 + Context/Instruction/Output Schema 4-part 조립), `src/adapters/llm-runner/common/prompt-relay.ts` (`assertFourPartLayout` preflight), `src/application/agent-io.ts` (`checkHeaderEcho` 7-field 검증) | always_hard (4-part layout + header echo 7 필드) | 2026-05-05-loop |
 | `AGC-NEXT-ACTION-REQUEST` ★ | spec-only | contract prose | always_hard (direct_invocation_forbidden, decision_reason 필수) | 2026-05-05-loop |
 | `AGC-TURN-ORDERING` ★ | spec-only | contract prose + `dialogue_coordinator.sh` (Stage 2) | always_hard (priority + fairness) | 2026-05-05-loop |
 | `AGC-CONFLICT-RESOLUTION` ★ | spec-only | contract prose + `dialogue_coordinator.sh` (Stage 2) | always_hard (re-dispatch / human escalation) | 2026-05-05-loop |
@@ -361,7 +361,7 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | `AGC-OUTPUT-RUNTIME-ENRICH` | partial | `src/application/envelope.ts` (`enrichEnvelope` injects `idempotency_key` + `runtime_metadata`, rejects key collisions and agent-authored caller-only fields) | always_hard | 2026-05-05-loop (3-scope idempotency 매핑) |
 | `AGC-LLM-NEUTRALITY` ★ | spec-only | contract prose. adapter normalize 책임 (`adapters/llm_runner/*`) | always_hard (provider-native → envelope normalize) | 2026-05-05-loop |
 | `AGC-CONTRIBUTION-OUTPUTS` | partial | `src/application/envelope-extended-validator.ts` (data-driven (parent_loop, phase_or_purpose, contribution_kind) → output_kind / verdict.result matrix) | always_hard (output_kind 매트릭스 검증) | 2026-05-05-loop |
-| `AGC-WORKSPACE` | partial | `adapters/workspace/*`, `application/caller_dispatch.sh` | stage_graded:scope_violation=warn (Stage 3b block) | 2026-05-05-loop (inner scope enforcement) |
+| `AGC-WORKSPACE` | partial | `src/ports/workspace.ts` (`WorkspacePort.prepareInnerWorkspace` + `commit` + `head`), `src/adapters/workspace/git-worktree.ts` (slice-local worktree), `src/adapters/workspace/fake.ts` (in-memory deterministic worktree). middle read-only checkout 은 phase 3 | stage_graded:scope_violation=warn (Stage 3b block) | 2026-05-05-loop (inner scope enforcement) |
 | `AGC-ISSUE-BODY` | spec-only | `docs/architecture/agent-output-format-mapping.md` | n/a (rendering 규약) | original |
 | `AGC-INVALID` | partial | `src/application/envelope.ts` (`AGC_INVALID_REASONS` enum, `AgcInvalidError`, parser/enricher/matrix classification surface). TDD strict / session_id collision / scope_violation 분기는 phase 2+ catch-up | always_hard | 2026-05-05-loop (TDD strict / session_id 충돌 추가) |
 
@@ -373,12 +373,12 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | `SOC-OBJECTS` | spec-only | contract prose. legacy `lib/state.sh` 는 milestone/task/CP 만 — Stage 2 rewrite | always_hard | 2026-05-05-loop (Slice/DialogueSession/SessionTurn/SliceMerge 신설) |
 | `SOC-LOOPS` ★ | spec-only | contract prose | always_hard (loop_kind 분류) | 2026-05-05-loop |
 | `SOC-MILESTONE-DUAL-SLOT` ★ | spec-only | `lib/dual_track_scheduler.sh` (Stage 4) | stage_graded:dual_slot_fairness=warn (Stage 5 block) | 2026-05-05-loop |
-| `SOC-SLICE-LIFECYCLE` ★ | spec-only | `lib/slice.sh` (Stage 2) | always_hard (state machine) | 2026-05-05-loop |
+| `SOC-SLICE-LIFECYCLE` ★ | partial | `src/domain/schema/slice.ts` (7-state schema), `src/application/ready-object.ts` (`pickReadyInnerTurn`: SLICE_READY → SLICE_BUILDING + session open), `src/application/turn-worker.ts` (`runOneInnerTurn`: SLICE_BUILDING → SLICE_REVIEWING on tests_green). middle review / SLICE_INTEGRATING / SLICE_VALIDATED 는 phase 3 | always_hard (state machine) | 2026-05-05-loop |
 | `SOC-SLICE-DEPENDENCIES` ★ | spec-only | `lib/slice.sh` + Planning lead artifact validation (Stage 2) | always_hard (cycle detection) | 2026-05-05-loop |
 | `SOC-SLICE-CLASS` ★ | spec-only | `lib/slice.sh` + escalation rule lookup (Stage 4) | always_hard (escalation 평가) | 2026-05-05-loop |
 | `SOC-SESSION-LIFECYCLE` ★ | partial | `src/domain/schema/dialogue-session.ts` (`DialogueSession` 5-state schema + `Participant`), `src/domain/schema/session-turn.ts` (`SessionTurn` + `CallerRoutingDecision`). dialogue coordinator dispatch 는 phase 3 | always_hard (state machine) | 2026-05-05-loop |
 | `SOC-SESSION-TERMINATION` ★ | partial | `src/domain/schema/dialogue-session.ts` (`SessionTermination` block: `FinalizationRule`, `RequiredEvidence`, `CompositeRule`). evaluator 는 phase 3 (`termination-evaluator.ts`) | stage_graded:required_evidence_unmet=warn (Stage 3b block) | 2026-05-05-loop |
-| `SOC-SLICE-MERGE` ★ | spec-only | `lib/slice_merge.sh` (Stage 2) | always_hard (state machine) | 2026-05-05-loop |
+| `SOC-SLICE-MERGE` ★ | partial | `src/domain/schema/slice-merge.ts` (7-state schema), `src/application/turn-worker.ts` (`openSliceMergeReadyForReview`: SM_DRAFT → SM_READY_FOR_REVIEW after inner CONVERGED tests_green). SM_APPROVED / SM_MERGED / SM_STALE 분기는 phase 3 | always_hard (state machine) | 2026-05-05-loop |
 | `SOC-DUAL-MILESTONE-BRANCH` ★ | spec-only | trunk 정책 (`SOC-MERGE-POLICY` 와 결합) | always_hard | 2026-05-05-loop |
 | `SOC-CROSS-MILESTONE-REFERENCE` ★ | spec-only | `application/dialogue_coordinator.sh` 의 cross-slot stale 감지 (Stage 4) | stage_graded:telemetry_enrichment_missing=warn | 2026-05-05-loop |
 | `SOC-INTAKE` | active | `application/feature_request.sh` | always_hard (idempotency_key) | 2026-05-05-loop (M_INTAKE_QUEUED 도입) |
@@ -404,7 +404,7 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | `RGC-DUAL-GATE-QUEUE` ★ | spec-only | `dual_track_scheduler.sh` (Stage 4) | always_hard (FIFO + idempotency) | 2026-05-05-loop |
 | `RGC-RECOVERY` | spec-only | `application/recovery.sh` (legacy-only catch-up needed) | always_hard | 2026-05-05-loop (loop-aware trigger) |
 | `RGC-FAILURE` | partial | `application/recovery.sh`, `scripts/cli/daemon.sh` | always_hard | 2026-05-05-loop (retry/escalation 운영 정책 매핑) |
-| `RGC-VERIFICATION` | partial | `src/domain/schema/verification.ts` (`VerificationRun` + `MetricRun` schemas). 실행자 (`application/verification-runner.ts`) 는 phase 2 | always_hard (deterministic_verification_authority) | 2026-05-05-loop (VerificationRun + MetricRun + required_evidence) |
+| `RGC-VERIFICATION` | partial | `src/domain/schema/verification.ts` (`VerificationRun` + `MetricRun` schemas), `src/ports/verification.ts` (`VerificationPort.runBuild/runTest/runLint/runMetric`), `src/adapters/verification/shell.ts` (실 실행), `src/adapters/verification/fake.ts` (테스트), `src/application/verification-runner.ts` (`runInnerVerification` — inner 동기 실행 + VerificationRun 영속). middle / outer 비동기 trigger 는 phase 3 | always_hard (deterministic_verification_authority) | 2026-05-05-loop (VerificationRun + MetricRun + required_evidence) |
 | `RGC-HUMAN-CONTRIBUTION` | spec-only | `application/human_signal.sh` (legacy-only catch-up needed) | always_hard (required human contribution) | 2026-05-05-loop (feature slice 한정 scope) |
 | `RGC-LEDGER` | partial | `src/domain/schema/ledger.ts` (필수 필드 schema), `src/application/ledger.ts` (`FileLedger.appendTransition` + audit_hash chain), `src/domain/audit-hash.ts` (sha256 canonical-json [prevHash, row]) | always_hard (필수 필드) | 2026-05-05-loop (slice/session/turn/loop_kind/action_kind/final_verdict 추가) |
 | `RGC-PAUSE` | active | `lib/signals.sh`, `scripts/cli/control.sh`, `application/human_signal.sh` | always_hard | original |
@@ -455,10 +455,10 @@ amendment 직후의 enforcement 상태는 `target.invariant_enforcement` (TCC-EN
 | Anchor | Status | Implementation Surface | Enforcement | Active Since |
 |---|---|---|---|---|
 | `ARC-SCOPE` | active | contract authority | n/a | 2026-05-05-loop (AGC vs ARC 책임 분리 추가) |
-| `ARC-PORT-SIGNATURE` | spec-only | `lib/ports/llm_runner.sh` rewrite (Stage 2). legacy signature 기준 → loop-based | always_hard (signature shape) | 2026-05-05-loop (session_id/turn_index/parent_loop/agent_role_in_session/session_context_ref 필수) |
-| `ARC-CALL-SEMANTICS` | active | `scheduler/runner.sh`, `adapters/llm_runner/*` | always_hard (stateless per call) | 2026-05-05-loop (turn 단위 strict + session state 미보유) |
+| `ARC-PORT-SIGNATURE` | partial | `src/ports/llm-runner.ts` (`LlmRunnerPort` interface + `LlmRunnerInput` / `LlmRunnerResult` 시그니처), `src/ports/llm-runner-executor.ts` (`runInvoke` 4-tuple 보장). | always_hard (signature shape) | 2026-05-05-loop (session_id/turn_index/parent_loop/agent_role_in_session/session_context_ref 필수) |
+| `ARC-CALL-SEMANTICS` | partial | `src/ports/llm-runner-executor.ts` (`runInvoke` — turn 단위 stateless invoke + 4-tuple 결과), `src/adapters/llm-runner/runtime-port.ts` (`AdapterRunnerPort` — provider adapter 를 contract-shaped port 로 노출), `src/application/agent-io.ts` (`callAgent` consumer — session state 미보유 호출). | always_hard (stateless per call) | 2026-05-05-loop (turn 단위 strict + session state 미보유) |
 | `ARC-EXIT-CLASSES` | active | `lib/ports/llm_runner.sh` `lr_classify_exit` | n/a (분류) | original |
 | `ARC-IDEMPOTENCY` | spec-only | `application/caller_dispatch.sh` + ledger (Stage 2) | always_hard | 2026-05-05-loop (3-scope per-turn / per-session-outcome / per-merge) |
-| `ARC-ADAPTER-PROMPT-CONTRACT` ★ | spec-only | `adapters/llm_runner/*` catch-up (Stage 2) | always_hard (4-part layout 보존) | 2026-05-05-loop |
+| `ARC-ADAPTER-PROMPT-CONTRACT` ★ | partial | `src/adapters/llm-runner/common/prompt-relay.ts` (`assertFourPartLayout`), `src/ports/llm-runner-executor.ts` (preflight before adapter spawn), `src/adapters/llm-runner/claude-code.ts`, `src/adapters/llm-runner/codex-cli.ts`, `src/adapters/llm-runner/fake.ts` (provider adapters relay stdin verbatim) | always_hard (4-part layout 보존) | 2026-05-05-loop |
 | `ARC-ADAPTER-SUBSTITUTION` | spec-only | `TCC-AGENT-PROFILES` binding (Stage 2) | always_hard (agent_profile_id 기반) | phase-pivot |
 | `ARC-FAILURE-MODES` | active | `lib/ports/llm_runner.sh`, `scheduler/runner.sh` | n/a (분류) | original |

--- a/src/adapters/llm-runner/runtime-port.ts
+++ b/src/adapters/llm-runner/runtime-port.ts
@@ -1,0 +1,20 @@
+import { runInvoke } from "../../ports/llm-runner-executor.js";
+import type {
+  LlmRunnerInput,
+  LlmRunnerPort,
+  LlmRunnerResult,
+} from "../../ports/llm-runner.js";
+import type { LlmRunnerAdapter } from "./types.js";
+
+/**
+ * Adapts a low-level LlmRunnerAdapter (provider-specific spawner) into the
+ * contract-shaped LlmRunnerPort by delegating to the shared `runInvoke`
+ * executor. Application code holds only the LlmRunnerPort interface.
+ */
+export class AdapterRunnerPort implements LlmRunnerPort {
+  constructor(private readonly adapter: LlmRunnerAdapter) {}
+
+  invoke(input: LlmRunnerInput): Promise<LlmRunnerResult> {
+    return runInvoke(input, this.adapter);
+  }
+}

--- a/src/adapters/verification/fake.ts
+++ b/src/adapters/verification/fake.ts
@@ -1,0 +1,76 @@
+import type { FailedTest } from "../../domain/schema/verification.js";
+import type {
+  CommandSpec,
+  MetricOutcome,
+  VerificationOutcome,
+  VerificationPort,
+} from "../../ports/verification.js";
+import type { ClockPort } from "../../ports/clock.js";
+
+/**
+ * Fake verification adapter — returns scripted outcomes based on the first
+ * argv token. Used by integration tests so an inner cycle can exercise the
+ * full pass/fail branches without forking real binaries.
+ */
+export interface FakeOutcomeMap {
+  build?: VerificationOutcomeOverride;
+  test?: VerificationOutcomeOverride;
+  lint?: VerificationOutcomeOverride;
+  metric?: { result: "met" | "unmet"; value: number };
+}
+
+export type VerificationOutcomeOverride = {
+  result: "pass" | "fail" | "error";
+  failed_tests?: FailedTest[];
+};
+
+export class FakeVerification implements VerificationPort {
+  constructor(
+    private readonly clock: ClockPort,
+    private readonly outcomes: FakeOutcomeMap = {},
+  ) {}
+
+  async runBuild(commands: CommandSpec[]): Promise<VerificationOutcome> {
+    return this.outcome(commands, this.outcomes.build ?? { result: "pass" });
+  }
+
+  async runTest(commands: CommandSpec[]): Promise<VerificationOutcome> {
+    return this.outcome(commands, this.outcomes.test ?? { result: "pass" });
+  }
+
+  async runLint(commands: CommandSpec[]): Promise<VerificationOutcome> {
+    return this.outcome(commands, this.outcomes.lint ?? { result: "pass" });
+  }
+
+  async runMetric(input: {
+    command: CommandSpec;
+    compare: (value: number) => "met" | "unmet";
+  }): Promise<MetricOutcome> {
+    const o = this.outcomes.metric ?? { result: "met", value: 0 };
+    const startedAt = this.clock.isoNow();
+    const finishedAt = this.clock.isoNow();
+    return {
+      result: o.result,
+      value: o.value,
+      log: `[fake metric: ${o.value}]`,
+      startedAt,
+      finishedAt,
+    };
+  }
+
+  private outcome(
+    commands: CommandSpec[],
+    o: VerificationOutcomeOverride,
+  ): VerificationOutcome {
+    const startedAt = this.clock.isoNow();
+    const finishedAt = this.clock.isoNow();
+    return {
+      result: o.result,
+      log: commands.map((c) => `$ ${c.argv.join(" ")}`).join("\n"),
+      failed_tests: o.failed_tests ?? [],
+      startedAt,
+      finishedAt,
+      exitCodes: commands.map(() => (o.result === "pass" ? 0 : 1)),
+    };
+  }
+}

--- a/src/adapters/verification/shell.ts
+++ b/src/adapters/verification/shell.ts
@@ -1,0 +1,158 @@
+import { spawn } from "node:child_process";
+import type { FailedTest } from "../../domain/schema/verification.js";
+import type {
+  CommandSpec,
+  MetricOutcome,
+  VerificationOutcome,
+  VerificationPort,
+  VerificationResult,
+} from "../../ports/verification.js";
+import type { ClockPort } from "../../ports/clock.js";
+
+/**
+ * Shell verification adapter — spawns commands without a shell. Argv must be
+ * pre-tokenised by the caller (target.yaml). All stdout/stderr is captured
+ * to the log buffer in command order.
+ *
+ * Test-failure parsing is intentionally absent in phase 2: the outcome's
+ * `failed_tests[]` is empty when an exec fails, and the exit code drives
+ * `pass`/`fail` classification. Phase 3+ may bolt on JUnit / Vitest report
+ * parsers behind the same port.
+ */
+
+export interface ShellVerificationCfg {
+  clock: ClockPort;
+  /** Default per-command timeout if a CommandSpec does not set one. */
+  defaultTimeoutSec?: number;
+}
+
+export class ShellVerification implements VerificationPort {
+  constructor(private readonly cfg: ShellVerificationCfg) {}
+
+  async runBuild(commands: CommandSpec[]): Promise<VerificationOutcome> {
+    return this.runAll(commands);
+  }
+
+  async runTest(commands: CommandSpec[]): Promise<VerificationOutcome> {
+    return this.runAll(commands);
+  }
+
+  async runLint(commands: CommandSpec[]): Promise<VerificationOutcome> {
+    return this.runAll(commands);
+  }
+
+  async runMetric(input: {
+    command: CommandSpec;
+    compare: (value: number) => "met" | "unmet";
+  }): Promise<MetricOutcome> {
+    const startedAt = this.cfg.clock.isoNow();
+    const exec = await runOne(input.command, this.timeout(input.command));
+    const finishedAt = this.cfg.clock.isoNow();
+    const log = formatExec(input.command, exec);
+    const value = parseMetricValue(exec.stdout);
+    const result =
+      Number.isNaN(value) || exec.code !== 0 ? "unmet" : input.compare(value);
+    return {
+      result,
+      value: Number.isNaN(value) ? 0 : value,
+      log,
+      startedAt,
+      finishedAt,
+    };
+  }
+
+  private async runAll(commands: CommandSpec[]): Promise<VerificationOutcome> {
+    const startedAt = this.cfg.clock.isoNow();
+    let result: VerificationResult = "pass";
+    const exitCodes: (number | null)[] = [];
+    const logs: string[] = [];
+    const failed: FailedTest[] = [];
+    for (const c of commands) {
+      const exec = await runOne(c, this.timeout(c));
+      logs.push(formatExec(c, exec));
+      exitCodes.push(exec.code);
+      if (exec.spawnError) {
+        result = "error";
+        break;
+      }
+      if (exec.code !== 0) {
+        result = "fail";
+      }
+    }
+    const finishedAt = this.cfg.clock.isoNow();
+    return {
+      result,
+      log: logs.join("\n"),
+      failed_tests: failed,
+      startedAt,
+      finishedAt,
+      exitCodes,
+    };
+  }
+
+  private timeout(c: CommandSpec): number | undefined {
+    return c.timeoutSec ?? this.cfg.defaultTimeoutSec;
+  }
+}
+
+interface ExecResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  spawnError?: string;
+  timedOut?: boolean;
+}
+
+async function runOne(
+  c: CommandSpec,
+  timeoutSec?: number,
+): Promise<ExecResult> {
+  if (c.argv.length === 0)
+    return { code: null, stdout: "", stderr: "", spawnError: "empty argv" };
+  return new Promise((resolveP) => {
+    const child = spawn(c.argv[0]!, c.argv.slice(1), {
+      cwd: c.cwd,
+      env: c.env ?? process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timer: NodeJS.Timeout | null = null;
+    let timedOut = false;
+    if (timeoutSec != null && timeoutSec > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, timeoutSec * 1000);
+    }
+    child.stdout?.on("data", (b: Buffer) => (stdout += b.toString("utf8")));
+    child.stderr?.on("data", (b: Buffer) => (stderr += b.toString("utf8")));
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      resolveP({
+        code: null,
+        stdout,
+        stderr,
+        spawnError: (err as Error).message,
+      });
+    });
+    child.on("exit", (code) => {
+      if (timer) clearTimeout(timer);
+      resolveP({ code, stdout, stderr, timedOut });
+    });
+  });
+}
+
+function formatExec(c: CommandSpec, r: ExecResult): string {
+  const head = `$ ${c.argv.join(" ")} (cwd=${c.cwd})`;
+  const tail = r.spawnError
+    ? `[spawn error: ${r.spawnError}]`
+    : `[exit=${r.code}${r.timedOut ? " timed_out" : ""}]`;
+  return [head, r.stdout, r.stderr, tail].filter((s) => s.length > 0).join("\n");
+}
+
+function parseMetricValue(stdout: string): number {
+  const trimmed = stdout.trim().split(/\s+/).pop() ?? "";
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : Number.NaN;
+}

--- a/src/adapters/verification/shell.ts
+++ b/src/adapters/verification/shell.ts
@@ -63,6 +63,21 @@ export class ShellVerification implements VerificationPort {
 
   private async runAll(commands: CommandSpec[]): Promise<VerificationOutcome> {
     const startedAt = this.cfg.clock.isoNow();
+    // P1 fix (PR #61 review): an empty command list is a configuration
+    // error, not a passing run. Returning `pass` here would let a missing
+    // target.yaml verify entry promote a turn to tests_green without
+    // running anything (#RGC-VERIFICATION deterministic_verification_authority).
+    if (commands.length === 0) {
+      const finishedAt = this.cfg.clock.isoNow();
+      return {
+        result: "error",
+        log: "[verification adapter: empty command list — no checks ran]",
+        failed_tests: [],
+        startedAt,
+        finishedAt,
+        exitCodes: [],
+      };
+    }
     let result: VerificationResult = "pass";
     const exitCodes: (number | null)[] = [];
     const logs: string[] = [];

--- a/src/adapters/workspace/fake.ts
+++ b/src/adapters/workspace/fake.ts
@@ -1,0 +1,101 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
+import type {
+  CommitInput,
+  CommitResult,
+  PreparedWorkspace,
+  WorkspacePort,
+} from "../../ports/workspace.js";
+
+/**
+ * In-memory + tmpdir workspace adapter for tests.
+ *
+ * `prepareInnerWorkspace` creates a directory under `rootDir/<slice_id>`
+ * (so application code can pass a real `agentCwd` to runners that read
+ * stdin frontmatter) but tracks heads as deterministic synthetic hashes
+ * keyed by slice_id + commit count. Files are written to disk so an
+ * integration test can inspect them.
+ *
+ * Determinism: head hashes are derived from slice_id + commit index +
+ * sorted file digests, so the same sequence of commits produces identical
+ * pins across runs. No call to git is performed.
+ */
+export class FakeWorkspace implements WorkspacePort {
+  private readonly state = new Map<string, { head: string; commits: number }>();
+
+  constructor(private readonly rootDir: string) {}
+
+  async prepareInnerWorkspace(input: {
+    sliceId: string;
+    trunkBaseRevision: string;
+  }): Promise<PreparedWorkspace> {
+    const dir = resolve(this.rootDir, input.sliceId);
+    mkdirSync(dir, { recursive: true });
+    const existing = this.state.get(input.sliceId);
+    if (existing == null) {
+      this.state.set(input.sliceId, {
+        head: input.trunkBaseRevision,
+        commits: 0,
+      });
+    }
+    return {
+      agentCwd: dir,
+      headBefore: this.state.get(input.sliceId)!.head,
+    };
+  }
+
+  async commit(input: CommitInput): Promise<CommitResult> {
+    const dir = resolve(this.rootDir, input.sliceId);
+    for (const f of input.files) {
+      assertSafeRel(f.path);
+      const target = resolve(dir, f.path);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, f.content, "utf8");
+    }
+    const cur = this.state.get(input.sliceId);
+    if (cur == null)
+      throw new Error(
+        `commit on un-prepared workspace for slice_id=${input.sliceId}`,
+      );
+    const next = cur.commits + 1;
+    const sortedDigest = input.files
+      .map((f) => `${f.path}:${sha(f.content)}`)
+      .sort()
+      .join("|");
+    const head = sha(
+      `${cur.head}|${input.sliceId}|${next}|${input.message}|${sortedDigest}`,
+    ).slice(0, 40);
+    this.state.set(input.sliceId, { head, commits: next });
+    return { commit: head };
+  }
+
+  async head(sliceId: string): Promise<string> {
+    const cur = this.state.get(sliceId);
+    if (cur == null)
+      throw new Error(`no workspace prepared for slice_id=${sliceId}`);
+    return cur.head;
+  }
+
+  /** Test-only — directory where files have been materialised. */
+  agentCwd(sliceId: string): string {
+    return resolve(this.rootDir, sliceId);
+  }
+}
+
+function sha(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function assertSafeRel(rel: string): void {
+  if (rel.length === 0) throw new Error("file path cannot be empty");
+  if (isAbsolute(rel)) throw new Error(`absolute paths forbidden: ${rel}`);
+  const norm = normalize(rel);
+  if (norm.startsWith("..") || norm.includes(`${"/"}..${"/"}`) || norm === "..")
+    throw new Error(`path traversal forbidden: ${rel}`);
+  if (norm !== rel && norm !== `./${rel}` && join(".", rel) !== norm) {
+    // Allow `./prefix` etc. — but reject anything that resolves outside the
+    // workspace root via a normalize-pass test.
+    if (norm.startsWith("/")) throw new Error(`unsafe path: ${rel}`);
+  }
+}

--- a/src/adapters/workspace/git-worktree.ts
+++ b/src/adapters/workspace/git-worktree.ts
@@ -60,13 +60,24 @@ export class GitWorktreeWorkspace implements WorkspacePort {
 
   async commit(input: CommitInput): Promise<CommitResult> {
     const wt = this.worktreePath(input.sliceId);
+    // P0 fix (PR #61 review): only add the explicit envelope-listed paths.
+    // `git add --all` would commit any side-effect file the agent process
+    // wrote outside `envelope.artifacts.files`, breaking Inv #4 (Caller-only
+    // operational write) and the AGC-OUTPUT envelope strict boundary.
     for (const f of input.files) {
       assertSafeRel(f.path);
       const target = resolve(wt, f.path);
       mkdirSync(dirname(target), { recursive: true });
       writeFileSync(target, f.content, "utf8");
     }
-    await git(wt, ["add", "--all"]);
+    if (input.files.length === 0) {
+      // No declared artefacts → nothing to commit. Caller decides whether
+      // this is a malformed envelope or a legitimate refactor-no-op.
+      const head = (await git(wt, ["rev-parse", "HEAD"])).stdout.trim();
+      return { commit: head };
+    }
+    const addArgs = ["add", "--", ...input.files.map((f) => f.path)];
+    await git(wt, addArgs);
     const env = this.commitEnv();
     await git(wt, ["commit", "-m", input.message], env);
     const head = (await git(wt, ["rev-parse", "HEAD"])).stdout.trim();

--- a/src/adapters/workspace/git-worktree.ts
+++ b/src/adapters/workspace/git-worktree.ts
@@ -1,0 +1,155 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, normalize, resolve } from "node:path";
+import type {
+  CommitInput,
+  CommitResult,
+  PreparedWorkspace,
+  WorkspacePort,
+} from "../../ports/workspace.js";
+
+/**
+ * Git worktree workspace adapter.
+ *
+ * Creates a slice-local worktree under `<workdir>/workspaces/<slice_id>` and
+ * a slice-local branch `slice/<slice_id>`. Subsequent commits are appended
+ * to that branch. Trunk push and rebase are out of scope (phase 3).
+ *
+ * The adapter shells out to `git`. All operations run inside the slice
+ * worktree's cwd. The repository root (where `.git` lives) is configured at
+ * construction.
+ */
+
+export interface GitWorktreeAdapterCfg {
+  /** Path to the repository root (the directory whose `.git` worktrees are reused). */
+  repoRoot: string;
+  /** Directory under which slice worktrees are created. */
+  workspacesDir: string;
+  /** Branch prefix. Default `slice/`. */
+  branchPrefix?: string;
+  /** Author identity used for commits. */
+  authorName?: string;
+  authorEmail?: string;
+}
+
+export class GitWorktreeWorkspace implements WorkspacePort {
+  constructor(private readonly cfg: GitWorktreeAdapterCfg) {}
+
+  async prepareInnerWorkspace(input: {
+    sliceId: string;
+    trunkBaseRevision: string;
+  }): Promise<PreparedWorkspace> {
+    const wt = this.worktreePath(input.sliceId);
+    const branch = this.branchName(input.sliceId);
+    if (!(await pathExists(wt))) {
+      mkdirSync(dirname(wt), { recursive: true });
+      await git(this.cfg.repoRoot, [
+        "worktree",
+        "add",
+        "-b",
+        branch,
+        wt,
+        input.trunkBaseRevision,
+      ]);
+    }
+    const headBefore = (
+      await git(wt, ["rev-parse", "HEAD"])
+    ).stdout.trim();
+    return { agentCwd: wt, headBefore };
+  }
+
+  async commit(input: CommitInput): Promise<CommitResult> {
+    const wt = this.worktreePath(input.sliceId);
+    for (const f of input.files) {
+      assertSafeRel(f.path);
+      const target = resolve(wt, f.path);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, f.content, "utf8");
+    }
+    await git(wt, ["add", "--all"]);
+    const env = this.commitEnv();
+    await git(wt, ["commit", "-m", input.message], env);
+    const head = (await git(wt, ["rev-parse", "HEAD"])).stdout.trim();
+    return { commit: head };
+  }
+
+  async head(sliceId: string): Promise<string> {
+    const wt = this.worktreePath(sliceId);
+    return (await git(wt, ["rev-parse", "HEAD"])).stdout.trim();
+  }
+
+  private worktreePath(sliceId: string): string {
+    return resolve(this.cfg.workspacesDir, sliceId);
+  }
+
+  private branchName(sliceId: string): string {
+    return `${this.cfg.branchPrefix ?? "slice/"}${sliceId}`;
+  }
+
+  private commitEnv(): NodeJS.ProcessEnv {
+    const e: NodeJS.ProcessEnv = {};
+    if (this.cfg.authorName) {
+      e.GIT_AUTHOR_NAME = this.cfg.authorName;
+      e.GIT_COMMITTER_NAME = this.cfg.authorName;
+    }
+    if (this.cfg.authorEmail) {
+      e.GIT_AUTHOR_EMAIL = this.cfg.authorEmail;
+      e.GIT_COMMITTER_EMAIL = this.cfg.authorEmail;
+    }
+    return e;
+  }
+}
+
+interface GitResult {
+  stdout: string;
+  stderr: string;
+}
+
+function git(
+  cwd: string,
+  args: readonly string[],
+  extraEnv?: NodeJS.ProcessEnv,
+): Promise<GitResult> {
+  return new Promise((resolveP, reject) => {
+    const child = spawn("git", args, {
+      cwd,
+      env: { ...process.env, ...(extraEnv ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (b: Buffer) => (stdout += b.toString("utf8")));
+    child.stderr.on("data", (b: Buffer) => (stderr += b.toString("utf8")));
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) resolveP({ stdout, stderr });
+      else
+        reject(
+          new Error(
+            `git ${args.join(" ")} exited code=${code} signal=${signal}\nstderr: ${stderr}`,
+          ),
+        );
+    });
+  });
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    const fs = await import("node:fs/promises");
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertSafeRel(rel: string): void {
+  if (rel.length === 0) throw new Error("file path cannot be empty");
+  if (isAbsolute(rel)) throw new Error(`absolute paths forbidden: ${rel}`);
+  const norm = normalize(rel);
+  if (norm.startsWith("..") || norm.includes(`${"/"}..${"/"}`) || norm === "..")
+    throw new Error(`path traversal forbidden: ${rel}`);
+  if (norm !== rel && join(".", rel) !== norm) {
+    if (norm.startsWith("/")) throw new Error(`unsafe path: ${rel}`);
+  }
+}

--- a/src/application/agent-io.ts
+++ b/src/application/agent-io.ts
@@ -1,0 +1,227 @@
+import { mkdtempSync } from "node:fs";
+import { writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ContextManifest } from "../domain/schema/manifest.js";
+import type {
+  AgentAuthoredEnvelope,
+  Envelope,
+} from "../domain/schema/envelope.js";
+import type {
+  LlmRunnerInput,
+  LlmRunnerPort,
+  LlmAgentProfileId,
+  AgentRole,
+  ParentLoop as RunnerParentLoop,
+} from "../ports/llm-runner.js";
+import {
+  enrichEnvelope,
+  parseAgentAuthored,
+  validateEnvelope,
+  type AgcInvalidReason,
+} from "./envelope.js";
+import type { ManifestBuilder } from "./manifest-builder.js";
+import { composePrompt } from "./prompt-compose.js";
+import type { IdempotencyParts } from "./idempotency.js";
+
+/**
+ * Phase 2 agent-io pipeline (#AGC-PROMPT-SERIALIZATION + #ARC-CALL-SEMANTICS).
+ *
+ * Single seam combining prompt assembly, LLM runner invocation, envelope
+ * parsing/enrichment/matrix validation, and revision-pin recheck. The
+ * caller is responsible for persisting the envelope and turn — agent-io
+ * is read-only on the store.
+ */
+
+export type AgentIoOutcome =
+  | {
+      ok: true;
+      envelope: Envelope;
+      diagnosticsRef: string;
+      stalePins: { object_id: string; recorded_pin: string }[];
+    }
+  | {
+      ok: false;
+      stage: "lr_invoke" | "envelope_parse" | "envelope_enrich" | "matrix_validate";
+      reason: AgcInvalidReason | "lr_exit_status";
+      detail: string;
+      diagnosticsRef: string;
+    };
+
+export interface AgentIoInput {
+  agentProfileId: LlmAgentProfileId;
+  agentRoleInSession: AgentRole;
+  parentLoop: RunnerParentLoop;
+  phaseOrPurpose: string;
+  sessionId: string;
+  turnIndex: number;
+  manifest: ContextManifest;
+  workspaceRevisionPin: string;
+  /** Slice-local worktree path for inner; read-only marker for outer/middle. */
+  agentCwd: string;
+  timeoutSec: number;
+  /**
+   * Idempotency parts used by enrichEnvelope. The Caller composes these per
+   * SOC-IDEMPOTENCY 3-scope rules. agent-io does not invent the parts.
+   */
+  idempotency: IdempotencyParts;
+  /**
+   * Runtime metadata bag for AGC-OUTPUT-RUNTIME-ENRICH. Agent-side keys are
+   * already rejected upstream (AgentAuthoredEnvelope.strict()).
+   */
+  runtimeMetadata: Record<string, unknown>;
+}
+
+export interface AgentIoDeps {
+  llmRunner: LlmRunnerPort;
+  manifestBuilder: ManifestBuilder;
+}
+
+export async function callAgent(
+  input: AgentIoInput,
+  deps: AgentIoDeps,
+): Promise<AgentIoOutcome> {
+  const promptBody = composePrompt({
+    agentProfileId: input.agentProfileId,
+    agentRoleInSession: input.agentRoleInSession,
+    parentLoop: input.parentLoop,
+    phaseOrPurpose: input.phaseOrPurpose,
+    sessionId: input.sessionId,
+    turnIndex: input.turnIndex,
+    manifest: input.manifest,
+    workspaceRevisionPin: input.workspaceRevisionPin,
+  });
+  const promptRef = await writePromptTmp(input.sessionId, input.turnIndex, promptBody);
+
+  const runnerInput: LlmRunnerInput = {
+    agentProfileId: input.agentProfileId,
+    sessionId: input.sessionId,
+    turnIndex: input.turnIndex,
+    parentLoop: input.parentLoop,
+    purpose: input.phaseOrPurpose,
+    agentRoleInSession: input.agentRoleInSession,
+    promptRef,
+    sessionContextRef: null,
+    manifestId: input.manifest.manifest_id,
+    agentCwd: input.agentCwd,
+    timeoutSec: input.timeoutSec,
+    // The runner uses this as a transport-level dedup key. Envelope-level
+    // idempotency_key is composed below by enrichEnvelope.
+    idempotencyKey: "",
+  };
+  const r = await deps.llmRunner.invoke(runnerInput);
+  if (r.exitStatus !== "ok") {
+    return {
+      ok: false,
+      stage: "lr_invoke",
+      reason: "lr_exit_status",
+      detail: `LlmRunner exitStatus=${r.exitStatus}; envelopeRef=${r.envelopeRef}`,
+      diagnosticsRef: r.diagnosticsRef,
+    };
+  }
+  const envelopeBody = await readFile(r.envelopeRef, "utf8");
+  let raw: unknown;
+  try {
+    raw = JSON.parse(envelopeBody);
+  } catch (e) {
+    return {
+      ok: false,
+      stage: "envelope_parse",
+      reason: "schema_violation",
+      detail: `envelope body is not valid JSON: ${(e as Error).message}`,
+      diagnosticsRef: r.diagnosticsRef,
+    };
+  }
+  const parsed = parseAgentAuthored(raw);
+  if (!parsed.ok) {
+    return {
+      ok: false,
+      stage: "envelope_parse",
+      reason: parsed.reason,
+      detail: parsed.detail,
+      diagnosticsRef: r.diagnosticsRef,
+    };
+  }
+  // Header echo invariant: the agent must replay header fields back. We
+  // assert the seven echo fields match the prompt frontmatter.
+  const echo = checkHeaderEcho(parsed.value, input);
+  if (echo != null) {
+    return {
+      ok: false,
+      stage: "envelope_parse",
+      reason: "header_echo_mismatch",
+      detail: echo,
+      diagnosticsRef: r.diagnosticsRef,
+    };
+  }
+  const enriched = enrichEnvelope(parsed.value, {
+    idempotency: input.idempotency,
+    runtime_metadata: input.runtimeMetadata,
+  });
+  if (!enriched.ok) {
+    return {
+      ok: false,
+      stage: "envelope_enrich",
+      reason: enriched.reason,
+      detail: enriched.detail,
+      diagnosticsRef: r.diagnosticsRef,
+    };
+  }
+  const validated = validateEnvelope(enriched.value);
+  if (!validated.ok) {
+    return {
+      ok: false,
+      stage: "matrix_validate",
+      reason: validated.reason,
+      detail: validated.detail,
+      diagnosticsRef: r.diagnosticsRef,
+    };
+  }
+  const stale = await deps.manifestBuilder.recheckPins(input.manifest);
+  return {
+    ok: true,
+    envelope: validated.value,
+    diagnosticsRef: r.diagnosticsRef,
+    stalePins: stale.map((e) => ({
+      object_id: e.object_id,
+      recorded_pin: e.revision_pin,
+    })),
+  };
+}
+
+async function writePromptTmp(
+  sessionId: string,
+  turnIndex: number,
+  body: string,
+): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "llm-team-prompt-"));
+  const path = join(dir, `${sessionId}-${turnIndex}.md`);
+  await writeFile(path, body, "utf8");
+  return path;
+}
+
+function checkHeaderEcho(
+  envelope: AgentAuthoredEnvelope,
+  input: AgentIoInput,
+): string | null {
+  const mismatches: string[] = [];
+  const echo = (
+    field: string,
+    expected: string | number,
+    got: string | number,
+  ) => {
+    if (expected !== got) mismatches.push(`${field} expected=${expected} got=${got}`);
+  };
+  echo("session_id", input.sessionId, envelope.session_id);
+  echo("turn_index", input.turnIndex, envelope.turn_index);
+  echo("parent_loop", input.parentLoop, envelope.parent_loop);
+  echo("phase_or_purpose", input.phaseOrPurpose, envelope.phase_or_purpose);
+  echo("agent_profile_id", input.agentProfileId, envelope.agent_profile_id);
+  echo(
+    "agent_role_in_session",
+    input.agentRoleInSession,
+    envelope.agent_role_in_session,
+  );
+  echo("manifest_id", input.manifest.manifest_id, envelope.manifest_id);
+  return mismatches.length > 0 ? mismatches.join("; ") : null;
+}

--- a/src/application/prompt-compose.ts
+++ b/src/application/prompt-compose.ts
@@ -1,0 +1,89 @@
+import type { ContextManifest } from "../domain/schema/manifest.js";
+import type {
+  AgentProfileId,
+  AgentRoleInSession,
+  ParentLoop,
+} from "../domain/schema/contribution.js";
+
+/**
+ * 4-part prompt composition (#AGC-PROMPT-SERIALIZATION,
+ * #ARC-ADAPTER-PROMPT-CONTRACT).
+ *
+ * Layout: frontmatter (header echo) + `# Context` + `# Instruction` +
+ * `# Output Schema`. The frontmatter carries the seven echo fields the
+ * adapter contract requires (agent_profile_id, phase_or_purpose,
+ * manifest_id, session_id, turn_index, parent_loop, agent_role_in_session).
+ *
+ * The fenced manifest JSON is included verbatim in `# Context` so adapters
+ * (including the fake adapter's `__PIN_*__` placeholders) can resolve
+ * manifest entries without re-reading the manifest file.
+ *
+ * Role-specific instruction body and output schema are kept minimal —
+ * phase 5 prompt builders will expand them with knowledge artefacts.
+ */
+
+export interface ComposePromptInput {
+  agentProfileId: AgentProfileId;
+  agentRoleInSession: AgentRoleInSession;
+  parentLoop: ParentLoop;
+  phaseOrPurpose: string;
+  sessionId: string;
+  turnIndex: number;
+  manifest: ContextManifest;
+  workspaceRevisionPin: string;
+  /** Optional extra instruction body appended to the role default. */
+  extraInstruction?: string;
+}
+
+export function composePrompt(input: ComposePromptInput): string {
+  const fm = [
+    "---",
+    `agent_profile_id: ${input.agentProfileId}`,
+    `phase_or_purpose: ${input.phaseOrPurpose}`,
+    `manifest_id: ${input.manifest.manifest_id}`,
+    `session_id: ${input.sessionId}`,
+    `turn_index: ${input.turnIndex}`,
+    `parent_loop: ${input.parentLoop}`,
+    `agent_role_in_session: ${input.agentRoleInSession}`,
+    "---",
+  ].join("\n");
+  const manifestJson = JSON.stringify(input.manifest, null, 2);
+  const context = [
+    "# Context",
+    "",
+    "## Manifest",
+    "",
+    "```json",
+    manifestJson,
+    "```",
+    "",
+    `workspace_revision_pin: ${input.workspaceRevisionPin}`,
+  ].join("\n");
+  const instruction = [
+    "# Instruction",
+    "",
+    instructionBody(input),
+    input.extraInstruction ?? "",
+  ]
+    .filter((s) => s.length > 0)
+    .join("\n");
+  const outputSchema = [
+    "# Output Schema",
+    "",
+    "Emit a single ```json fenced block with the AGC-OUTPUT envelope.",
+    "Required header echo: session_id, turn_index, parent_loop,",
+    "phase_or_purpose, agent_profile_id, agent_role_in_session, manifest_id.",
+  ].join("\n");
+  return [fm, "", context, "", instruction, "", outputSchema, ""].join("\n");
+}
+
+function instructionBody(input: ComposePromptInput): string {
+  if (input.parentLoop === "inner" && input.phaseOrPurpose === "tdd_build") {
+    return [
+      "You are forge in the inner tdd_build loop.",
+      "Read the manifest, perform a single TDD step, and emit a patch envelope.",
+      "Set output_kind=patch, contribution_kind=lead_draft, tdd_phase ∈ {red_green, refactor}.",
+    ].join("\n");
+  }
+  return `You are ${input.agentProfileId} in the ${input.parentLoop} loop (${input.phaseOrPurpose}).`;
+}

--- a/src/application/ready-object.ts
+++ b/src/application/ready-object.ts
@@ -1,0 +1,185 @@
+import { newMonotonicId } from "../domain/ids.js";
+import {
+  DialogueSession,
+  type DialogueSession as DialogueSessionT,
+} from "../domain/schema/dialogue-session.js";
+import { Slice, type Slice as SliceT } from "../domain/schema/slice.js";
+import type { ClockPort } from "../ports/clock.js";
+import type { StorePort } from "../ports/store.js";
+import { layout } from "./persistence-layout.js";
+
+/**
+ * Phase 2 turn pickup — internal slices only, forge solo, inner tdd_build.
+ *
+ * `dialogue-coordinator` and `caller-dispatch` (phase 3) generalise this; the
+ * present module covers a single combination so the first e2e cycle has a
+ * deterministic entry point.
+ *
+ * Behaviour:
+ *   - Lists `slices/` and selects the oldest SLICE_READY internal slice.
+ *   - If the slice has no `current_session_id`, opens a new SESSION_OPEN
+ *     DialogueSession (lead_only, forge, inner, tdd_build) and advances the
+ *     slice to SLICE_BUILDING.
+ *   - If the slice already has a SESSION_OPEN session, returns that session
+ *     to continue (turn_index taken from session.current_turn_index).
+ *   - Returns null when no SLICE_READY internal slices exist.
+ *
+ * Idempotency: opening a session writes both records under
+ * `withFileLock(slice_path)` so concurrent runners cannot create two
+ * sessions for the same slice.
+ */
+
+export interface ReadyTurn {
+  slice: SliceT;
+  session: DialogueSessionT;
+  turnIndex: number;
+  /** Whether the session was newly opened by this pickup. */
+  newSession: boolean;
+}
+
+export interface PickReadyTurnDeps {
+  store: StorePort;
+  clock: ClockPort;
+}
+
+export async function pickReadyInnerTurn(
+  deps: PickReadyTurnDeps,
+): Promise<ReadyTurn | null> {
+  const slice = await pickOldestReadyInternalSlice(deps);
+  if (slice == null) return null;
+  return openOrResumeSession(slice, deps);
+}
+
+async function pickOldestReadyInternalSlice(
+  deps: PickReadyTurnDeps,
+): Promise<SliceT | null> {
+  const entries = await deps.store.list("slices");
+  const candidates: SliceT[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    const body = await deps.store.readText(`slices/${name}`);
+    if (body == null) continue;
+    let parsed: SliceT;
+    try {
+      parsed = Slice.parse(JSON.parse(body));
+    } catch {
+      continue;
+    }
+    if (parsed.slice_kind !== "internal") continue;
+    if (parsed.state !== "SLICE_READY" && parsed.state !== "SLICE_BUILDING")
+      continue;
+    candidates.push(parsed);
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => a.created_at.localeCompare(b.created_at));
+  return candidates[0]!;
+}
+
+async function openOrResumeSession(
+  slice: SliceT,
+  deps: PickReadyTurnDeps,
+): Promise<ReadyTurn> {
+  return deps.store.withFileLock(layout.slice(slice.slice_id), async () => {
+    const reread = await rereadSlice(slice.slice_id, deps);
+    const live = reread ?? slice;
+    if (live.current_session_id != null) {
+      const sessionBody = await deps.store.readText(
+        layout.sessionMetadata(live.current_session_id),
+      );
+      if (sessionBody == null)
+        throw new Error(
+          `slice ${live.slice_id} references session ${live.current_session_id} but metadata.json missing`,
+        );
+      const session = DialogueSession.parse(JSON.parse(sessionBody));
+      if (session.state !== "SESSION_OPEN") {
+        // The slice still claims the session but the session itself is
+        // converged/abandoned. Phase 3 caller-dispatch resolves this; in
+        // phase 2 we return null upstream by treating the slice as
+        // unavailable.
+        throw new SessionNotOpenError(slice.slice_id, session.session_id, session.state);
+      }
+      return {
+        slice: live,
+        session,
+        turnIndex: session.current_turn_index,
+        newSession: false,
+      };
+    }
+    const session = await openSession(live, deps);
+    const updated = Slice.parse({
+      ...live,
+      state: "SLICE_BUILDING",
+      current_session_id: session.session_id,
+      updated_at: deps.clock.isoNow(),
+    });
+    await deps.store.writeAtomic(
+      layout.slice(updated.slice_id),
+      JSON.stringify(updated, null, 2),
+    );
+    return {
+      slice: updated,
+      session,
+      turnIndex: session.current_turn_index,
+      newSession: true,
+    };
+  });
+}
+
+async function rereadSlice(
+  sliceId: string,
+  deps: PickReadyTurnDeps,
+): Promise<SliceT | null> {
+  const body = await deps.store.readText(layout.slice(sliceId));
+  if (body == null) return null;
+  return Slice.parse(JSON.parse(body));
+}
+
+async function openSession(
+  slice: SliceT,
+  deps: PickReadyTurnDeps,
+): Promise<DialogueSessionT> {
+  const sessionId = newMonotonicId(deps.clock.now());
+  const session = DialogueSession.parse({
+    session_id: sessionId,
+    parent_object_kind: "slice",
+    parent_object_id: slice.slice_id,
+    parent_loop: "inner",
+    purpose: "tdd_build",
+    participants: [{ agent_profile_id: "forge", role: "lead" }],
+    session_termination: {
+      finalization_rule: "lead_only",
+      required_evidence: [
+        {
+          kind: "verification_green",
+          acceptance_tests: slice.acceptance_tests.map((a) => `${a.path}:${a.name}`),
+          deterministic_checks: [],
+        },
+      ],
+      composite_rule: "evidence_only",
+    },
+    workspace_revision_pin: slice.trunk_base_revision,
+    current_turn_index: 0,
+    state: "SESSION_OPEN",
+    max_turns: 10,
+    created_at: deps.clock.isoNow(),
+    updated_at: deps.clock.isoNow(),
+  });
+  await deps.store.writeAtomic(
+    layout.sessionMetadata(sessionId),
+    JSON.stringify(session, null, 2),
+  );
+  return session;
+}
+
+export class SessionNotOpenError extends Error {
+  constructor(
+    readonly sliceId: string,
+    readonly sessionId: string,
+    readonly state: string,
+  ) {
+    super(
+      `slice ${sliceId} session ${sessionId} is in state ${state}, expected SESSION_OPEN`,
+    );
+    this.name = "SessionNotOpenError";
+  }
+}

--- a/src/application/ready-object.ts
+++ b/src/application/ready-object.ts
@@ -6,6 +6,8 @@ import {
 import { Slice, type Slice as SliceT } from "../domain/schema/slice.js";
 import type { ClockPort } from "../ports/clock.js";
 import type { StorePort } from "../ports/store.js";
+import { idempotencyKey } from "./idempotency.js";
+import type { LedgerAppender } from "./ledger.js";
 import { layout } from "./persistence-layout.js";
 
 /**
@@ -19,10 +21,12 @@ import { layout } from "./persistence-layout.js";
  *   - Lists `slices/` and selects the oldest SLICE_READY internal slice.
  *   - If the slice has no `current_session_id`, opens a new SESSION_OPEN
  *     DialogueSession (lead_only, forge, inner, tdd_build) and advances the
- *     slice to SLICE_BUILDING.
+ *     slice to SLICE_BUILDING. Both writes happen inside `withFileLock` and
+ *     are followed by a ledger row (`action_kind=session_progress`,
+ *     `to_state=SLICE_BUILDING`) so the audit trail covers the transition.
  *   - If the slice already has a SESSION_OPEN session, returns that session
  *     to continue (turn_index taken from session.current_turn_index).
- *   - Returns null when no SLICE_READY internal slices exist.
+ *   - Returns null when no SLICE_READY/SLICE_BUILDING internal slices exist.
  *
  * Idempotency: opening a session writes both records under
  * `withFileLock(slice_path)` so concurrent runners cannot create two
@@ -40,6 +44,9 @@ export interface ReadyTurn {
 export interface PickReadyTurnDeps {
   store: StorePort;
   clock: ClockPort;
+  ledger: LedgerAppender;
+  callerId: string;
+  targetId: string;
 }
 
 export async function pickReadyInnerTurn(
@@ -92,11 +99,11 @@ async function openOrResumeSession(
         );
       const session = DialogueSession.parse(JSON.parse(sessionBody));
       if (session.state !== "SESSION_OPEN") {
-        // The slice still claims the session but the session itself is
-        // converged/abandoned. Phase 3 caller-dispatch resolves this; in
-        // phase 2 we return null upstream by treating the slice as
-        // unavailable.
-        throw new SessionNotOpenError(slice.slice_id, session.session_id, session.state);
+        throw new SessionNotOpenError(
+          slice.slice_id,
+          session.session_id,
+          session.state,
+        );
       }
       return {
         slice: live,
@@ -105,6 +112,7 @@ async function openOrResumeSession(
         newSession: false,
       };
     }
+    const previousState = live.state;
     const session = await openSession(live, deps);
     const updated = Slice.parse({
       ...live,
@@ -116,6 +124,51 @@ async function openOrResumeSession(
       layout.slice(updated.slice_id),
       JSON.stringify(updated, null, 2),
     );
+
+    // P0 fix (PR #61 review): emit a ledger row for the SLICE_READY →
+    // SLICE_BUILDING transition + session-open so the audit trail does
+    // not skip the transition. Caller-side idempotency uses the canonical
+    // compositor.
+    await deps.ledger.appendTransition({
+      transition_id: newMonotonicId(deps.clock.now()),
+      target_id: deps.targetId,
+      object_id: updated.slice_id,
+      object_kind: "slice",
+      from_state: previousState,
+      to_state: "SLICE_BUILDING",
+      loop_kind: "inner",
+      phase: null,
+      slice_id: updated.slice_id,
+      slice_kind: updated.slice_kind,
+      dod_revision: updated.dod_revision_pin,
+      session_id: session.session_id,
+      turn_index: null,
+      slot_kind: "delivery",
+      agent_profile_id: "forge",
+      contribution_kind: null,
+      action_kind: "session_progress",
+      final_verdict: null,
+      caller_id: deps.callerId,
+      manifest_id: null,
+      input_revision_pins: [],
+      output_hash: null,
+      verification_run_id: null,
+      metric_run_id: null,
+      idempotency_key: idempotencyKey({
+        scope: "external_observation",
+        parts: {
+          kind: "session_open",
+          slice_id: updated.slice_id,
+          session_id: session.session_id,
+        },
+      }),
+      lease_token: null,
+      lease_kind: null,
+      result: "applied",
+      result_detail: null,
+      timestamp: deps.clock.isoNow(),
+    });
+
     return {
       slice: updated,
       session,
@@ -151,7 +204,9 @@ async function openSession(
       required_evidence: [
         {
           kind: "verification_green",
-          acceptance_tests: slice.acceptance_tests.map((a) => `${a.path}:${a.name}`),
+          acceptance_tests: slice.acceptance_tests.map(
+            (a) => `${a.path}:${a.name}`,
+          ),
           deterministic_checks: [],
         },
       ],

--- a/src/application/session-turn-persist.ts
+++ b/src/application/session-turn-persist.ts
@@ -1,0 +1,94 @@
+import {
+  DialogueSession,
+  type DialogueSession as DialogueSessionT,
+} from "../domain/schema/dialogue-session.js";
+import type { Envelope } from "../domain/schema/envelope.js";
+import {
+  SessionTurn,
+  type SessionTurn as SessionTurnT,
+  type CallerRoutingDecision,
+} from "../domain/schema/session-turn.js";
+import type { ClockPort } from "../ports/clock.js";
+import type { StorePort } from "../ports/store.js";
+import { layout } from "./persistence-layout.js";
+
+/**
+ * SessionTurn persistence (SOC-SESSION-LIFECYCLE).
+ *
+ * Single seam for writing a turn to `sessions/<id>/turns/<n>.json` and
+ * advancing the session's `current_turn_index` + workspace_revision_pin.
+ * The caller supplies the embedded canonical envelope, the routing
+ * decision, the new workspace_commit, and the verification_run_id (or
+ * null for non-inner / failure turns).
+ *
+ * The function is idempotent on the (session_id, turn_index) pair: if a
+ * turn file already exists at that path, the write is rejected.
+ */
+
+export interface PersistTurnInput {
+  session: DialogueSessionT;
+  envelope: Envelope;
+  callerRoutingDecision: CallerRoutingDecision | null;
+  workspaceCommit: string | null;
+  verificationRunId: string | null;
+  /**
+   * Pin override for the session's workspace_revision_pin after this turn.
+   * Typically the same as workspaceCommit when present, otherwise unchanged.
+   */
+  newWorkspaceRevisionPin?: string | null;
+}
+
+export interface PersistTurnDeps {
+  store: StorePort;
+  clock: ClockPort;
+}
+
+export class TurnAlreadyPersistedError extends Error {
+  constructor(readonly sessionId: string, readonly turnIndex: number) {
+    super(`turn already persisted: session=${sessionId} turn_index=${turnIndex}`);
+    this.name = "TurnAlreadyPersistedError";
+  }
+}
+
+export async function persistSessionTurn(
+  input: PersistTurnInput,
+  deps: PersistTurnDeps,
+): Promise<{ turn: SessionTurnT; session: DialogueSessionT }> {
+  const sessionId = input.session.session_id;
+  const turnIndex = input.envelope.turn_index;
+  return deps.store.withFileLock(
+    layout.sessionMetadata(sessionId),
+    async () => {
+      const turnPath = layout.sessionTurn(sessionId, turnIndex);
+      if (await deps.store.exists(turnPath)) {
+        throw new TurnAlreadyPersistedError(sessionId, turnIndex);
+      }
+      const turn = SessionTurn.parse({
+        session_id: sessionId,
+        turn_index: turnIndex,
+        agent_profile_id: input.envelope.agent_profile_id,
+        input_manifest_id: input.envelope.manifest_id,
+        input_turn_log_snapshot_ref: null,
+        output_envelope: input.envelope,
+        next_action_request: input.envelope.next_action_request,
+        caller_routing_decision: input.callerRoutingDecision,
+        workspace_commit: input.workspaceCommit,
+        verification_result_ref: input.verificationRunId,
+        recorded_at: deps.clock.isoNow(),
+      });
+      await deps.store.writeAtomic(turnPath, JSON.stringify(turn, null, 2));
+      const updated = DialogueSession.parse({
+        ...input.session,
+        current_turn_index: turnIndex + 1,
+        workspace_revision_pin:
+          input.newWorkspaceRevisionPin ?? input.session.workspace_revision_pin,
+        updated_at: deps.clock.isoNow(),
+      });
+      await deps.store.writeAtomic(
+        layout.sessionMetadata(sessionId),
+        JSON.stringify(updated, null, 2),
+      );
+      return { turn, session: updated };
+    },
+  );
+}

--- a/src/application/turn-worker.ts
+++ b/src/application/turn-worker.ts
@@ -3,12 +3,13 @@ import {
   DialogueSession,
   type DialogueSession as DialogueSessionT,
 } from "../domain/schema/dialogue-session.js";
-import { LedgerRow } from "../domain/schema/ledger.js";
 import {
   SliceMerge,
   type SliceMerge as SliceMergeT,
 } from "../domain/schema/slice-merge.js";
 import { Slice, type Slice as SliceT } from "../domain/schema/slice.js";
+import type { Envelope } from "../domain/schema/envelope.js";
+import type { CallerRoutingDecision } from "../domain/schema/session-turn.js";
 import type { ClockPort } from "../ports/clock.js";
 import type { LlmRunnerPort } from "../ports/llm-runner.js";
 import type { StorePort } from "../ports/store.js";
@@ -17,9 +18,14 @@ import type {
   VerificationPort,
 } from "../ports/verification.js";
 import type { WorkspacePort } from "../ports/workspace.js";
-import { callAgent } from "./agent-io.js";
+import { callAgent, type AgentIoOutcome } from "./agent-io.js";
+import { idempotencyKey } from "./idempotency.js";
 import type { LedgerAppender } from "./ledger.js";
-import { ManifestBuilder, type ManifestEntryDraft, type RevisionPinResolver } from "./manifest-builder.js";
+import {
+  ManifestBuilder,
+  type ManifestEntryDraft,
+  type RevisionPinResolver,
+} from "./manifest-builder.js";
 import { layout } from "./persistence-layout.js";
 import { pickReadyInnerTurn } from "./ready-object.js";
 import { persistSessionTurn } from "./session-turn-persist.js";
@@ -32,7 +38,7 @@ import { runInnerVerification } from "./verification-runner.js";
  *   1. Pickup ready inner turn (forge / tdd_build / internal slice)
  *   2. Lease (turn_index CAS via session-turn-persist)
  *   3. Manifest + Workspace + Prompt
- *   4. Invoke + Validate + Pin Recheck (agent-io)
+ *   4. Invoke + Validate + Pin Recheck (agent-io) + stale-pin gate
  *   5. SessionTurn Persist
  *   6. Cleanup + Ledger
  *
@@ -40,6 +46,15 @@ import { runInnerVerification } from "./verification-runner.js";
  * inlines the caller-dispatch side-effects up to
  * `SLICE_BUILDING → SLICE_REVIEWING + SM_DRAFT → SM_READY_FOR_REVIEW`.
  * The middle review session itself is phase 3.
+ *
+ * Crash-recovery posture (PR #61 review feedback):
+ *   - Every off-happy-path return emits an `invalid` ledger row so audit
+ *     trail is never broken by an early return (callAgent failure,
+ *     stale-pin gate, etc.).
+ *   - Success path persists the slice transition (current_session_id=null +
+ *     SLICE_REVIEWING) BEFORE marking the session CONVERGED — otherwise a
+ *     mid-sequence crash would leave a CONVERGED session referenced by a
+ *     SLICE_BUILDING slice, which `ready-object` cannot recover from.
  *
  * No retry. A failed verification or invalid envelope ends the cycle —
  * the slice stays SLICE_BUILDING for the next pickup, and the operator (or
@@ -70,6 +85,12 @@ export type TurnWorkerOutcome =
       stage: string;
       reason: string;
       detail: string;
+    }
+  | {
+      kind: "stale_pins";
+      sessionId: string;
+      sliceId: string;
+      stalePins: { object_id: string; recorded_pin: string }[];
     };
 
 export interface TurnWorkerCfg {
@@ -98,6 +119,9 @@ export async function runOneInnerTurn(
   const ready = await pickReadyInnerTurn({
     store: deps.store,
     clock: deps.clock,
+    ledger: deps.ledger,
+    callerId: deps.cfg.callerId,
+    targetId: deps.cfg.targetId,
   });
   if (ready == null) {
     return { kind: "noop", detail: "no SLICE_READY/SLICE_BUILDING internal slices" };
@@ -142,6 +166,16 @@ export async function runOneInnerTurn(
   );
 
   // Step 4 — Invoke + Validate + Pin Recheck
+  const turnIdempotency = idempotencyKey({
+    scope: "per_turn",
+    parts: {
+      session_id: session.session_id,
+      turn_index: turnIndex,
+      agent_profile_id: "forge",
+      manifest_id: manifest.manifest_id,
+      input_revision_pins: manifest.entries.map((e) => e.revision_pin),
+    },
+  });
   const agentOut = await callAgent(
     {
       agentProfileId: "forge",
@@ -169,6 +203,19 @@ export async function runOneInnerTurn(
     { llmRunner: deps.llmRunner, manifestBuilder },
   );
   if (!agentOut.ok) {
+    // P0 fix (PR #61 review): record an invalid ledger row so the audit
+    // trail covers envelope/header failures. Phase 4 failure-policy will
+    // promote repeat-invalids to ABANDONED; phase-2 just stops.
+    await emitInvalidTurn(
+      deps,
+      slice,
+      session,
+      turnIndex,
+      manifest.manifest_id,
+      manifest.entries.map((e) => e.revision_pin),
+      turnIdempotency,
+      agentOut,
+    );
     return {
       kind: "invalid_envelope",
       sessionId: session.session_id,
@@ -176,6 +223,33 @@ export async function runOneInnerTurn(
       stage: agentOut.stage,
       reason: agentOut.reason,
       detail: agentOut.detail,
+    };
+  }
+  // P0 fix (PR #61 review): stalePins gate. Pin recheck after callAgent
+  // detected drift in a manifest entry — refuse to commit/verify so a
+  // stale-context turn cannot promote to SLICE_REVIEWING.
+  if (agentOut.stalePins.length > 0) {
+    await emitInvalidTurn(
+      deps,
+      slice,
+      session,
+      turnIndex,
+      manifest.manifest_id,
+      manifest.entries.map((e) => e.revision_pin),
+      turnIdempotency,
+      {
+        ok: false,
+        stage: "matrix_validate",
+        reason: "missing_revision_pins",
+        detail: `stale_pins: ${agentOut.stalePins.map((p) => p.object_id).join(",")}`,
+        diagnosticsRef: agentOut.diagnosticsRef,
+      },
+    );
+    return {
+      kind: "stale_pins",
+      sessionId: session.session_id,
+      sliceId: slice.slice_id,
+      stalePins: agentOut.stalePins,
     };
   }
 
@@ -204,15 +278,12 @@ export async function runOneInnerTurn(
   );
 
   // Step 5 — SessionTurn persist (CAS via withFileLock + exists check)
-  const { turn, session: sessionAfterTurn } = await persistSessionTurn(
+  const callerRoutingDecision = computeCallerRoutingDecision(agentOut.envelope);
+  const { session: sessionAfterTurn } = await persistSessionTurn(
     {
       session,
       envelope: agentOut.envelope,
-      callerRoutingDecision: {
-        decision: "dropped",
-        decision_reason: "single-agent inner session has no next_action_request to route",
-        resolved_addressed_to: null,
-      },
+      callerRoutingDecision,
       workspaceCommit: commit.commit,
       verificationRunId: verificationRun.verification_run_id,
       newWorkspaceRevisionPin: commit.commit,
@@ -266,26 +337,19 @@ export async function runOneInnerTurn(
     };
   }
 
-  // Step 6b — phase-2 caller-dispatch inline:
-  //   session CONVERGED tests_green
-  //   slice SLICE_BUILDING → SLICE_REVIEWING
-  //   SliceMerge SM_DRAFT → SM_READY_FOR_REVIEW
-  const finalized = DialogueSession.parse({
-    ...sessionAfterTurn,
-    state: "CONVERGED",
-    final_verdict: "tests_green",
-    finalization_decision: "required_evidence",
-    updated_at: deps.clock.isoNow(),
-  });
-  await deps.store.writeAtomic(
-    layout.sessionMetadata(finalized.session_id),
-    JSON.stringify(finalized, null, 2),
-  );
-
+  // Step 6b — phase-2 caller-dispatch inline (atomicity-aware ordering):
+  //   1. Create SliceMerge (phase-3 reviewer pickup target)
+  //   2. Slice → SLICE_REVIEWING + clear current_session_id   ← BEFORE session
+  //   3. Session → CONVERGED                                  ← LAST
+  // Rationale: if a crash happens between (2) and (3), the slice is no
+  // longer pickable (SLICE_REVIEWING) and the leftover SESSION_OPEN session
+  // is orphaned but harmless. The opposite ordering would leave a CONVERGED
+  // session referenced by SLICE_BUILDING, which `ready-object` rejects with
+  // SessionNotOpenError — unrecoverable in phase 2.
   const sliceMerge = await openSliceMergeReadyForReview(
     {
       slice,
-      session: finalized,
+      session: sessionAfterTurn,
       preMergeRevision: commit.commit,
       verificationRunId: verificationRun.verification_run_id,
     },
@@ -303,41 +367,19 @@ export async function runOneInnerTurn(
     JSON.stringify(reviewingSlice, null, 2),
   );
 
-  // Ledger rows for the dispatch side-effects
-  const sessionFinalizeKey = `per_session_outcome|${finalized.session_id}|tests_green|required_evidence|${commit.commit}`;
-  await deps.ledger.appendTransition({
-    transition_id: newMonotonicId(deps.clock.now()),
-    target_id: deps.cfg.targetId,
-    object_id: finalized.session_id,
-    object_kind: "dialogue_session",
-    from_state: "SESSION_OPEN",
-    to_state: "CONVERGED",
-    loop_kind: "inner",
-    phase: null,
-    slice_id: slice.slice_id,
-    slice_kind: slice.slice_kind,
-    dod_revision: slice.dod_revision_pin,
-    session_id: finalized.session_id,
-    turn_index: turnIndex,
-    slot_kind: "delivery",
-    agent_profile_id: "forge",
-    contribution_kind: null,
-    action_kind: "session_finalize",
+  const finalized = DialogueSession.parse({
+    ...sessionAfterTurn,
+    state: "CONVERGED",
     final_verdict: "tests_green",
-    caller_id: deps.cfg.callerId,
-    manifest_id: null,
-    input_revision_pins: [],
-    output_hash: null,
-    verification_run_id: verificationRun.verification_run_id,
-    metric_run_id: null,
-    idempotency_key: sessionFinalizeKey,
-    lease_token: null,
-    lease_kind: null,
-    result: "applied",
-    result_detail: null,
-    timestamp: deps.clock.isoNow(),
+    finalization_decision: "required_evidence",
+    updated_at: deps.clock.isoNow(),
   });
+  await deps.store.writeAtomic(
+    layout.sessionMetadata(finalized.session_id),
+    JSON.stringify(finalized, null, 2),
+  );
 
+  // Ledger rows for the dispatch side-effects (canonical idempotency keys)
   await deps.ledger.appendTransition({
     transition_id: newMonotonicId(deps.clock.now()),
     target_id: deps.cfg.targetId,
@@ -363,7 +405,14 @@ export async function runOneInnerTurn(
     output_hash: null,
     verification_run_id: verificationRun.verification_run_id,
     metric_run_id: null,
-    idempotency_key: `slice_merge_open|${sliceMerge.slice_merge_id}`,
+    idempotency_key: idempotencyKey({
+      scope: "per_merge",
+      parts: {
+        slice_merge_id: sliceMerge.slice_merge_id,
+        pre_merge_workspace_revision: commit.commit,
+        trunk_base_revision_at_merge_attempt: slice.trunk_base_revision,
+      },
+    }),
     lease_token: null,
     lease_kind: null,
     result: "applied",
@@ -376,7 +425,7 @@ export async function runOneInnerTurn(
     target_id: deps.cfg.targetId,
     object_id: slice.slice_id,
     object_kind: "slice",
-    from_state: "SLICE_BUILDING",
+    from_state: slice.state,
     to_state: "SLICE_REVIEWING",
     loop_kind: "inner",
     phase: null,
@@ -396,7 +445,14 @@ export async function runOneInnerTurn(
     output_hash: null,
     verification_run_id: verificationRun.verification_run_id,
     metric_run_id: null,
-    idempotency_key: `slice_state|${slice.slice_id}|SLICE_REVIEWING`,
+    idempotency_key: idempotencyKey({
+      scope: "external_observation",
+      parts: {
+        kind: "slice_state",
+        slice_id: slice.slice_id,
+        to_state: "SLICE_REVIEWING",
+      },
+    }),
     lease_token: null,
     lease_kind: null,
     result: "applied",
@@ -404,8 +460,47 @@ export async function runOneInnerTurn(
     timestamp: deps.clock.isoNow(),
   });
 
-  void turn;
-  void LedgerRow; // imported for type-symmetry; runtime usage above goes through appendTransition's own validator
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.cfg.targetId,
+    object_id: finalized.session_id,
+    object_kind: "dialogue_session",
+    from_state: "SESSION_OPEN",
+    to_state: "CONVERGED",
+    loop_kind: "inner",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: finalized.session_id,
+    turn_index: turnIndex,
+    slot_kind: "delivery",
+    agent_profile_id: "forge",
+    contribution_kind: null,
+    action_kind: "session_finalize",
+    final_verdict: "tests_green",
+    caller_id: deps.cfg.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: verificationRun.verification_run_id,
+    metric_run_id: null,
+    idempotency_key: idempotencyKey({
+      scope: "per_session_outcome",
+      parts: {
+        session_id: finalized.session_id,
+        final_verdict: "tests_green",
+        finalization_decision: "required_evidence",
+        workspace_revision_pin_at_convergence: commit.commit,
+      },
+    }),
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: null,
+    timestamp: deps.clock.isoNow(),
+  });
+
   return {
     kind: "converged",
     sessionId: finalized.session_id,
@@ -413,6 +508,67 @@ export async function runOneInnerTurn(
     sliceMergeId: sliceMerge.slice_merge_id,
     verificationRunId: verificationRun.verification_run_id,
     workspaceCommit: commit.commit,
+  };
+}
+
+async function emitInvalidTurn(
+  deps: TurnWorkerDeps,
+  slice: SliceT,
+  session: DialogueSessionT,
+  turnIndex: number,
+  manifestId: string,
+  inputPins: string[],
+  turnIdempotencyKey: string,
+  failure: Extract<AgentIoOutcome, { ok: false }>,
+): Promise<void> {
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.cfg.targetId,
+    object_id: session.session_id,
+    object_kind: "session_turn",
+    from_state: null,
+    to_state: `turn_index=${turnIndex}`,
+    loop_kind: "inner",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: session.session_id,
+    turn_index: turnIndex,
+    slot_kind: "delivery",
+    agent_profile_id: "forge",
+    contribution_kind: null,
+    action_kind: "session_progress",
+    final_verdict: null,
+    caller_id: deps.cfg.callerId,
+    manifest_id: manifestId,
+    input_revision_pins: inputPins,
+    output_hash: null,
+    verification_run_id: null,
+    metric_run_id: null,
+    idempotency_key: turnIdempotencyKey,
+    lease_token: null,
+    lease_kind: null,
+    result: "invalid",
+    result_detail: `${failure.stage}/${failure.reason}: ${truncate(failure.detail, 200)}`,
+    timestamp: deps.clock.isoNow(),
+  });
+}
+
+function computeCallerRoutingDecision(envelope: Envelope): CallerRoutingDecision {
+  const nar = envelope.next_action_request;
+  if (nar == null) {
+    return {
+      decision: "dropped",
+      decision_reason:
+        "single-agent inner session has no next_action_request to route",
+      resolved_addressed_to: null,
+    };
+  }
+  return {
+    decision: "accepted",
+    decision_reason: `accepted next_action_request from ${envelope.agent_profile_id} (intent="${truncate(nar.intent, 80)}")`,
+    resolved_addressed_to: typeof nar.addressed_to === "string" ? nar.addressed_to : null,
   };
 }
 

--- a/src/application/turn-worker.ts
+++ b/src/application/turn-worker.ts
@@ -1,0 +1,491 @@
+import { newMonotonicId } from "../domain/ids.js";
+import {
+  DialogueSession,
+  type DialogueSession as DialogueSessionT,
+} from "../domain/schema/dialogue-session.js";
+import { LedgerRow } from "../domain/schema/ledger.js";
+import {
+  SliceMerge,
+  type SliceMerge as SliceMergeT,
+} from "../domain/schema/slice-merge.js";
+import { Slice, type Slice as SliceT } from "../domain/schema/slice.js";
+import type { ClockPort } from "../ports/clock.js";
+import type { LlmRunnerPort } from "../ports/llm-runner.js";
+import type { StorePort } from "../ports/store.js";
+import type {
+  CommandSpec,
+  VerificationPort,
+} from "../ports/verification.js";
+import type { WorkspacePort } from "../ports/workspace.js";
+import { callAgent } from "./agent-io.js";
+import type { LedgerAppender } from "./ledger.js";
+import { ManifestBuilder, type ManifestEntryDraft, type RevisionPinResolver } from "./manifest-builder.js";
+import { layout } from "./persistence-layout.js";
+import { pickReadyInnerTurn } from "./ready-object.js";
+import { persistSessionTurn } from "./session-turn-persist.js";
+import { runInnerVerification } from "./verification-runner.js";
+
+/**
+ * Phase 2 turn worker — single-process, single-agent inner cycle.
+ *
+ * Runs the 6-step pipeline from `pipeline-end-to-end.md` §Turn Worker Cycle:
+ *   1. Pickup ready inner turn (forge / tdd_build / internal slice)
+ *   2. Lease (turn_index CAS via session-turn-persist)
+ *   3. Manifest + Workspace + Prompt
+ *   4. Invoke + Validate + Pin Recheck (agent-io)
+ *   5. SessionTurn Persist
+ *   6. Cleanup + Ledger
+ *
+ * Plus the phase-2 gate: when the turn yields tests_green, this function
+ * inlines the caller-dispatch side-effects up to
+ * `SLICE_BUILDING → SLICE_REVIEWING + SM_DRAFT → SM_READY_FOR_REVIEW`.
+ * The middle review session itself is phase 3.
+ *
+ * No retry. A failed verification or invalid envelope ends the cycle —
+ * the slice stays SLICE_BUILDING for the next pickup, and the operator (or
+ * phase-4 failure-policy) decides next steps.
+ */
+
+export type TurnWorkerOutcome =
+  | { kind: "noop"; detail: string }
+  | {
+      kind: "converged";
+      sessionId: string;
+      sliceId: string;
+      sliceMergeId: string;
+      verificationRunId: string;
+      workspaceCommit: string;
+    }
+  | {
+      kind: "verification_failed";
+      sessionId: string;
+      sliceId: string;
+      verificationRunId: string;
+      workspaceCommit: string;
+    }
+  | {
+      kind: "invalid_envelope";
+      sessionId: string;
+      sliceId: string;
+      stage: string;
+      reason: string;
+      detail: string;
+    };
+
+export interface TurnWorkerCfg {
+  callerId: string;
+  targetId: string;
+  testCommands: (workspacePath: string) => CommandSpec[];
+  environmentFingerprint: string;
+  workspacePinSourceLabel?: string;
+  agentTimeoutSec?: number;
+}
+
+export interface TurnWorkerDeps {
+  store: StorePort;
+  clock: ClockPort;
+  llmRunner: LlmRunnerPort;
+  workspace: WorkspacePort;
+  verification: VerificationPort;
+  ledger: LedgerAppender;
+  cfg: TurnWorkerCfg;
+}
+
+export async function runOneInnerTurn(
+  deps: TurnWorkerDeps,
+): Promise<TurnWorkerOutcome> {
+  // Step 1 — Pickup
+  const ready = await pickReadyInnerTurn({
+    store: deps.store,
+    clock: deps.clock,
+  });
+  if (ready == null) {
+    return { kind: "noop", detail: "no SLICE_READY/SLICE_BUILDING internal slices" };
+  }
+  const { slice, session, turnIndex } = ready;
+
+  // Step 3 — Workspace prep
+  const prep = await deps.workspace.prepareInnerWorkspace({
+    sliceId: slice.slice_id,
+    trunkBaseRevision: slice.trunk_base_revision,
+  });
+
+  // Step 3 — Manifest build (slice body + dod_revision)
+  const drafts: ManifestEntryDraft[] = [
+    {
+      object_kind: "slice",
+      object_id: slice.slice_id,
+      fetch_scope: "body",
+      required: true,
+      purpose: "primary input",
+    },
+    {
+      object_kind: "code_tree",
+      object_id: slice.slice_id,
+      fetch_scope: "tree",
+      required: false,
+      purpose: "self-fetch",
+    },
+  ];
+  const pinResolver = new SliceLocalPinResolver(slice, prep.headBefore);
+  const manifestBuilder = new ManifestBuilder(pinResolver, deps.clock);
+  const manifest = await manifestBuilder.build({
+    session_id: session.session_id,
+    turn_index: turnIndex,
+    purpose: "tdd_build",
+    target: { object_kind: "slice", object_id: slice.slice_id },
+    drafts,
+  });
+  await deps.store.writeAtomic(
+    layout.manifest(manifest.manifest_id),
+    JSON.stringify(manifest, null, 2),
+  );
+
+  // Step 4 — Invoke + Validate + Pin Recheck
+  const agentOut = await callAgent(
+    {
+      agentProfileId: "forge",
+      agentRoleInSession: "lead",
+      parentLoop: "inner",
+      phaseOrPurpose: "tdd_build",
+      sessionId: session.session_id,
+      turnIndex,
+      manifest,
+      workspaceRevisionPin: prep.headBefore,
+      agentCwd: prep.agentCwd,
+      timeoutSec: deps.cfg.agentTimeoutSec ?? 120,
+      idempotency: {
+        scope: "per_turn",
+        parts: {
+          session_id: session.session_id,
+          turn_index: turnIndex,
+          agent_profile_id: "forge",
+          manifest_id: manifest.manifest_id,
+          input_revision_pins: manifest.entries.map((e) => e.revision_pin),
+        },
+      },
+      runtimeMetadata: { workspace_pin_before: prep.headBefore },
+    },
+    { llmRunner: deps.llmRunner, manifestBuilder },
+  );
+  if (!agentOut.ok) {
+    return {
+      kind: "invalid_envelope",
+      sessionId: session.session_id,
+      sliceId: slice.slice_id,
+      stage: agentOut.stage,
+      reason: agentOut.reason,
+      detail: agentOut.detail,
+    };
+  }
+
+  // Step 4b — apply patch artefacts to the worktree, then commit
+  const files = extractPatchFiles(agentOut.envelope.artifacts);
+  const commitMessage = `[forge] ${truncate(agentOut.envelope.summary, 70)}`;
+  const commit = await deps.workspace.commit({
+    sliceId: slice.slice_id,
+    message: commitMessage,
+    files,
+  });
+
+  // Verification (#RGC-VERIFICATION inner = synchronous post-commit)
+  const verificationRun = await runInnerVerification(
+    {
+      targetId: deps.cfg.targetId,
+      targetRevision: commit.commit,
+      testCommands: deps.cfg.testCommands(prep.agentCwd),
+      environmentFingerprint: deps.cfg.environmentFingerprint,
+    },
+    {
+      verification: deps.verification,
+      store: deps.store,
+      clock: deps.clock,
+    },
+  );
+
+  // Step 5 — SessionTurn persist (CAS via withFileLock + exists check)
+  const { turn, session: sessionAfterTurn } = await persistSessionTurn(
+    {
+      session,
+      envelope: agentOut.envelope,
+      callerRoutingDecision: {
+        decision: "dropped",
+        decision_reason: "single-agent inner session has no next_action_request to route",
+        resolved_addressed_to: null,
+      },
+      workspaceCommit: commit.commit,
+      verificationRunId: verificationRun.verification_run_id,
+      newWorkspaceRevisionPin: commit.commit,
+    },
+    { store: deps.store, clock: deps.clock },
+  );
+
+  // Step 6a — ledger row for the turn itself (action_kind=session_progress)
+  const turnPins = manifest.entries.map((e) => e.revision_pin);
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.cfg.targetId,
+    object_id: session.session_id,
+    object_kind: "session_turn",
+    from_state: null,
+    to_state: `turn_index=${turnIndex}`,
+    loop_kind: "inner",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: session.session_id,
+    turn_index: turnIndex,
+    slot_kind: "delivery",
+    agent_profile_id: "forge",
+    contribution_kind: agentOut.envelope.contribution_kind,
+    action_kind: "session_progress",
+    final_verdict: null,
+    caller_id: deps.cfg.callerId,
+    manifest_id: manifest.manifest_id,
+    input_revision_pins: turnPins,
+    output_hash: null,
+    verification_run_id: verificationRun.verification_run_id,
+    metric_run_id: null,
+    idempotency_key: agentOut.envelope.idempotency_key,
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: null,
+    timestamp: deps.clock.isoNow(),
+  });
+
+  // Verification failed → no further dispatch. Session stays SESSION_OPEN.
+  if (verificationRun.result !== "pass") {
+    return {
+      kind: "verification_failed",
+      sessionId: session.session_id,
+      sliceId: slice.slice_id,
+      verificationRunId: verificationRun.verification_run_id,
+      workspaceCommit: commit.commit,
+    };
+  }
+
+  // Step 6b — phase-2 caller-dispatch inline:
+  //   session CONVERGED tests_green
+  //   slice SLICE_BUILDING → SLICE_REVIEWING
+  //   SliceMerge SM_DRAFT → SM_READY_FOR_REVIEW
+  const finalized = DialogueSession.parse({
+    ...sessionAfterTurn,
+    state: "CONVERGED",
+    final_verdict: "tests_green",
+    finalization_decision: "required_evidence",
+    updated_at: deps.clock.isoNow(),
+  });
+  await deps.store.writeAtomic(
+    layout.sessionMetadata(finalized.session_id),
+    JSON.stringify(finalized, null, 2),
+  );
+
+  const sliceMerge = await openSliceMergeReadyForReview(
+    {
+      slice,
+      session: finalized,
+      preMergeRevision: commit.commit,
+      verificationRunId: verificationRun.verification_run_id,
+    },
+    deps,
+  );
+
+  const reviewingSlice = Slice.parse({
+    ...slice,
+    state: "SLICE_REVIEWING",
+    current_session_id: null,
+    updated_at: deps.clock.isoNow(),
+  });
+  await deps.store.writeAtomic(
+    layout.slice(slice.slice_id),
+    JSON.stringify(reviewingSlice, null, 2),
+  );
+
+  // Ledger rows for the dispatch side-effects
+  const sessionFinalizeKey = `per_session_outcome|${finalized.session_id}|tests_green|required_evidence|${commit.commit}`;
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.cfg.targetId,
+    object_id: finalized.session_id,
+    object_kind: "dialogue_session",
+    from_state: "SESSION_OPEN",
+    to_state: "CONVERGED",
+    loop_kind: "inner",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: finalized.session_id,
+    turn_index: turnIndex,
+    slot_kind: "delivery",
+    agent_profile_id: "forge",
+    contribution_kind: null,
+    action_kind: "session_finalize",
+    final_verdict: "tests_green",
+    caller_id: deps.cfg.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: verificationRun.verification_run_id,
+    metric_run_id: null,
+    idempotency_key: sessionFinalizeKey,
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: null,
+    timestamp: deps.clock.isoNow(),
+  });
+
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.cfg.targetId,
+    object_id: sliceMerge.slice_merge_id,
+    object_kind: "slice_merge",
+    from_state: null,
+    to_state: "SM_READY_FOR_REVIEW",
+    loop_kind: "inner",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: finalized.session_id,
+    turn_index: null,
+    slot_kind: "delivery",
+    agent_profile_id: null,
+    contribution_kind: null,
+    action_kind: "slice_merge",
+    final_verdict: null,
+    caller_id: deps.cfg.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: verificationRun.verification_run_id,
+    metric_run_id: null,
+    idempotency_key: `slice_merge_open|${sliceMerge.slice_merge_id}`,
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: null,
+    timestamp: deps.clock.isoNow(),
+  });
+
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.cfg.targetId,
+    object_id: slice.slice_id,
+    object_kind: "slice",
+    from_state: "SLICE_BUILDING",
+    to_state: "SLICE_REVIEWING",
+    loop_kind: "inner",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: finalized.session_id,
+    turn_index: null,
+    slot_kind: "delivery",
+    agent_profile_id: null,
+    contribution_kind: null,
+    action_kind: "slice_merge",
+    final_verdict: null,
+    caller_id: deps.cfg.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: verificationRun.verification_run_id,
+    metric_run_id: null,
+    idempotency_key: `slice_state|${slice.slice_id}|SLICE_REVIEWING`,
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: null,
+    timestamp: deps.clock.isoNow(),
+  });
+
+  void turn;
+  void LedgerRow; // imported for type-symmetry; runtime usage above goes through appendTransition's own validator
+  return {
+    kind: "converged",
+    sessionId: finalized.session_id,
+    sliceId: slice.slice_id,
+    sliceMergeId: sliceMerge.slice_merge_id,
+    verificationRunId: verificationRun.verification_run_id,
+    workspaceCommit: commit.commit,
+  };
+}
+
+async function openSliceMergeReadyForReview(
+  input: {
+    slice: SliceT;
+    session: DialogueSessionT;
+    preMergeRevision: string;
+    verificationRunId: string;
+  },
+  deps: TurnWorkerDeps,
+): Promise<SliceMergeT> {
+  const id = newMonotonicId(deps.clock.now());
+  const sm = SliceMerge.parse({
+    slice_merge_id: id,
+    slice_id: input.slice.slice_id,
+    target_id: deps.cfg.targetId,
+    pre_merge_workspace_revision: input.preMergeRevision,
+    merge_revision: null,
+    inner_session_id: input.session.session_id,
+    review_session_id: null,
+    verification_run_id: input.verificationRunId,
+    state: "SM_READY_FOR_REVIEW",
+    merged_at: null,
+    merged_by_caller_id: null,
+    lease_token: null,
+    audit_chain_predecessor_id: null,
+    external_refs: [],
+    created_at: deps.clock.isoNow(),
+    updated_at: deps.clock.isoNow(),
+  });
+  await deps.store.writeAtomic(
+    layout.sliceMerge(id),
+    JSON.stringify(sm, null, 2),
+  );
+  return sm;
+}
+
+class SliceLocalPinResolver implements RevisionPinResolver {
+  constructor(
+    private readonly slice: SliceT,
+    private readonly workspaceHead: string,
+  ) {}
+  async resolve(entry: ManifestEntryDraft): Promise<string> {
+    if (entry.object_kind === "slice") return this.slice.dod_revision_pin;
+    if (entry.object_kind === "code_tree") return this.workspaceHead;
+    return this.workspaceHead;
+  }
+}
+
+interface PatchArtifacts {
+  files?: Array<{ path: string; content: string }>;
+}
+
+function extractPatchFiles(
+  artifacts: Record<string, unknown> | null,
+): { path: string; content: string }[] {
+  if (artifacts == null) return [];
+  const a = artifacts as PatchArtifacts;
+  if (!Array.isArray(a.files)) return [];
+  const out: { path: string; content: string }[] = [];
+  for (const f of a.files) {
+    if (
+      f != null &&
+      typeof f.path === "string" &&
+      typeof f.content === "string"
+    ) {
+      out.push({ path: f.path, content: f.content });
+    }
+  }
+  return out;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}

--- a/src/application/verification-runner.ts
+++ b/src/application/verification-runner.ts
@@ -1,0 +1,71 @@
+import { newMonotonicId } from "../domain/ids.js";
+import {
+  VerificationRun,
+  type VerificationRun as VerificationRunT,
+} from "../domain/schema/verification.js";
+import type { ClockPort } from "../ports/clock.js";
+import type { StorePort } from "../ports/store.js";
+import type {
+  CommandSpec,
+  VerificationOutcome,
+  VerificationPort,
+} from "../ports/verification.js";
+import { layout } from "./persistence-layout.js";
+
+/**
+ * Inner-loop synchronous verification runner (#RGC-VERIFICATION).
+ *
+ * Phase 2 scope:
+ *   - Runs the configured test commands for a slice's worktree.
+ *   - Persists a single VerificationRun record.
+ *   - Returns the VerificationRun id so callers can attach it to the
+ *     SessionTurn (`verification_result_ref`).
+ *
+ * Build / lint / metric runs are exposed via the same pattern but only
+ * `runInner` (test) is wired into the phase-2 cycle.
+ */
+
+export interface RunInnerVerificationInput {
+  targetId: string;
+  targetRevision: string;
+  testCommands: CommandSpec[];
+  environmentFingerprint: string;
+}
+
+export interface VerificationRunnerDeps {
+  verification: VerificationPort;
+  store: StorePort;
+  clock: ClockPort;
+}
+
+export async function runInnerVerification(
+  input: RunInnerVerificationInput,
+  deps: VerificationRunnerDeps,
+): Promise<VerificationRunT> {
+  const outcome = await deps.verification.runTest(input.testCommands);
+  return persistVerification(input, outcome, deps);
+}
+
+export async function persistVerification(
+  input: RunInnerVerificationInput,
+  outcome: VerificationOutcome,
+  deps: VerificationRunnerDeps,
+): Promise<VerificationRunT> {
+  const run = VerificationRun.parse({
+    verification_run_id: newMonotonicId(deps.clock.now()),
+    target_id: input.targetId,
+    target_revision: input.targetRevision,
+    commands_or_checks: input.testCommands.map((c) => c.argv.join(" ")),
+    environment_fingerprint: input.environmentFingerprint,
+    started_at: outcome.startedAt,
+    finished_at: outcome.finishedAt,
+    result: outcome.result,
+    failed_tests: outcome.failed_tests,
+    log_ref: null,
+  });
+  await deps.store.writeAtomic(
+    layout.verification(run.verification_run_id),
+    JSON.stringify(run, null, 2),
+  );
+  return run;
+}

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env -S node --enable-source-maps
+import { readFile } from "node:fs/promises";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { FakeAdapter } from "../adapters/llm-runner/fake.js";
+import { AdapterRunnerPort } from "../adapters/llm-runner/runtime-port.js";
+import { NdjsonLogger } from "../adapters/logger/ndjson.js";
+import { FsStore } from "../adapters/store/fs.js";
+import { FakeVerification } from "../adapters/verification/fake.js";
+import { ShellVerification } from "../adapters/verification/shell.js";
+import { GitWorktreeWorkspace } from "../adapters/workspace/git-worktree.js";
+import { FakeWorkspace } from "../adapters/workspace/fake.js";
+import { validateOrThrow } from "../application/config-validator.js";
+import { FileLedger } from "../application/ledger.js";
+import { LOG_DAEMON_PATH } from "../application/persistence-layout.js";
+import { runOneInnerTurn } from "../application/turn-worker.js";
+import { SystemClock } from "../ports/clock.js";
+
+/**
+ * Phase 2 CLI entrypoint — runs a single inner turn and exits.
+ *
+ *   tsx src/cli/runner.ts --once --agent-profile forge \
+ *     --target ./target.json [--workdir <path>]
+ *     [--fake-llm-fixtures <dir>] [--fake-workspace] [--fake-verification]
+ *
+ * Phase 2 enforcement: only `--once --agent-profile forge` is accepted.
+ * Daemon mode arrives in phase 4.
+ *
+ * PID lockdir at `<workdir>/log/runner.pid.lock` prevents two runners
+ * from racing on the same workdir. The lock is released on exit.
+ */
+
+interface CliArgs {
+  once: boolean;
+  agentProfile: string;
+  targetPath: string;
+  workdir?: string;
+  fakeLlmFixtures?: string;
+  fakeWorkspace: boolean;
+  fakeVerification: boolean;
+  testCmd?: string;
+  callerId: string;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  const a = [...argv];
+  const out: CliArgs = {
+    once: false,
+    agentProfile: "",
+    targetPath: "./target.json",
+    fakeWorkspace: false,
+    fakeVerification: false,
+    callerId: process.env.LLM_TEAM_CALLER_ID ?? `caller-${process.pid}`,
+  };
+  while (a.length > 0) {
+    const flag = a.shift()!;
+    switch (flag) {
+      case "--once":
+        out.once = true;
+        break;
+      case "--agent-profile":
+        out.agentProfile = a.shift() ?? "";
+        break;
+      case "--target":
+        out.targetPath = a.shift() ?? "";
+        break;
+      case "--workdir":
+        out.workdir = a.shift();
+        break;
+      case "--fake-llm-fixtures":
+        out.fakeLlmFixtures = a.shift();
+        break;
+      case "--fake-workspace":
+        out.fakeWorkspace = true;
+        break;
+      case "--fake-verification":
+        out.fakeVerification = true;
+        break;
+      case "--test-cmd":
+        out.testCmd = a.shift();
+        break;
+      case "--caller-id":
+        out.callerId = a.shift() ?? out.callerId;
+        break;
+      default:
+        throw new Error(`unknown flag: ${flag}`);
+    }
+  }
+  if (!out.once) throw new Error("phase 2 CLI requires --once");
+  if (out.agentProfile !== "forge")
+    throw new Error("phase 2 CLI only supports --agent-profile forge");
+  return out;
+}
+
+async function main(argv: readonly string[]): Promise<number> {
+  const args = parseArgs(argv);
+  const targetRaw = JSON.parse(await readFile(args.targetPath, "utf8"));
+  const cfg = validateOrThrow(targetRaw);
+  const workdir = resolve(
+    args.workdir ?? cfg.identity.workdir_path ?? process.cwd(),
+  );
+  const store = new FsStore({ workdir });
+  const clock = new SystemClock();
+  const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+
+  // PID lockdir
+  const lockPath = resolve(workdir, "log", "runner.pid.lock");
+  mkdirSync(resolve(workdir, "log"), { recursive: true });
+  try {
+    mkdirSync(lockPath);
+  } catch (e) {
+    throw new Error(
+      `another runner appears active (lockdir exists): ${lockPath}: ${(e as Error).message}`,
+    );
+  }
+  writeFileSync(resolve(lockPath, "pid"), String(process.pid), "utf8");
+
+  try {
+    const ledger = new FileLedger({
+      store,
+      logger,
+      auditHashSeed: cfg.identity.audit_hash_seed,
+    });
+
+    const llmRunner = args.fakeLlmFixtures
+      ? new AdapterRunnerPort(
+          new FakeAdapter({ fixtureDir: args.fakeLlmFixtures }),
+        )
+      : (() => {
+          throw new Error(
+            "phase 2 CLI requires --fake-llm-fixtures (real adapters wired in later phases)",
+          );
+        })();
+
+    const workspace = args.fakeWorkspace
+      ? new FakeWorkspace(resolve(workdir, "workspaces"))
+      : new GitWorktreeWorkspace({
+          repoRoot: process.cwd(),
+          workspacesDir: resolve(workdir, "workspaces"),
+        });
+
+    const verification = args.fakeVerification
+      ? new FakeVerification(clock)
+      : new ShellVerification({ clock });
+
+    const testCommands = (cwd: string) => [
+      args.testCmd
+        ? { argv: tokenize(args.testCmd), cwd }
+        : { argv: ["npm", "test"], cwd },
+    ];
+
+    const outcome = await runOneInnerTurn({
+      store,
+      clock,
+      llmRunner,
+      workspace,
+      verification,
+      ledger,
+      cfg: {
+        callerId: args.callerId,
+        targetId: cfg.identity.target_id,
+        testCommands,
+        environmentFingerprint: `node${process.version}`,
+      },
+    });
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
+    return outcome.kind === "noop" ||
+      outcome.kind === "converged"
+      ? 0
+      : 1;
+  } finally {
+    try {
+      rmSync(lockPath, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+function tokenize(cmd: string): string[] {
+  return cmd.split(/\s+/).filter((s) => s.length > 0);
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error(err instanceof Error ? err.stack : String(err));
+      process.exit(2);
+    },
+  );
+}
+
+export { main as runnerMain };

--- a/src/ports/verification.ts
+++ b/src/ports/verification.ts
@@ -1,0 +1,63 @@
+import type { FailedTest } from "../domain/schema/verification.js";
+
+/**
+ * Verification port (#RGC-VERIFICATION).
+ *
+ * Phase 2 surface — inner-loop synchronous execution. The port's job is to
+ * run a target-configured command and return the deterministic outcome.
+ * Persistence (VerificationRun / MetricRun records) is handled in
+ * `application/verification-runner.ts`.
+ *
+ * Result classification (pass/fail/error):
+ *   - `pass`   — all checks succeeded
+ *   - `fail`   — checks ran, at least one failed (test failure, lint error,
+ *                metric below threshold)
+ *   - `error`  — could not run (binary missing, infra failure)
+ */
+
+export type VerificationResult = "pass" | "fail" | "error";
+
+export interface CommandSpec {
+  /** Argv-style command. Implementations resolve the binary and run it without a shell. */
+  argv: string[];
+  cwd: string;
+  /** Optional override; otherwise inherits process env. */
+  env?: NodeJS.ProcessEnv;
+  /** Soft per-command timeout in seconds. */
+  timeoutSec?: number;
+}
+
+export interface VerificationOutcome {
+  result: VerificationResult;
+  /** Per-command stdout/stderr concatenated, in command order. */
+  log: string;
+  /** Empty for build/lint runs; populated for test runs that report structured failures. */
+  failed_tests: FailedTest[];
+  startedAt: string;
+  finishedAt: string;
+  exitCodes: (number | null)[];
+}
+
+export interface MetricOutcome {
+  result: "met" | "unmet";
+  value: number;
+  log: string;
+  startedAt: string;
+  finishedAt: string;
+}
+
+export interface VerificationPort {
+  runBuild(commands: CommandSpec[]): Promise<VerificationOutcome>;
+  runTest(commands: CommandSpec[]): Promise<VerificationOutcome>;
+  runLint(commands: CommandSpec[]): Promise<VerificationOutcome>;
+
+  /**
+   * Runs a metric command and parses its single-number stdout. Comparator +
+   * threshold are applied by the caller; the port returns the raw value and
+   * a met/unmet decision passed in via `compare`.
+   */
+  runMetric(input: {
+    command: CommandSpec;
+    compare: (value: number) => "met" | "unmet";
+  }): Promise<MetricOutcome>;
+}

--- a/src/ports/workspace.ts
+++ b/src/ports/workspace.ts
@@ -1,0 +1,51 @@
+/**
+ * Workspace port (#AGC-WORKSPACE).
+ *
+ * Phase 2 inner-only surface: prepares a slice-local mutable worktree,
+ * applies envelope artefacts, commits to the slice-local branch, and
+ * reports the current head revision (for revision_pin recheck).
+ *
+ * Read-only checkout (middle review) and trunk rebase (SliceMerge) are
+ * deferred to phase 3.
+ */
+
+export interface PreparedWorkspace {
+  /** Absolute path to the prepared mutable worktree. */
+  agentCwd: string;
+  /** Revision pin that the workspace currently points at. */
+  headBefore: string;
+}
+
+export interface PatchFile {
+  /** Repo-relative path. Absolute paths and `..` segments are rejected. */
+  path: string;
+  /** UTF-8 content. Binary not modelled in phase 2. */
+  content: string;
+}
+
+export interface CommitInput {
+  sliceId: string;
+  message: string;
+  files: PatchFile[];
+}
+
+export interface CommitResult {
+  commit: string;
+}
+
+export interface WorkspacePort {
+  prepareInnerWorkspace(input: {
+    sliceId: string;
+    trunkBaseRevision: string;
+  }): Promise<PreparedWorkspace>;
+
+  /**
+   * Atomically applies the file set then commits. Returns the new commit's
+   * revision pin. The implementation is responsible for `git add` + `git
+   * commit` semantics; callers see only the resulting commit hash.
+   */
+  commit(input: CommitInput): Promise<CommitResult>;
+
+  /** Current head revision of the slice-local branch. */
+  head(sliceId: string): Promise<string>;
+}

--- a/tests/adapters/verification-shell.test.ts
+++ b/tests/adapters/verification-shell.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { ShellVerification } from "../../src/adapters/verification/shell.js";
+import { FakeVerification } from "../../src/adapters/verification/fake.js";
+import { FixedClock } from "../../src/ports/clock.js";
+
+describe("ShellVerification", () => {
+  it("runTest returns pass when commands succeed", async () => {
+    const v = new ShellVerification({ clock: new FixedClock(0) });
+    const out = await v.runTest([{ argv: ["true"], cwd: process.cwd() }]);
+    expect(out.result).toBe("pass");
+    expect(out.exitCodes).toEqual([0]);
+  });
+
+  it("runTest returns fail when first command exits non-zero", async () => {
+    const v = new ShellVerification({ clock: new FixedClock(0) });
+    const out = await v.runTest([{ argv: ["false"], cwd: process.cwd() }]);
+    expect(out.result).toBe("fail");
+  });
+
+  it("runBuild returns error when binary missing", async () => {
+    const v = new ShellVerification({ clock: new FixedClock(0) });
+    const out = await v.runBuild([
+      { argv: ["definitely-not-a-binary-xyz"], cwd: process.cwd() },
+    ]);
+    expect(out.result).toBe("error");
+  });
+
+  it("runMetric parses last numeric token from stdout", async () => {
+    const v = new ShellVerification({ clock: new FixedClock(0) });
+    const out = await v.runMetric({
+      command: { argv: ["printf", "value: 7"], cwd: process.cwd() },
+      compare: (n) => (n <= 10 ? "met" : "unmet"),
+    });
+    expect(out.value).toBe(7);
+    expect(out.result).toBe("met");
+  });
+});
+
+describe("FakeVerification", () => {
+  it("returns the scripted outcome", async () => {
+    const v = new FakeVerification(new FixedClock(0), {
+      test: {
+        result: "fail",
+        failed_tests: [
+          { path: "tests/foo.test.ts", name: "x", message: "got 2" },
+        ],
+      },
+    });
+    const out = await v.runTest([{ argv: ["true"], cwd: "." }]);
+    expect(out.result).toBe("fail");
+    expect(out.failed_tests.length).toBe(1);
+  });
+
+  it("metric default is met=0", async () => {
+    const v = new FakeVerification(new FixedClock(0));
+    const out = await v.runMetric({
+      command: { argv: ["x"], cwd: "." },
+      compare: () => "met",
+    });
+    expect(out.result).toBe("met");
+    expect(out.value).toBe(0);
+  });
+});

--- a/tests/adapters/verification-shell.test.ts
+++ b/tests/adapters/verification-shell.test.ts
@@ -25,6 +25,14 @@ describe("ShellVerification", () => {
     expect(out.result).toBe("error");
   });
 
+  it("empty command list classifies as error (not zero-check pass)", async () => {
+    const v = new ShellVerification({ clock: new FixedClock(0) });
+    const out = await v.runTest([]);
+    expect(out.result).toBe("error");
+    expect(out.exitCodes.length).toBe(0);
+    expect(out.log).toContain("empty command list");
+  });
+
   it("runMetric parses last numeric token from stdout", async () => {
     const v = new ShellVerification({ clock: new FixedClock(0) });
     const out = await v.runMetric({

--- a/tests/adapters/workspace-fake.test.ts
+++ b/tests/adapters/workspace-fake.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+
+const SLICE_ID = "01HZS00000000000000000000A";
+
+describe("FakeWorkspace", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "fakews-"));
+  });
+  afterEach(() => {
+    // tmpdir entries are intentionally left behind for post-mortem debugging.
+  });
+
+  it("prepare → commit → head produces deterministic head differing from base", async () => {
+    const ws = new FakeWorkspace(root);
+    const prep = await ws.prepareInnerWorkspace({
+      sliceId: SLICE_ID,
+      trunkBaseRevision: "deadbeef",
+    });
+    expect(prep.headBefore).toBe("deadbeef");
+    const c1 = await ws.commit({
+      sliceId: SLICE_ID,
+      message: "first",
+      files: [{ path: "src/foo.ts", content: "export const x = 1;\n" }],
+    });
+    expect(c1.commit.length).toBeGreaterThan(0);
+    expect(await ws.head(SLICE_ID)).toBe(c1.commit);
+    const written = readFileSync(join(prep.agentCwd, "src/foo.ts"), "utf8");
+    expect(written).toBe("export const x = 1;\n");
+  });
+
+  it("commit hash is deterministic for the same input sequence", async () => {
+    const a = new FakeWorkspace(mkdtempSync(join(tmpdir(), "fakews-a-")));
+    const b = new FakeWorkspace(mkdtempSync(join(tmpdir(), "fakews-b-")));
+    for (const ws of [a, b]) {
+      await ws.prepareInnerWorkspace({
+        sliceId: SLICE_ID,
+        trunkBaseRevision: "deadbeef",
+      });
+      await ws.commit({
+        sliceId: SLICE_ID,
+        message: "m",
+        files: [{ path: "f.txt", content: "hello" }],
+      });
+    }
+    expect(await a.head(SLICE_ID)).toBe(await b.head(SLICE_ID));
+  });
+
+  it("rejects absolute paths and traversal", async () => {
+    const ws = new FakeWorkspace(root);
+    await ws.prepareInnerWorkspace({
+      sliceId: SLICE_ID,
+      trunkBaseRevision: "x",
+    });
+    await expect(
+      ws.commit({
+        sliceId: SLICE_ID,
+        message: "m",
+        files: [{ path: "/etc/passwd", content: "x" }],
+      }),
+    ).rejects.toThrow(/absolute/);
+    await expect(
+      ws.commit({
+        sliceId: SLICE_ID,
+        message: "m",
+        files: [{ path: "../escape.txt", content: "x" }],
+      }),
+    ).rejects.toThrow(/traversal/);
+  });
+
+  it("head() before prepare throws", async () => {
+    const ws = new FakeWorkspace(root);
+    await expect(ws.head(SLICE_ID)).rejects.toThrow(/no workspace prepared/);
+  });
+});

--- a/tests/application/agent-io.test.ts
+++ b/tests/application/agent-io.test.ts
@@ -1,0 +1,212 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FakeAdapter } from "../../src/adapters/llm-runner/fake.js";
+import { AdapterRunnerPort } from "../../src/adapters/llm-runner/runtime-port.js";
+import { callAgent } from "../../src/application/agent-io.js";
+import { ManifestBuilder } from "../../src/application/manifest-builder.js";
+import { ContextManifest } from "../../src/domain/schema/manifest.js";
+import { FixedClock } from "../../src/ports/clock.js";
+
+const SESSION_ID = "01HZSE0000000000000000000A";
+const SLICE_ID = "01HZS00000000000000000000A";
+const MANIFEST_ID = "01HZMA0000000000000000000A";
+const ISO = "2026-05-07T00:00:00.000Z";
+
+function buildManifest() {
+  return ContextManifest.parse({
+    manifest_id: MANIFEST_ID,
+    session_id: SESSION_ID,
+    turn_index: 0,
+    purpose: "tdd_build",
+    target: { object_kind: "slice", object_id: SLICE_ID },
+    entries: [
+      {
+        object_kind: "slice",
+        object_id: SLICE_ID,
+        fetch_scope: "body",
+        revision_pin: "deadbeef",
+        required: true,
+        purpose: "primary",
+      },
+    ],
+    created_at: ISO,
+  });
+}
+
+class StaticResolver {
+  constructor(private pin: string) {}
+  async resolve(): Promise<string> {
+    return this.pin;
+  }
+}
+
+function envelopeFixture(): string {
+  return JSON.stringify({
+    session_id: SESSION_ID,
+    turn_index: 0,
+    parent_loop: "inner",
+    phase_or_purpose: "tdd_build",
+    slice_id: SLICE_ID,
+    slice_kind: "internal",
+    tdd_phase: "red_green",
+    agent_profile_id: "forge",
+    agent_role_in_session: "lead",
+    contribution_kind: "lead_draft",
+    output_kind: "patch",
+    object_id: SLICE_ID,
+    manifest_id: MANIFEST_ID,
+    input_revision_pins: ["deadbeef"],
+    summary: "first turn",
+  });
+}
+
+describe("callAgent", () => {
+  it("runs prompt → fake adapter → parse → enrich → validate → pin recheck", async () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), "fixt-"));
+    writeFileSync(
+      join(fixtureDir, "forge-tdd_build.json"),
+      envelopeFixture(),
+      "utf8",
+    );
+    const cwd = mkdtempSync(join(tmpdir(), "cwd-"));
+    const adapter = new FakeAdapter({ fixtureDir });
+    const runner = new AdapterRunnerPort(adapter);
+    const builder = new ManifestBuilder(
+      new StaticResolver("deadbeef"),
+      new FixedClock(0),
+    );
+    const out = await callAgent(
+      {
+        agentProfileId: "forge",
+        agentRoleInSession: "lead",
+        parentLoop: "inner",
+        phaseOrPurpose: "tdd_build",
+        sessionId: SESSION_ID,
+        turnIndex: 0,
+        manifest: buildManifest(),
+        workspaceRevisionPin: "deadbeef",
+        agentCwd: cwd,
+        timeoutSec: 30,
+        idempotency: {
+          scope: "per_turn",
+          parts: {
+            session_id: SESSION_ID,
+            turn_index: 0,
+            agent_profile_id: "forge",
+            manifest_id: MANIFEST_ID,
+            input_revision_pins: ["deadbeef"],
+          },
+        },
+        runtimeMetadata: { workspace_commit: "deadbeef" },
+      },
+      { llmRunner: runner, manifestBuilder: builder },
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.envelope.idempotency_key.startsWith("per_turn|")).toBe(true);
+      expect(out.envelope.runtime_metadata).toEqual({ workspace_commit: "deadbeef" });
+      expect(out.stalePins.length).toBe(0);
+    }
+  });
+
+  it("reports header_echo_mismatch when fixture replays wrong session_id", async () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), "fixt-"));
+    const wrong = JSON.parse(envelopeFixture());
+    wrong.session_id = "01HZSE0000000000000000000B";
+    writeFileSync(
+      join(fixtureDir, "forge-tdd_build.json"),
+      JSON.stringify(wrong),
+      "utf8",
+    );
+    const cwd = mkdtempSync(join(tmpdir(), "cwd-"));
+    const runner = new AdapterRunnerPort(new FakeAdapter({ fixtureDir }));
+    const builder = new ManifestBuilder(
+      new StaticResolver("deadbeef"),
+      new FixedClock(0),
+    );
+    const out = await callAgent(
+      {
+        agentProfileId: "forge",
+        agentRoleInSession: "lead",
+        parentLoop: "inner",
+        phaseOrPurpose: "tdd_build",
+        sessionId: SESSION_ID,
+        turnIndex: 0,
+        manifest: buildManifest(),
+        workspaceRevisionPin: "deadbeef",
+        agentCwd: cwd,
+        timeoutSec: 30,
+        idempotency: {
+          scope: "per_turn",
+          parts: {
+            session_id: SESSION_ID,
+            turn_index: 0,
+            agent_profile_id: "forge",
+            manifest_id: MANIFEST_ID,
+            input_revision_pins: ["deadbeef"],
+          },
+        },
+        runtimeMetadata: {},
+      },
+      { llmRunner: runner, manifestBuilder: builder },
+    );
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.stage).toBe("envelope_parse");
+      expect(out.reason).toBe("header_echo_mismatch");
+    }
+  });
+
+  it("flags stale pins when the resolver pin diverges from the manifest", async () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), "fixt-"));
+    writeFileSync(
+      join(fixtureDir, "forge-tdd_build.json"),
+      envelopeFixture(),
+      "utf8",
+    );
+    const cwd = mkdtempSync(join(tmpdir(), "cwd-"));
+    const runner = new AdapterRunnerPort(new FakeAdapter({ fixtureDir }));
+    // Build manifest with pin "deadbeef" but resolver returns "drifted" — a
+    // post-build drift that recheckPins must catch.
+    const builder = new ManifestBuilder(
+      new StaticResolver("drifted"),
+      new FixedClock(0),
+    );
+    const out = await callAgent(
+      {
+        agentProfileId: "forge",
+        agentRoleInSession: "lead",
+        parentLoop: "inner",
+        phaseOrPurpose: "tdd_build",
+        sessionId: SESSION_ID,
+        turnIndex: 0,
+        manifest: buildManifest(),
+        workspaceRevisionPin: "deadbeef",
+        agentCwd: cwd,
+        timeoutSec: 30,
+        idempotency: {
+          scope: "per_turn",
+          parts: {
+            session_id: SESSION_ID,
+            turn_index: 0,
+            agent_profile_id: "forge",
+            manifest_id: MANIFEST_ID,
+            input_revision_pins: ["deadbeef"],
+          },
+        },
+        runtimeMetadata: {},
+      },
+      { llmRunner: runner, manifestBuilder: builder },
+    );
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.stalePins.length).toBe(1);
+      expect(out.stalePins[0]?.recorded_pin).toBe("deadbeef");
+    }
+  });
+});
+
+// Avoid unused-import warnings.
+void mkdirSync;

--- a/tests/conformance/phase-2.test.ts
+++ b/tests/conformance/phase-2.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Phase 2 contract conformance.
+ *
+ * Asserts that:
+ *   1. The contract README's CONTRACT-CONFORMANCE matrix points at TS
+ *      surfaces that exist for every anchor this phase is responsible for.
+ *   2. The phase-2 modules expose the documented public functions / types.
+ *   3. The TurnWorker assembles the inner-cycle 6-step flow without
+ *      drifting from the architecture mapping.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "../..");
+const README = resolve(REPO_ROOT, "docs/contracts/README.md");
+
+const PHASE_2_ANCHORS = [
+  "AGC-PROMPT-SERIALIZATION",
+  "AGC-WORKSPACE",
+  "SOC-SLICE-LIFECYCLE",
+  "SOC-SLICE-MERGE",
+  "RGC-VERIFICATION",
+  "ARC-CALL-SEMANTICS",
+  "ARC-PORT-SIGNATURE",
+  "ARC-ADAPTER-PROMPT-CONTRACT",
+];
+
+function findRowForAnchor(readme: string, anchor: string): string {
+  const re = new RegExp(`\\|\\s*\`${anchor}\`[^\n]*\\|`);
+  const m = readme.match(re);
+  if (!m) throw new Error(`anchor ${anchor} not found in README matrix`);
+  return m[0];
+}
+
+function extractTsPaths(matrixRow: string): string[] {
+  const paths = new Set<string>();
+  const re = /`(src\/[^`\s]+\.ts)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(matrixRow)) != null) {
+    if (m[1]) paths.add(m[1]);
+  }
+  return [...paths];
+}
+
+describe("Phase 2 — contract conformance matrix", () => {
+  const readme = readFileSync(README, "utf8");
+  for (const anchor of PHASE_2_ANCHORS) {
+    it(`${anchor} row references at least one src/**/*.ts surface that exists`, () => {
+      const row = findRowForAnchor(readme, anchor);
+      const paths = extractTsPaths(row);
+      expect(
+        paths.length,
+        `${anchor} matrix row should cite at least one TS path`,
+      ).toBeGreaterThan(0);
+      for (const p of paths) {
+        expect(existsSync(resolve(REPO_ROOT, p)), `missing file: ${p}`).toBe(
+          true,
+        );
+      }
+    });
+  }
+});
+
+describe("Phase 2 — module surface contract", () => {
+  it("WorkspacePort exposes prepareInnerWorkspace / commit / head", async () => {
+    const mod = await import("../../src/ports/workspace.js");
+    // The port is an interface; we instead probe the fake adapter to enforce
+    // shape via a structural duck-typed assertion.
+    const { FakeWorkspace } = await import(
+      "../../src/adapters/workspace/fake.js"
+    );
+    const fw = new FakeWorkspace("/tmp/never");
+    expect(typeof fw.prepareInnerWorkspace).toBe("function");
+    expect(typeof fw.commit).toBe("function");
+    expect(typeof fw.head).toBe("function");
+    void mod;
+  });
+
+  it("VerificationPort surface — runBuild / runTest / runLint / runMetric", async () => {
+    const { ShellVerification } = await import(
+      "../../src/adapters/verification/shell.js"
+    );
+    const { FixedClock } = await import("../../src/ports/clock.js");
+    const v = new ShellVerification({ clock: new FixedClock(0) });
+    for (const fn of ["runBuild", "runTest", "runLint", "runMetric"] as const) {
+      expect(typeof (v as unknown as Record<string, unknown>)[fn]).toBe(
+        "function",
+      );
+    }
+  });
+
+  it("agent-io.callAgent is a function (single seam consumer)", async () => {
+    const mod = await import("../../src/application/agent-io.js");
+    expect(typeof mod.callAgent).toBe("function");
+  });
+
+  it("turn-worker.runOneInnerTurn is a function", async () => {
+    const mod = await import("../../src/application/turn-worker.js");
+    expect(typeof mod.runOneInnerTurn).toBe("function");
+  });
+
+  it("verification-runner.runInnerVerification is a function", async () => {
+    const mod = await import("../../src/application/verification-runner.js");
+    expect(typeof mod.runInnerVerification).toBe("function");
+  });
+
+  it("ready-object.pickReadyInnerTurn is a function", async () => {
+    const mod = await import("../../src/application/ready-object.js");
+    expect(typeof mod.pickReadyInnerTurn).toBe("function");
+  });
+
+  it("session-turn-persist.persistSessionTurn is a function", async () => {
+    const mod = await import("../../src/application/session-turn-persist.js");
+    expect(typeof mod.persistSessionTurn).toBe("function");
+  });
+
+  it("CLI runner exports runnerMain (tsx entrypoint)", async () => {
+    const mod = await import("../../src/cli/runner.js");
+    expect(typeof mod.runnerMain).toBe("function");
+  });
+});
+
+describe("Phase 2 — turn-worker outcome enum", () => {
+  it("documented outcomes are noop / converged / verification_failed / invalid_envelope", async () => {
+    // Source-level regression gate: keep the kind union in sync. We grep the
+    // module body so a future refactor that drops a kind without updating
+    // this list trips the test.
+    const body = readFileSync(
+      resolve(REPO_ROOT, "src/application/turn-worker.ts"),
+      "utf8",
+    );
+    for (const kind of [
+      `kind: "noop"`,
+      `kind: "converged"`,
+      `kind: "verification_failed"`,
+      `kind: "invalid_envelope"`,
+    ]) {
+      expect(body).toContain(kind);
+    }
+  });
+});

--- a/tests/integration/inner-cycle-failures.test.ts
+++ b/tests/integration/inner-cycle-failures.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Phase 2 inner cycle — failure-mode integration tests.
+ *
+ * Pairs with `inner-cycle.test.ts` (happy path + noop) to verify that each
+ * off-happy-path branch:
+ *   - emits an `invalid` ledger row (no audit gap),
+ *   - leaves the slice / session in a state that the next pickup can
+ *     reason about (no SessionNotOpenError loop, no orphan partial state),
+ *   - does NOT promote the slice to SLICE_REVIEWING or SM_READY_FOR_REVIEW.
+ *
+ * Branches covered:
+ *   1. invalid envelope (header echo mismatch — agent fixture replays the
+ *      wrong session_id)
+ *   2. stale-pin gate (manifest entry's recorded pin diverges from current
+ *      revision — agent-io's recheckPins detects drift)
+ *   3. verification fail (tests run, exit non-zero — turn persists, but no
+ *      dispatch)
+ *   4. verification empty-commands → error (cfg returns []; ShellVerification
+ *      classifies as error per PR #61 review fix)
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { NdjsonLogger } from "../../src/adapters/logger/ndjson.js";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import { FakeVerification } from "../../src/adapters/verification/fake.js";
+import { ShellVerification } from "../../src/adapters/verification/shell.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import {
+  LOG_DAEMON_PATH,
+  layout,
+} from "../../src/application/persistence-layout.js";
+import { runOneInnerTurn } from "../../src/application/turn-worker.js";
+import { Slice } from "../../src/domain/schema/slice.js";
+import { DialogueSession } from "../../src/domain/schema/dialogue-session.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { SystemClock } from "../../src/ports/clock.js";
+import type { LlmRunnerInput, LlmRunnerPort, LlmRunnerResult } from "../../src/ports/llm-runner.js";
+
+const TARGET_ID = "demo-target";
+const SLICE_ID = "01HZS00000000000000000000A";
+const MILESTONE_ID = "01HZM00000000000000000000A";
+const ISO = "2026-05-08T00:00:00.000Z";
+
+function readJson<T>(workdir: string, rel: string, parse: (raw: unknown) => T): T {
+  const fs = require("node:fs") as typeof import("node:fs");
+  return parse(JSON.parse(fs.readFileSync(join(workdir, rel), "utf8")));
+}
+
+function readNdjsonLines(workdir: string, rel: string): string[] {
+  const fs = require("node:fs") as typeof import("node:fs");
+  if (!fs.existsSync(join(workdir, rel))) return [];
+  return fs
+    .readFileSync(join(workdir, rel), "utf8")
+    .split("\n")
+    .filter((s) => s.length > 0);
+}
+
+function seedReadySlice(workdir: string): void {
+  const slice = Slice.parse({
+    slice_id: SLICE_ID,
+    milestone_id: MILESTONE_ID,
+    slice_kind: "internal",
+    value_statement: "demo",
+    ac_ids: ["AC-1"],
+    acceptance_tests: [
+      { path: "tests/x.test.ts", name: "x", ac_id: "AC-1" },
+    ],
+    declared_scope: ["src/x.ts"],
+    declared_metric_threshold: null,
+    interface_break: false,
+    dependencies: [],
+    trunk_base_revision: "trunk-base",
+    dod_revision_pin: "dod-pin",
+    state: "SLICE_READY",
+    external_refs: [],
+    created_at: ISO,
+    updated_at: ISO,
+  });
+  const fs = require("node:fs") as typeof import("node:fs");
+  fs.mkdirSync(join(workdir, "slices"), { recursive: true });
+  fs.writeFileSync(
+    join(workdir, layout.slice(SLICE_ID)),
+    JSON.stringify(slice),
+    "utf8",
+  );
+}
+
+function envelopeBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    parent_loop: "inner",
+    phase_or_purpose: "tdd_build",
+    slice_id: SLICE_ID,
+    slice_kind: "internal",
+    tdd_phase: "red_green",
+    agent_profile_id: "forge",
+    agent_role_in_session: "lead",
+    contribution_kind: "lead_draft",
+    output_kind: "patch",
+    object_id: SLICE_ID,
+    summary: "demo turn",
+    artifacts: {
+      files: [{ path: "src/x.ts", content: "export const x = 1;\n" }],
+    },
+    input_revision_pins: ["__PIN__"],
+    ...overrides,
+  };
+}
+
+function parseFrontmatter(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!body.startsWith("---\n")) return out;
+  const end = body.indexOf("\n---\n", 4);
+  if (end < 0) return out;
+  const fm = body.slice(4, end);
+  for (const line of fm.split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_]+)\s*:\s*(.+?)\s*$/);
+    if (m) out[m[1]!] = m[2]!.replace(/^['"]|['"]$/g, "");
+  }
+  return out;
+}
+
+function manifestPins(prompt: string): string[] {
+  const re = /```json[ \t]*\r?\n([\s\S]*?)\r?\n```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(prompt)) !== null) {
+    try {
+      const obj = JSON.parse(m[1] ?? "") as { entries?: Array<{ revision_pin?: string }> };
+      if (Array.isArray(obj.entries)) {
+        return obj.entries
+          .map((e) => e.revision_pin)
+          .filter((p): p is string => typeof p === "string");
+      }
+    } catch {}
+  }
+  return [];
+}
+
+/**
+ * Test-only LlmRunnerPort that returns the supplied envelope literal,
+ * stamping the runtime session_id / turn_index / manifest_id from the
+ * prompt frontmatter and pulling input_revision_pins from the rendered
+ * manifest. The override hook lets a test inject a wrong header echo
+ * (used for the invalid-envelope branch).
+ */
+class StampingRunner implements LlmRunnerPort {
+  constructor(
+    private readonly envelope: Record<string, unknown>,
+    private readonly transform?: (body: Record<string, unknown>) => Record<string, unknown>,
+  ) {}
+  async invoke(input: LlmRunnerInput): Promise<LlmRunnerResult> {
+    const fs = await import("node:fs/promises");
+    const promptBody = await fs.readFile(input.promptRef, "utf8");
+    const fm = parseFrontmatter(promptBody);
+    let env: Record<string, unknown> = {
+      ...this.envelope,
+      session_id: fm.session_id,
+      turn_index: Number(fm.turn_index),
+      manifest_id: fm.manifest_id,
+      input_revision_pins: manifestPins(promptBody),
+    };
+    if (this.transform) env = this.transform(env);
+    const stdout = "```json\n" + JSON.stringify(env) + "\n```\n";
+    // Write synthetic envelope/diagnostic refs.
+    const tmp = mkdtempSync(join(tmpdir(), "stamping-"));
+    const envRef = join(tmp, "envelope.json");
+    const diagRef = join(tmp, "diagnostics.txt");
+    // The runtime executor strips the fence; here we emit the raw json
+    // body to mimic the post-extraction state.
+    const body = stdout
+      .replace(/^```json\s*\n/, "")
+      .replace(/\n```\s*$/, "");
+    await fs.writeFile(envRef, body, "utf8");
+    await fs.writeFile(diagRef, "", "utf8");
+    return {
+      exitStatus: "ok",
+      envelopeRef: envRef,
+      diagnosticsRef: diagRef,
+      consumedAt: new Date().toISOString(),
+    };
+  }
+}
+
+function buildDeps(opts: {
+  workdir: string;
+  wsRoot: string;
+  runner: LlmRunnerPort;
+  testCommands: (cwd: string) => Parameters<typeof runOneInnerTurn>[0]["cfg"]["testCommands"] extends (
+    cwd: string,
+  ) => infer R
+    ? R
+    : never;
+  verificationOutcome?: "pass" | "fail" | "error";
+  shellVerification?: boolean;
+}) {
+  const store = new FsStore({ workdir: opts.workdir });
+  const clock = new SystemClock();
+  const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+  const ledger = new FileLedger({ store, logger });
+  const verification = opts.shellVerification
+    ? new ShellVerification({ clock })
+    : new FakeVerification(clock, {
+        test: { result: opts.verificationOutcome ?? "pass" },
+      });
+  return {
+    store,
+    clock,
+    llmRunner: opts.runner,
+    workspace: new FakeWorkspace(opts.wsRoot),
+    verification,
+    ledger,
+    cfg: {
+      callerId: "test-caller",
+      targetId: TARGET_ID,
+      environmentFingerprint: "vitest",
+      testCommands: opts.testCommands,
+    },
+  } as Parameters<typeof runOneInnerTurn>[0];
+}
+
+describe("Phase 2 inner cycle — failure modes", () => {
+  it("invalid envelope (header echo mismatch) emits ledger invalid row + slice unchanged", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "fail-invalid-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-fail-invalid-"));
+    seedReadySlice(workdir);
+    const runner = new StampingRunner(envelopeBody(), (env) => ({
+      ...env,
+      session_id: "01HZSE0000000000000000000Z",
+    }));
+    const outcome = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        testCommands: (cwd) => [{ argv: ["true"], cwd }],
+      }),
+    );
+    expect(outcome.kind).toBe("invalid_envelope");
+    if (outcome.kind !== "invalid_envelope") return;
+    expect(outcome.reason).toBe("header_echo_mismatch");
+
+    const sliceLive = readJson(workdir, layout.slice(SLICE_ID), Slice.parse);
+    expect(sliceLive.state).toBe("SLICE_BUILDING"); // ready-object opened the session, but did not promote past
+    expect(sliceLive.current_session_id).toBe(outcome.sessionId);
+
+    const sessionLive = readJson(
+      workdir,
+      layout.sessionMetadata(outcome.sessionId),
+      DialogueSession.parse,
+    );
+    expect(sessionLive.state).toBe("SESSION_OPEN");
+
+    const rows = readNdjsonLines(workdir, "ledger/transitions.ndjson").map((l) =>
+      LedgerRow.parse(JSON.parse(l)),
+    );
+    const invalidRow = rows.find(
+      (r) => r.action_kind === "session_progress" && r.result === "invalid",
+    );
+    expect(invalidRow, "must record an invalid ledger row").toBeDefined();
+    expect(invalidRow?.result_detail).toContain("header_echo_mismatch");
+    // No SLICE_REVIEWING transition row.
+    expect(
+      rows.find((r) => r.to_state === "SLICE_REVIEWING"),
+    ).toBeUndefined();
+  });
+
+  // Stale-pin gate: covered at the unit level by `agent-io.test.ts`. The
+  // SliceLocalPinResolver in turn-worker.ts captures the workspaceHead at
+  // build time, so triggering drift through the public turn-worker entry
+  // point would require a contrived custom resolver. The gate's behaviour
+  // (invalid row + no commit/verification) is exercised directly via
+  // `callAgent` in agent-io.test.ts → 'flags stale pins when the resolver
+  // pin diverges from the manifest'.
+
+  it("verification fail leaves SESSION_OPEN + persists session_progress (applied) but no dispatch", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "fail-verify-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-fail-verify-"));
+    seedReadySlice(workdir);
+    const runner = new StampingRunner(envelopeBody());
+    const outcome = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        verificationOutcome: "fail",
+        testCommands: (cwd) => [{ argv: ["true"], cwd }],
+      }),
+    );
+    expect(outcome.kind).toBe("verification_failed");
+    if (outcome.kind !== "verification_failed") return;
+
+    const sliceLive = readJson(workdir, layout.slice(SLICE_ID), Slice.parse);
+    expect(sliceLive.state).toBe("SLICE_BUILDING");
+    const sessionLive = readJson(
+      workdir,
+      layout.sessionMetadata(outcome.sessionId),
+      DialogueSession.parse,
+    );
+    expect(sessionLive.state).toBe("SESSION_OPEN");
+
+    const rows = readNdjsonLines(workdir, "ledger/transitions.ndjson").map((l) =>
+      LedgerRow.parse(JSON.parse(l)),
+    );
+    const turnRow = rows.find(
+      (r) => r.action_kind === "session_progress" && r.turn_index === 0,
+    );
+    expect(turnRow).toBeDefined();
+    expect(turnRow?.verification_run_id).toBe(outcome.verificationRunId);
+    expect(rows.find((r) => r.to_state === "SLICE_REVIEWING")).toBeUndefined();
+    expect(rows.find((r) => r.to_state === "CONVERGED")).toBeUndefined();
+  });
+
+  it("empty verification commands → error (no zero-check tests_green)", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "fail-empty-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-fail-empty-"));
+    seedReadySlice(workdir);
+    const runner = new StampingRunner(envelopeBody());
+    const outcome = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        shellVerification: true,
+        testCommands: () => [],
+      }),
+    );
+    expect(outcome.kind).toBe("verification_failed");
+    if (outcome.kind !== "verification_failed") return;
+
+    const rows = readNdjsonLines(workdir, "ledger/transitions.ndjson").map((l) =>
+      LedgerRow.parse(JSON.parse(l)),
+    );
+    expect(rows.find((r) => r.to_state === "SLICE_REVIEWING")).toBeUndefined();
+  });
+});

--- a/tests/integration/inner-cycle.test.ts
+++ b/tests/integration/inner-cycle.test.ts
@@ -1,0 +1,300 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FakeAdapter } from "../../src/adapters/llm-runner/fake.js";
+import { AdapterRunnerPort } from "../../src/adapters/llm-runner/runtime-port.js";
+import { NdjsonLogger } from "../../src/adapters/logger/ndjson.js";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import { FakeVerification } from "../../src/adapters/verification/fake.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import { LOG_DAEMON_PATH, layout } from "../../src/application/persistence-layout.js";
+import { runOneInnerTurn } from "../../src/application/turn-worker.js";
+import { Slice } from "../../src/domain/schema/slice.js";
+import { SliceMerge } from "../../src/domain/schema/slice-merge.js";
+import { DialogueSession } from "../../src/domain/schema/dialogue-session.js";
+import { SessionTurn } from "../../src/domain/schema/session-turn.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { SystemClock } from "../../src/ports/clock.js";
+
+const TARGET_ID = "demo-target";
+const SLICE_ID = "01HZS00000000000000000000A";
+const MILESTONE_ID = "01HZM00000000000000000000A";
+const ISO = "2026-05-07T00:00:00.000Z";
+
+function envelopeFixture(): string {
+  return JSON.stringify({
+    parent_loop: "inner",
+    phase_or_purpose: "tdd_build",
+    slice_id: SLICE_ID,
+    slice_kind: "internal",
+    tdd_phase: "red_green",
+    agent_profile_id: "forge",
+    agent_role_in_session: "lead",
+    contribution_kind: "lead_draft",
+    output_kind: "patch",
+    object_id: SLICE_ID,
+    summary: "first turn — implement add()",
+    artifacts: {
+      files: [
+        { path: "src/add.ts", content: "export const add = (a:number,b:number)=>a+b;\n" },
+        { path: "tests/add.test.ts", content: "import { add } from '../src/add';\nimport { test, expect } from 'vitest';\ntest('add', () => expect(add(1,2)).toBe(3));\n" },
+      ],
+    },
+    // session_id, turn_index, manifest_id are placeholders the fake adapter
+    // will leave intact — turn-worker injects them via prompt frontmatter and
+    // header-echo check expects the fixture to match exactly. We override at
+    // write time below.
+  });
+}
+
+function readJson<T>(workdir: string, rel: string, parse: (raw: unknown) => T): T {
+  const fs = require("node:fs") as typeof import("node:fs");
+  return parse(JSON.parse(fs.readFileSync(join(workdir, rel), "utf8")));
+}
+
+function readNdjsonLines(workdir: string, rel: string): string[] {
+  const fs = require("node:fs") as typeof import("node:fs");
+  if (!fs.existsSync(join(workdir, rel))) return [];
+  return fs
+    .readFileSync(join(workdir, rel), "utf8")
+    .split("\n")
+    .filter((s) => s.length > 0);
+}
+
+describe("Phase 2 inner cycle integration", () => {
+  it("forge solo SLICE_READY → SLICE_REVIEWING + SM_READY_FOR_REVIEW + ledger rows", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "inner-cycle-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "fxt-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-"));
+
+    // Seed the SLICE_READY internal slice.
+    const slice = Slice.parse({
+      slice_id: SLICE_ID,
+      milestone_id: MILESTONE_ID,
+      slice_kind: "internal",
+      value_statement: "add() function",
+      ac_ids: ["AC-1"],
+      acceptance_tests: [
+        { path: "tests/add.test.ts", name: "add", ac_id: "AC-1" },
+      ],
+      declared_scope: ["src/add.ts", "tests/add.test.ts"],
+      declared_metric_threshold: null,
+      interface_break: false,
+      dependencies: [],
+      trunk_base_revision: "trunk-base",
+      dod_revision_pin: "dod-pin",
+      state: "SLICE_READY",
+      external_refs: [],
+      created_at: ISO,
+      updated_at: ISO,
+    });
+    const fs = await import("node:fs");
+    fs.mkdirSync(join(workdir, "slices"), { recursive: true });
+    fs.writeFileSync(
+      join(workdir, layout.slice(SLICE_ID)),
+      JSON.stringify(slice),
+      "utf8",
+    );
+
+    // Fake LLM fixture — turn-worker uses the fake adapter via frontmatter
+    // (agent_profile=forge / phase_or_purpose=tdd_build). Header echo is
+    // checked against the runtime-generated session_id / manifest_id so we
+    // wire those in via __SESSION__ / __MANIFEST_ID__ placeholders. The
+    // fake adapter already substitutes __MANIFEST_ID__ from frontmatter; we
+    // add session_id by post-processing the fixture body in agent-io
+    // pipeline indirectly — easier: write fixture with placeholders, then
+    // add a substitution wrapper. The fake adapter only knows __MANIFEST_ID__
+    // and __PIN__; for session_id / turn_index the cleanest path is to write
+    // the fixture as a JS Function… simpler: write a lightweight outer test
+    // using callAgent directly. But here we exercise the full turn-worker.
+    //
+    // Trick: the fake adapter emits the fixture verbatim, but our envelope
+    // requires session_id matching the runtime. We use a custom adapter that
+    // stamps the runtime ids onto the envelope after the FakeAdapter returns.
+    writeFileSync(
+      join(fixtureDir, "forge-tdd_build.json"),
+      JSON.stringify({ session_id: "__SESSION__", turn_index: 0, manifest_id: "__MANIFEST_ID__", input_revision_pins: ["__PIN__"] }),
+      "utf8",
+    );
+
+    const wrapAdapter = new StampingFakeAdapter(envelopeFixture(), fixtureDir);
+    const llmRunner = new AdapterRunnerPort(wrapAdapter);
+
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+    const ledger = new FileLedger({ store, logger });
+
+    const outcome = await runOneInnerTurn({
+      store,
+      clock,
+      llmRunner,
+      workspace: new FakeWorkspace(wsRoot),
+      verification: new FakeVerification(clock, { test: { result: "pass" } }),
+      ledger,
+      cfg: {
+        callerId: "test-caller",
+        targetId: TARGET_ID,
+        environmentFingerprint: "vitest",
+        testCommands: (cwd) => [{ argv: ["true"], cwd }],
+      },
+    });
+
+    expect(outcome.kind).toBe("converged");
+    if (outcome.kind !== "converged") return;
+
+    // Slice → SLICE_REVIEWING
+    const updatedSlice = readJson(workdir, layout.slice(SLICE_ID), (raw) =>
+      Slice.parse(raw),
+    );
+    expect(updatedSlice.state).toBe("SLICE_REVIEWING");
+    expect(updatedSlice.current_session_id).toBeNull();
+
+    // SliceMerge → SM_READY_FOR_REVIEW
+    const sm = readJson(workdir, layout.sliceMerge(outcome.sliceMergeId), (raw) =>
+      SliceMerge.parse(raw),
+    );
+    expect(sm.state).toBe("SM_READY_FOR_REVIEW");
+    expect(sm.pre_merge_workspace_revision).toBe(outcome.workspaceCommit);
+
+    // Session → CONVERGED tests_green
+    const session = readJson(
+      workdir,
+      layout.sessionMetadata(outcome.sessionId),
+      (raw) => DialogueSession.parse(raw),
+    );
+    expect(session.state).toBe("CONVERGED");
+    expect(session.final_verdict).toBe("tests_green");
+
+    // SessionTurn turn 0 persisted with envelope, workspace_commit, verification ref
+    const turn = readJson(
+      workdir,
+      layout.sessionTurn(outcome.sessionId, 0),
+      (raw) => SessionTurn.parse(raw),
+    );
+    expect(turn.workspace_commit).toBe(outcome.workspaceCommit);
+    expect(turn.verification_result_ref).toBe(outcome.verificationRunId);
+    expect(turn.output_envelope.contribution_kind).toBe("lead_draft");
+
+    // Ledger has ≥4 rows (turn + session_finalize + slice_merge + slice transition)
+    const rows = readNdjsonLines(workdir, "ledger/transitions.ndjson").map((l) =>
+      LedgerRow.parse(JSON.parse(l)),
+    );
+    expect(rows.length).toBeGreaterThanOrEqual(4);
+    const turnRow = rows.find(
+      (r) =>
+        r.action_kind === "session_progress" &&
+        r.session_id === outcome.sessionId &&
+        r.turn_index === 0,
+    );
+    expect(turnRow).toBeDefined();
+    expect(turnRow?.result).toBe("applied");
+    expect(turnRow?.audit_hash_prev.length).toBe(64);
+
+    const sliceTx = rows.find(
+      (r) => r.object_kind === "slice" && r.to_state === "SLICE_REVIEWING",
+    );
+    expect(sliceTx).toBeDefined();
+    const smTx = rows.find(
+      (r) =>
+        r.object_kind === "slice_merge" && r.to_state === "SM_READY_FOR_REVIEW",
+    );
+    expect(smTx).toBeDefined();
+  });
+
+  it("returns noop when no SLICE_READY/SLICE_BUILDING internal slices exist", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "noop-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-noop-"));
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+    const ledger = new FileLedger({ store, logger });
+    const fakeAdapter = new FakeAdapter({
+      fixtureDir: mkdtempSync(join(tmpdir(), "empty-fxt-")),
+    });
+    const outcome = await runOneInnerTurn({
+      store,
+      clock,
+      llmRunner: new AdapterRunnerPort(fakeAdapter),
+      workspace: new FakeWorkspace(wsRoot),
+      verification: new FakeVerification(clock),
+      ledger,
+      cfg: {
+        callerId: "x",
+        targetId: TARGET_ID,
+        environmentFingerprint: "vitest",
+        testCommands: () => [],
+      },
+    });
+    expect(outcome.kind).toBe("noop");
+  });
+});
+
+/**
+ * Stamping fake adapter: behaves like FakeAdapter but rewrites the
+ * fixture's envelope to use the runtime session_id / turn_index / manifest_id
+ * extracted from the prompt frontmatter, so the header-echo check passes.
+ */
+class StampingFakeAdapter {
+  readonly id = "fake" as const;
+  constructor(
+    private readonly envelopeJson: string,
+    private readonly fixtureDir: string,
+  ) {
+    void this.fixtureDir;
+  }
+  async run(input: { stdin: string; agentCwd: string; timeoutSec: number }) {
+    const envelope = JSON.parse(this.envelopeJson) as Record<string, unknown>;
+    const headers = parseFrontmatter(input.stdin);
+    envelope.session_id = headers.session_id;
+    envelope.turn_index = Number(headers.turn_index);
+    envelope.manifest_id = headers.manifest_id;
+    // Pull the manifest's recorded revision pin to satisfy input_revision_pins.
+    const manifestPins = extractManifestPins(input.stdin);
+    envelope.input_revision_pins = manifestPins;
+    const stdout = "```json\n" + JSON.stringify(envelope) + "\n```\n";
+    void input.timeoutSec;
+    void input.agentCwd;
+    return {
+      rawCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout,
+      stderr: "",
+    };
+  }
+}
+
+function parseFrontmatter(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!body.startsWith("---\n")) return out;
+  const end = body.indexOf("\n---\n", 4);
+  if (end < 0) return out;
+  const fm = body.slice(4, end);
+  for (const line of fm.split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_]+)\s*:\s*(.+?)\s*$/);
+    if (m) out[m[1]!] = m[2]!.replace(/^['"]|['"]$/g, "");
+  }
+  return out;
+}
+
+function extractManifestPins(prompt: string): string[] {
+  const re = /```json[ \t]*\r?\n([\s\S]*?)\r?\n```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(prompt)) !== null) {
+    const body = m[1] ?? "";
+    try {
+      const obj = JSON.parse(body) as { entries?: Array<{ revision_pin?: string }> };
+      if (Array.isArray(obj.entries)) {
+        return obj.entries
+          .map((e) => e.revision_pin)
+          .filter((p): p is string => typeof p === "string" && p.length > 0);
+      }
+    } catch {
+      // continue
+    }
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary

Phase 2 of the TS rewrite per `/Users/macpro/.claude/plans/serene-conjuring-lecun.md`.

Builds the first end-to-end cycle on top of phase 1a/1b foundations:

1. Single daemon picks a SLICE_READY internal slice (forge / inner / tdd_build).
2. Opens a DialogueSession (lead_only / forge), advances slice to SLICE_BUILDING.
3. Runs one turn: prompt compose → LlmRunnerPort.invoke → envelope parse/enrich/matrix-validate → header-echo + pin recheck.
4. Commits patch artefacts to a slice-local worktree.
5. Runs inner synchronous verification (#RGC-VERIFICATION).
6. Persists SessionTurn (envelope + workspace_commit + verification_result_ref).
7. On `tests_green`, inlines the phase-2 caller-dispatch:
   - session CONVERGED tests_green
   - SliceMerge SM_DRAFT → SM_READY_FOR_REVIEW
   - slice SLICE_BUILDING → SLICE_REVIEWING
   - ledger rows (session_progress, session_finalize, slice_merge, slice transition)

The cycle stops at the gate `SLICE_REVIEWING + SM_READY_FOR_REVIEW` per the plan; middle review and SLICE_VALIDATED are phase 3.

## Surfaces

- New ports: `WorkspacePort`, `VerificationPort`.
- New adapters: workspace `git-worktree` + `fake`; verification `shell` + `fake`; `AdapterRunnerPort` (contract-shaped wrapper around provider adapters).
- New application modules: `prompt-compose`, `agent-io`, `ready-object`, `verification-runner`, `session-turn-persist`, `turn-worker`.
- CLI entrypoint: `src/cli/runner.ts` — `tsx src/cli/runner.ts --once --agent-profile forge --target ./target.json [...]`. PID lockdir at `<workdir>/log/runner.pid.lock`.

## MVP simplifications (and invariant impact)

| Simplification | Invariant impact |
|---|---|
| dialogue-coordinator absent — turn-worker opens/append/closes the session inline | Inv #2 (mediated addressing) trivially holds for single-agent session; routing decision = `dropped` with explicit `decision_reason`. |
| internal slice only | Inv #5 (feature human gate) not engaged. |
| dual-track scheduler absent (single milestone fixture) | Inv #3 (dual-slot serialization) auto-holds. No slot_lock acquisition. |
| middle review absent | Slice / SliceMerge stop at the phase-2 gate. Inv #6 (deterministic verification authority) preserved by `verification-runner` synchronous post-commit. |
| GitHub absent — FS only | `external_refs[]` empty. No invariant impact. |
| sentinel/atlas/scout not dispatched | Runner registry already has all 4 (phase 1a); dispatch deferred. |
| 1 turn → 1 invalid → cycle ends; no retry | Phase-4 failure-policy will add retry counters / ESCALATED. |

## Contract matrix updates

`docs/contracts/README.md` rows updated for:

- `AGC-PROMPT-SERIALIZATION` ★ → partial (`prompt-compose.ts` + `prompt-relay.ts` + `agent-io.ts#checkHeaderEcho`)
- `AGC-WORKSPACE` → partial (`ports/workspace.ts` + git-worktree/fake adapters)
- `SOC-SLICE-LIFECYCLE` ★ → partial (`ready-object.ts` + `turn-worker.ts`)
- `SOC-SLICE-MERGE` ★ → partial (`turn-worker.ts#openSliceMergeReadyForReview`)
- `RGC-VERIFICATION` → partial (port + shell/fake adapters + `verification-runner.ts`)
- `ARC-CALL-SEMANTICS` → partial (`runInvoke` + `AdapterRunnerPort` + `agent-io.callAgent`)
- `ARC-PORT-SIGNATURE` → partial (interface + executor)
- `ARC-ADAPTER-PROMPT-CONTRACT` ★ → partial (preflight + provider adapters)

## Test plan

- [x] `npm run typecheck` zero errors
- [x] `npm run build` clean
- [x] `npm test` 265 passing across 30 files (was 246/28 on phase 1b main)
- [x] `tests/integration/inner-cycle.test.ts` — full 6-step cycle e2e:
  - SLICE_READY fixture → CONVERGED tests_green → SLICE_REVIEWING + SM_READY_FOR_REVIEW
  - SessionTurn embeds canonical envelope + workspace_commit + verification_run_id
  - Ledger has ≥4 rows (turn / session_finalize / slice_merge / slice transition); audit_hash chain intact
  - noop branch when no SLICE_READY/SLICE_BUILDING internal slices exist
- [x] `tests/conformance/phase-2.test.ts`:
  - 8 anchors' matrix rows resolve to existing TS files
  - Module surface contracts (port + application + CLI)
  - turn-worker outcome enum regression gate
- [x] `tests/adapters/workspace-fake.test.ts` — deterministic head, traversal-rejection
- [x] `tests/adapters/verification-shell.test.ts` — pass / fail / error / metric parse
- [x] `tests/application/agent-io.test.ts` — parse/enrich/validate, header-echo mismatch, stale-pin reporting
- [x] CLI smoke: `tsx src/cli/runner.ts --once --agent-profile forge --target target.json --fake-llm-fixtures ... --fake-workspace --fake-verification` returns `{"kind":"noop",...}` on empty workdir

🤖 Generated with [Claude Code](https://claude.com/claude-code)