### PR TITLE
feat(phase-7b): control-state machine + daemon prelude wiring (G1-4)

### DIFF
--- a/src/application/control-state.ts
+++ b/src/application/control-state.ts
@@ -72,6 +72,18 @@ export type ApplyControlOutcome =
   | { kind: "transitioned"; from: ControlState; to: ControlState }
   | { kind: "noop"; state: ControlState; reason: string };
 
+/**
+ * PR #74 codex P1 (gpt5.5): when an audit context is supplied, a successful
+ * control transition emits a `pause_resume` ledger row with `result=applied`
+ * so PAUSED→RUNNING etc. are visible in the audit trail (the prelude only
+ * emits `result=noop` when the gate blocks pickup).
+ */
+export interface ControlAuditContext {
+  ledger: LedgerAppender;
+  callerId: string;
+  targetId: string;
+}
+
 const NEXT_STATE: Record<
   "pause" | "resume" | "stop",
   (from: ControlState) => ControlState | { reason: string }
@@ -92,6 +104,7 @@ export async function applyControlSignal(
   store: StorePort,
   clock: ClockPort,
   signal: HumanSignalEnvelope,
+  audit?: ControlAuditContext,
 ): Promise<ApplyControlOutcome> {
   const t = signal.signal_type;
   if (t !== "pause" && t !== "resume" && t !== "stop") {
@@ -101,7 +114,7 @@ export async function applyControlSignal(
       reason: `signal_type=${t} is not a control signal`,
     };
   }
-  return store.withFileLock(CONTROL_STATE_PATH, async () => {
+  const outcome = await store.withFileLock(CONTROL_STATE_PATH, async () => {
     const current = await readControlState(store, clock);
     if (current.signal_id === signal.signal_id) {
       return {
@@ -138,6 +151,52 @@ export async function applyControlSignal(
       to: candidate,
     } as const;
   });
+  // PR #74 codex P1: emit an `applied` ledger row for actual transitions
+  // so the audit trail captures pause/resume/stop firings (the prelude only
+  // emits `noop` rows for non-RUNNING gate hits).
+  if (outcome.kind === "transitioned" && audit != null) {
+    const idem = idempotencyKey({
+      scope: "pause_resume",
+      parts: {
+        signal_id: signal.signal_id,
+        from: outcome.from,
+        to: outcome.to,
+      },
+    });
+    await audit.ledger.appendTransition({
+      transition_id: newMonotonicId(clock.now()),
+      target_id: audit.targetId,
+      object_id: "system",
+      object_kind: "system",
+      from_state: outcome.from,
+      to_state: outcome.to,
+      loop_kind: null,
+      phase: null,
+      slice_id: null,
+      slice_kind: null,
+      dod_revision: null,
+      session_id: null,
+      turn_index: null,
+      slot_kind: null,
+      agent_profile_id: null,
+      contribution_kind: null,
+      action_kind: "pause_resume",
+      final_verdict: null,
+      caller_id: audit.callerId,
+      manifest_id: null,
+      input_revision_pins: [],
+      output_hash: null,
+      verification_run_id: null,
+      metric_run_id: null,
+      idempotency_key: idem,
+      lease_token: null,
+      lease_kind: null,
+      result: "applied",
+      result_detail: `signal_type=${t}:signal_id=${signal.signal_id}`,
+      timestamp: clock.isoNow(),
+    });
+  }
+  return outcome;
 }
 
 export interface DaemonPreludeDeps {

--- a/src/application/control-state.ts
+++ b/src/application/control-state.ts
@@ -1,0 +1,220 @@
+/**
+ * RGC-SIGNALS — daemon control state machine (Phase 7b).
+ *
+ * Persists `<workdir>/control/state.json` and provides:
+ *   - readControlState  : load the current record (RUNNING default if absent).
+ *   - applyControlSignal: apply pause/resume/stop transitions inside a lock,
+ *                         idempotent on (signal_id, signal_type).
+ *   - runDaemonPrelude  : the single helper every daemon role invokes before
+ *                         pickup — drains pending human signals (which feeds
+ *                         control transitions back through this module) and
+ *                         then reports the gate outcome (proceed / paused /
+ *                         stopped). Emits the `paused` noop ledger row when
+ *                         the gate blocks pickup.
+ *
+ * Transition table (RGC-SIGNALS, Inv #4 / #8):
+ *   RUNNING --pause--> PAUSED
+ *   PAUSED  --resume--> RUNNING
+ *   RUNNING|PAUSED --stop--> STOPPED  (terminal)
+ *
+ *   STOPPED is immutable; subsequent pause/resume/stop signals are accepted
+ *   (markProcessed=applied) but produce no further transitions.
+ *   pause from PAUSED, resume from RUNNING, and any duplicate signal_id are
+ *   no-ops as well.
+ */
+import { newMonotonicId } from "../domain/ids.js";
+import {
+  ControlStateRecord,
+  type ControlState,
+  type ControlStateRecord as ControlStateRecordT,
+} from "../domain/schema/control-state.js";
+import type { HumanSignalEnvelope } from "../domain/schema/human-signal.js";
+import type { ClockPort } from "../ports/clock.js";
+import type { StorePort } from "../ports/store.js";
+import { idempotencyKey } from "./idempotency.js";
+import type { LedgerAppender } from "./ledger.js";
+
+export const CONTROL_STATE_PATH = "control/state.json";
+
+/** Sentinel signal_id for the implicit RUNNING default. */
+const DEFAULT_SIGNAL_ID = "system:default";
+const DEFAULT_ACTOR = "system";
+
+const DEFAULT_RECORD = (isoNow: string): ControlStateRecordT =>
+  ControlStateRecord.parse({
+    state: "RUNNING",
+    changed_at: isoNow,
+    changed_by: DEFAULT_ACTOR,
+    signal_id: DEFAULT_SIGNAL_ID,
+  });
+
+/**
+ * Read the current control state. Returns the implicit RUNNING default when
+ * the file is absent — daemons must not crash on a fresh workdir.
+ */
+export async function readControlState(
+  store: StorePort,
+  clock: ClockPort,
+): Promise<ControlStateRecordT> {
+  const body = await store.readText(CONTROL_STATE_PATH);
+  if (body == null) return DEFAULT_RECORD(clock.isoNow());
+  try {
+    return ControlStateRecord.parse(JSON.parse(body));
+  } catch {
+    // Corrupt file — fall back to RUNNING default (operator can inspect the
+    // raw file on disk to recover). The next pause/resume/stop signal will
+    // overwrite it.
+    return DEFAULT_RECORD(clock.isoNow());
+  }
+}
+
+export type ApplyControlOutcome =
+  | { kind: "transitioned"; from: ControlState; to: ControlState }
+  | { kind: "noop"; state: ControlState; reason: string };
+
+const NEXT_STATE: Record<
+  "pause" | "resume" | "stop",
+  (from: ControlState) => ControlState | { reason: string }
+> = {
+  pause: (from) => (from === "RUNNING" ? "PAUSED" : { reason: `cannot pause from ${from}` }),
+  resume: (from) => (from === "PAUSED" ? "RUNNING" : { reason: `cannot resume from ${from}` }),
+  stop: (from) => (from === "STOPPED" ? { reason: "already STOPPED" } : "STOPPED"),
+};
+
+/**
+ * Apply a pause/resume/stop signal under the control-state file lock. Any
+ * other signal_type is rejected by the type system at the call site.
+ *
+ * Idempotent on signal_id: re-applying the same envelope is a noop, so the
+ * drain caller can safely re-emit if markProcessed lost the previous race.
+ */
+export async function applyControlSignal(
+  store: StorePort,
+  clock: ClockPort,
+  signal: HumanSignalEnvelope,
+): Promise<ApplyControlOutcome> {
+  const t = signal.signal_type;
+  if (t !== "pause" && t !== "resume" && t !== "stop") {
+    return {
+      kind: "noop",
+      state: "RUNNING",
+      reason: `signal_type=${t} is not a control signal`,
+    };
+  }
+  return store.withFileLock(CONTROL_STATE_PATH, async () => {
+    const current = await readControlState(store, clock);
+    if (current.signal_id === signal.signal_id) {
+      return {
+        kind: "noop",
+        state: current.state,
+        reason: "duplicate signal_id",
+      } as const;
+    }
+    const candidate = NEXT_STATE[t](current.state);
+    if (typeof candidate !== "string") {
+      return {
+        kind: "noop",
+        state: current.state,
+        reason: candidate.reason,
+      } as const;
+    }
+    if (candidate === current.state) {
+      return {
+        kind: "noop",
+        state: current.state,
+        reason: "no-op transition",
+      } as const;
+    }
+    const record = ControlStateRecord.parse({
+      state: candidate,
+      changed_at: clock.isoNow(),
+      changed_by: signal.actor,
+      signal_id: signal.signal_id,
+    });
+    await store.writeAtomic(CONTROL_STATE_PATH, JSON.stringify(record, null, 2));
+    return {
+      kind: "transitioned",
+      from: current.state,
+      to: candidate,
+    } as const;
+  });
+}
+
+export interface DaemonPreludeDeps {
+  store: StorePort;
+  clock: ClockPort;
+  ledger: LedgerAppender;
+  callerId: string;
+  targetId: string;
+  /** Daemon role label (turn-worker / dialogue-coordinator / ...) recorded
+   *  in the noop ledger row's result_detail for operator visibility. */
+  role: string;
+}
+
+export type DaemonPreludeOutcome =
+  | { action: "proceed"; state: "RUNNING" }
+  | { action: "paused"; state: "PAUSED" }
+  | { action: "stopped"; state: "STOPPED" };
+
+/**
+ * Daemon pre-pickup gate. Reads the current control state and, when
+ * non-RUNNING, emits a `pause_resume` ledger row capturing the noop pickup.
+ * The drain itself runs *outside* this helper so callers can supply the
+ * binding deps appropriate to the role (5b.2 outer binding etc.).
+ */
+export async function runDaemonPrelude(
+  deps: DaemonPreludeDeps,
+): Promise<DaemonPreludeOutcome> {
+  const current = await readControlState(deps.store, deps.clock);
+  if (current.state === "RUNNING") {
+    return { action: "proceed", state: "RUNNING" };
+  }
+  const action = current.state === "PAUSED" ? "paused" : "stopped";
+  // RGC-SIGNALS: emit a noop row so operators see the gate firing. The
+  // idempotency key folds together (role, signal_id, state) so a daemon
+  // looping while paused does not flood the ledger with duplicates per
+  // signal — but a *new* pause signal will produce a new row.
+  const idem = idempotencyKey({
+    scope: "pause_resume",
+    parts: {
+      role: deps.role,
+      state: current.state,
+      signal_id: current.signal_id,
+    },
+  });
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.targetId,
+    object_id: "system",
+    object_kind: "system",
+    from_state: null,
+    to_state: current.state,
+    loop_kind: null,
+    phase: null,
+    slice_id: null,
+    slice_kind: null,
+    dod_revision: null,
+    session_id: null,
+    turn_index: null,
+    slot_kind: null,
+    agent_profile_id: null,
+    contribution_kind: null,
+    action_kind: "pause_resume",
+    final_verdict: null,
+    caller_id: deps.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: null,
+    metric_run_id: null,
+    idempotency_key: idem,
+    lease_token: null,
+    lease_kind: null,
+    result: "noop",
+    result_detail: `paused:role=${deps.role}:signal_id=${current.signal_id}`,
+    timestamp: deps.clock.isoNow(),
+  });
+  return action === "paused"
+    ? { action: "paused", state: "PAUSED" }
+    : { action: "stopped", state: "STOPPED" };
+}

--- a/src/application/human-signal-drain.ts
+++ b/src/application/human-signal-drain.ts
@@ -17,6 +17,10 @@ import type { ClockPort } from "../ports/clock.js";
 import type { HumanSignalPort } from "../ports/human-signal.js";
 import type { StorePort } from "../ports/store.js";
 import {
+  applyControlSignal,
+  type ApplyControlOutcome,
+} from "./control-state.js";
+import {
   bindHumanSignalToSession,
   type HumanSignalBindingDeps,
 } from "./human-signal-binding.js";
@@ -33,6 +37,9 @@ export type DrainOutcome =
       binding?:
         | { kind: "appended"; session_id: string; turn_index: number }
         | { kind: "unsupported"; reason: string };
+      /** Phase 7b: present for pause/resume/stop signals — records the
+       *  control-state machine transition (or noop reason). */
+      control?: ApplyControlOutcome;
     }
   | {
       kind: "invalid";
@@ -62,6 +69,13 @@ export interface DrainDeps {
    * persistence semantics.
    */
   binding?: HumanSignalBindingDeps;
+  /**
+   * Phase 7b: when true, pause/resume/stop envelopes drive the persisted
+   * control state machine (RGC-SIGNALS, Inv #4 / #8). Daemons opt in via
+   * `runDaemonPrelude`; phase-5a callers omit it so the envelope-only test
+   * surface is preserved.
+   */
+  applyControlState?: boolean;
 }
 
 export async function runHumanSignalDrain(
@@ -74,6 +88,17 @@ export async function runHumanSignalDrain(
     const validation = validateEnvelope(env);
     const now = deps.clock.isoNow();
     if (validation.ok) {
+      // Phase 7b: control signals (pause / resume / stop) drive the
+      // persisted control-state machine BEFORE markProcessed so a daemon
+      // pickup that races with markProcessed still sees the new state.
+      let controlDetail: ApplyControlOutcome | undefined;
+      const isControl =
+        env.signal_type === "pause" ||
+        env.signal_type === "resume" ||
+        env.signal_type === "stop";
+      if (isControl && deps.applyControlState === true) {
+        controlDetail = await applyControlSignal(deps.store, deps.clock, env);
+      }
       // Phase 5b.2: bind FIRST (before markProcessed) so the contribution
       // is visible to the next coordinator pickup. If binding emits a turn,
       // its idempotency_key is the SessionTurn's per_turn key — separate
@@ -125,6 +150,7 @@ export async function runHumanSignalDrain(
         target_kind: env.target_kind,
         target_id: env.target_id,
         ...(bindingDetail != null ? { binding: bindingDetail } : {}),
+        ...(controlDetail != null ? { control: controlDetail } : {}),
       });
     } else {
       const r = await deps.signal.markProcessed({
@@ -162,9 +188,12 @@ function validateEnvelope(env: HumanSignalEnvelope): { ok: true } | { ok: false;
     }
   }
   // Some signal_type / target_kind combinations are documented as system-only.
+  // Phase 7b: `stop` joins pause/resume as the third control-state signal —
+  // all three drive the persisted control-state machine.
   const SYSTEM_ONLY: Record<string, true> = {
     pause: true,
     resume: true,
+    stop: true,
   };
   if (SYSTEM_ONLY[env.signal_type] === true && env.target_kind !== "system") {
     return {

--- a/src/application/human-signal-drain.ts
+++ b/src/application/human-signal-drain.ts
@@ -19,6 +19,7 @@ import type { StorePort } from "../ports/store.js";
 import {
   applyControlSignal,
   type ApplyControlOutcome,
+  type ControlAuditContext,
 } from "./control-state.js";
 import {
   bindHumanSignalToSession,
@@ -76,6 +77,12 @@ export interface DrainDeps {
    * surface is preserved.
    */
   applyControlState?: boolean;
+  /**
+   * PR #74 codex P1: when supplied alongside `applyControlState=true`, an
+   * actual pause/resume/stop transition emits a `pause_resume` ledger row
+   * with `result=applied` for audit-trail completeness.
+   */
+  controlAudit?: ControlAuditContext;
 }
 
 export async function runHumanSignalDrain(
@@ -88,6 +95,18 @@ export async function runHumanSignalDrain(
     const validation = validateEnvelope(env);
     const now = deps.clock.isoNow();
     if (validation.ok) {
+      // PR #74 codex P0 (gpt5.5): bindable signals (approve / reject /
+      // request_rework) MUST NOT be markProcessed=applied by a non-binding
+      // role — otherwise the outer-coordinator never sees them. Stay
+      // pending so the next outer-coordinator drain cycle picks them up.
+      if (BINDABLE_SIGNAL_TYPES[env.signal_type] === true && deps.binding == null) {
+        results.push({
+          kind: "deferred",
+          signal_id: env.signal_id,
+          reason: "no_binding_caller",
+        });
+        continue;
+      }
       // Phase 7b: control signals (pause / resume / stop) drive the
       // persisted control-state machine BEFORE markProcessed so a daemon
       // pickup that races with markProcessed still sees the new state.
@@ -97,7 +116,12 @@ export async function runHumanSignalDrain(
         env.signal_type === "resume" ||
         env.signal_type === "stop";
       if (isControl && deps.applyControlState === true) {
-        controlDetail = await applyControlSignal(deps.store, deps.clock, env);
+        controlDetail = await applyControlSignal(
+          deps.store,
+          deps.clock,
+          env,
+          deps.controlAudit,
+        );
       }
       // Phase 5b.2: bind FIRST (before markProcessed) so the contribution
       // is visible to the next coordinator pickup. If binding emits a turn,
@@ -171,6 +195,20 @@ export async function runHumanSignalDrain(
 
   return results;
 }
+
+/**
+ * Signal types that bind to an outer DialogueSession (see
+ * `human-signal-binding.ts` VERDICT_FOR). Drain emits `deferred` for these
+ * when invoked without binding deps so the outer-coordinator's next cycle
+ * can consume them — a non-outer role MUST NOT markProcessed=applied them.
+ */
+const BINDABLE_SIGNAL_TYPES: Partial<
+  Record<HumanSignalEnvelope["signal_type"], true>
+> = {
+  approve: true,
+  reject: true,
+  request_rework: true,
+};
 
 function validateEnvelope(env: HumanSignalEnvelope): { ok: true } | { ok: false; reason: string } {
   // Basic conditional-required checks per RGC-SIGNALS.

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -35,9 +35,12 @@ import { FakeVerification } from "../adapters/verification/fake.js";
 import { ShellVerification } from "../adapters/verification/shell.js";
 import { GitWorktreeWorkspace } from "../adapters/workspace/git-worktree.js";
 import { FakeWorkspace } from "../adapters/workspace/fake.js";
+import { FsHumanSignal } from "../adapters/human-signal/fs.js";
 import { validateOrThrow } from "../application/config-validator.js";
+import { runDaemonPrelude } from "../application/control-state.js";
 import { runOneMiddleReviewTurn } from "../application/dialogue-coordinator.js";
 import { runOneDualTrackTurn } from "../application/dual-track-scheduler.js";
+import { runHumanSignalDrain } from "../application/human-signal-drain.js";
 import { FileLedger } from "../application/ledger.js";
 import { runOneOuterTurn } from "../application/outer-turn.js";
 import { LOG_DAEMON_PATH } from "../application/persistence-layout.js";
@@ -219,6 +222,11 @@ async function main(argv: readonly string[]): Promise<number> {
         : { argv: ["npm", "test"], cwd },
     ];
 
+    // Phase 7b: a single FsHumanSignal adapter feeds the per-cycle drain
+    // for every role. The control-state machine lives at
+    // `<workdir>/control/state.json` (see runDaemonPrelude).
+    const humanSignal = new FsHumanSignal(store);
+
     do {
       // Every cycle starts with a recovery sweep (RGC-RECOVERY).
       const sweep = await runRecoverySweep({
@@ -246,6 +254,59 @@ async function main(argv: readonly string[]): Promise<number> {
             reanimated_sessions: sweep.reanimatedSessions,
           },
         });
+      }
+      // Phase 7b (G1-4): drain pending human signals + apply the control
+      // state machine, then gate pickup. This runs for every role so
+      // pause/resume/stop are observed everywhere.
+      await runHumanSignalDrain({
+        store,
+        signal: humanSignal,
+        clock,
+        applyControlState: true,
+        // Outer-coordinator can additionally bind approve/reject signals to
+        // the open outer DialogueSession. Other roles deal only with the
+        // control-state side-effect; the binding deps are omitted so
+        // bindable signals stay pending until the outer-coordinator picks
+        // them up (drain emits `deferred` for those).
+        ...(args.role === "outer-coordinator"
+          ? {
+              binding: {
+                store,
+                clock,
+                ledger,
+                callerId: args.callerId,
+                targetId: cfg.identity.target_id,
+              },
+            }
+          : {}),
+      });
+      const gate = await runDaemonPrelude({
+        store,
+        clock,
+        ledger,
+        callerId: args.callerId,
+        targetId: cfg.identity.target_id,
+        role: args.role,
+      });
+      if (gate.action === "stopped") {
+        // Graceful daemon shutdown — STOPPED is terminal. The finally
+        // block releases held leases and the role lockdir.
+        process.stdout.write(
+          `${JSON.stringify({ role: args.role, outcome: { kind: "stopped" } })}\n`,
+        );
+        return 0;
+      }
+      if (gate.action === "paused") {
+        process.stdout.write(
+          `${JSON.stringify({
+            role: args.role,
+            outcome: { kind: "noop", detail: "paused" },
+          })}\n`,
+        );
+        if (args.once || interrupted) break;
+        if (args.cycleIntervalMs > 0)
+          await new Promise((r) => setTimeout(r, args.cycleIntervalMs));
+        continue;
       }
       let outcomeJson: string;
       switch (args.role) {

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -263,6 +263,13 @@ async function main(argv: readonly string[]): Promise<number> {
         signal: humanSignal,
         clock,
         applyControlState: true,
+        // PR #74 codex P1: emit `pause_resume` applied ledger row when the
+        // control state machine actually transitions (RUNNING↔PAUSED, →STOPPED).
+        controlAudit: {
+          ledger,
+          callerId: args.callerId,
+          targetId: cfg.identity.target_id,
+        },
         // Outer-coordinator can additionally bind approve/reject signals to
         // the open outer DialogueSession. Other roles deal only with the
         // control-state side-effect; the binding deps are omitted so

--- a/src/domain/schema/control-state.ts
+++ b/src/domain/schema/control-state.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * RGC-SIGNALS — daemon control state record (Phase 7b).
+ *
+ * Persisted at `<workdir>/control/state.json`. A single record records the
+ * most recent `pause` / `resume` / `stop` transition; daemons read it as the
+ * authoritative gate before every pickup.
+ *
+ * State machine:
+ *   RUNNING --pause--> PAUSED
+ *   PAUSED  --resume--> RUNNING
+ *   RUNNING|PAUSED --stop--> STOPPED  (terminal — no further transitions)
+ *
+ * `signal_id` is the human signal envelope that produced the transition. The
+ * sentinel `system:default` is used by the implicit RUNNING default that
+ * exists before any signal has fired.
+ */
+export const ControlState = z.enum(["RUNNING", "PAUSED", "STOPPED"]);
+export type ControlState = z.infer<typeof ControlState>;
+
+export const ControlStateRecord = z
+  .object({
+    state: ControlState,
+    changed_at: z.string().datetime(),
+    changed_by: z.string().min(1),
+    signal_id: z.string().min(1),
+  })
+  .strict();
+export type ControlStateRecord = z.infer<typeof ControlStateRecord>;

--- a/tests/application/control-state.test.ts
+++ b/tests/application/control-state.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Phase 7b (G1-4) — daemon control state machine + prelude.
+ *
+ * Covers RGC-SIGNALS / Inv #4 / #8 transitions:
+ *   - default RUNNING when state.json missing
+ *   - pause: RUNNING → PAUSED, idempotent on duplicate signal_id
+ *   - resume: PAUSED → RUNNING
+ *   - stop: terminal (RUNNING|PAUSED → STOPPED, no further transitions)
+ *   - prelude noop ledger row when paused, graceful shutdown gate when
+ *     stopped.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import {
+  CONTROL_STATE_PATH,
+  applyControlSignal,
+  readControlState,
+  runDaemonPrelude,
+} from "../../src/application/control-state.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import { LEDGER_TRANSITIONS_PATH } from "../../src/application/persistence-layout.js";
+import {
+  HumanSignalEnvelope,
+  type HumanSignalEnvelope as HumanSignalEnvelopeT,
+} from "../../src/domain/schema/human-signal.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { FixedClock } from "../../src/ports/clock.js";
+
+function workdir() {
+  return mkdtempSync(join(tmpdir(), "control-state-"));
+}
+
+function controlSignal(
+  partial: Partial<HumanSignalEnvelopeT> & {
+    signal_id: string;
+    signal_type: "pause" | "resume" | "stop";
+  },
+): HumanSignalEnvelopeT {
+  return HumanSignalEnvelope.parse({
+    target_kind: "system",
+    target_id: "system",
+    actor: "operator",
+    created_at: "2026-05-09T00:00:00.000Z",
+    source: "fs_drop",
+    ...partial,
+  });
+}
+
+function makeLedger(store: FsStore) {
+  return new FileLedger({ store, auditHashSeed: "seed-7b" });
+}
+
+async function readLedgerRows(store: FsStore): Promise<LedgerRow[]> {
+  const body = await store.readText(LEDGER_TRANSITIONS_PATH);
+  if (body == null) return [];
+  return body
+    .split("\n")
+    .filter((s) => s.length > 0)
+    .map((s) => LedgerRow.parse(JSON.parse(s)));
+}
+
+describe("readControlState", () => {
+  it("returns RUNNING default when state.json missing", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const rec = await readControlState(store, clock);
+    expect(rec.state).toBe("RUNNING");
+    expect(rec.signal_id).toBe("system:default");
+    expect(rec.changed_by).toBe("system");
+  });
+
+  it("falls back to RUNNING default on corrupt state.json", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    await store.writeAtomic(CONTROL_STATE_PATH, "{ not json");
+    const rec = await readControlState(store, clock);
+    expect(rec.state).toBe("RUNNING");
+  });
+});
+
+describe("applyControlSignal", () => {
+  it("RUNNING --pause--> PAUSED", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const out = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    expect(out).toEqual({ kind: "transitioned", from: "RUNNING", to: "PAUSED" });
+    const rec = await readControlState(store, clock);
+    expect(rec.state).toBe("PAUSED");
+    expect(rec.signal_id).toBe("sig-pause");
+    expect(rec.changed_by).toBe("operator");
+  });
+
+  it("duplicate signal_id is a noop (idempotent)", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const env = controlSignal({ signal_id: "sig-pause", signal_type: "pause" });
+    await applyControlSignal(store, clock, env);
+    const second = await applyControlSignal(store, clock, env);
+    expect(second.kind).toBe("noop");
+    if (second.kind === "noop") {
+      expect(second.reason).toMatch(/duplicate/);
+      expect(second.state).toBe("PAUSED");
+    }
+  });
+
+  it("pause from PAUSED is a noop with reason", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    const out = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause-2", signal_type: "pause" }),
+    );
+    expect(out.kind).toBe("noop");
+    if (out.kind === "noop") expect(out.reason).toMatch(/cannot pause/);
+  });
+
+  it("PAUSED --resume--> RUNNING", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    const out = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-resume", signal_type: "resume" }),
+    );
+    expect(out).toEqual({ kind: "transitioned", from: "PAUSED", to: "RUNNING" });
+    expect((await readControlState(store, clock)).state).toBe("RUNNING");
+  });
+
+  it("resume from RUNNING is a noop", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const out = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-resume", signal_type: "resume" }),
+    );
+    expect(out.kind).toBe("noop");
+    if (out.kind === "noop") expect(out.reason).toMatch(/cannot resume/);
+  });
+
+  it("RUNNING --stop--> STOPPED (terminal)", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const out = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-stop", signal_type: "stop" }),
+    );
+    expect(out).toEqual({ kind: "transitioned", from: "RUNNING", to: "STOPPED" });
+    // pause / resume after stop are noops — STOPPED is immutable.
+    const p = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    expect(p.kind).toBe("noop");
+    const r = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-resume", signal_type: "resume" }),
+    );
+    expect(r.kind).toBe("noop");
+    const s2 = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-stop-2", signal_type: "stop" }),
+    );
+    expect(s2.kind).toBe("noop");
+    if (s2.kind === "noop") expect(s2.reason).toMatch(/already STOPPED/);
+    expect((await readControlState(store, clock)).state).toBe("STOPPED");
+  });
+
+  it("PAUSED --stop--> STOPPED", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    const out = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-stop", signal_type: "stop" }),
+    );
+    expect(out).toEqual({ kind: "transitioned", from: "PAUSED", to: "STOPPED" });
+  });
+});
+
+describe("runDaemonPrelude", () => {
+  it("RUNNING → proceed, no ledger row", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    const out = await runDaemonPrelude({
+      store,
+      clock,
+      ledger,
+      callerId: "test-caller",
+      targetId: "test-target",
+      role: "turn-worker",
+    });
+    expect(out).toEqual({ action: "proceed", state: "RUNNING" });
+    expect(await readLedgerRows(store)).toEqual([]);
+  });
+
+  it("PAUSED → emits noop ledger row with action_kind=pause_resume", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    const out = await runDaemonPrelude({
+      store,
+      clock,
+      ledger,
+      callerId: "test-caller",
+      targetId: "test-target",
+      role: "turn-worker",
+    });
+    expect(out).toEqual({ action: "paused", state: "PAUSED" });
+    const rows = await readLedgerRows(store);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.action_kind).toBe("pause_resume");
+    expect(rows[0]?.result).toBe("noop");
+    expect(rows[0]?.to_state).toBe("PAUSED");
+    expect(rows[0]?.object_kind).toBe("system");
+    expect(rows[0]?.result_detail).toMatch(/role=turn-worker/);
+    expect(rows[0]?.result_detail).toMatch(/sig-pause/);
+  });
+
+  it("PAUSED noop is idempotent across daemon loops (same signal_id)", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    await runDaemonPrelude({
+      store,
+      clock,
+      ledger,
+      callerId: "test-caller",
+      targetId: "test-target",
+      role: "turn-worker",
+    });
+    await runDaemonPrelude({
+      store,
+      clock,
+      ledger,
+      callerId: "test-caller",
+      targetId: "test-target",
+      role: "turn-worker",
+    });
+    const rows = await readLedgerRows(store);
+    // Both rows persist as `noop` — the ledger's dedup only folds
+    // applied/recovered/rolled_back/escalated. Operators see one row per
+    // loop they spent paused, but the shared idempotency_key keeps the
+    // audit trail traceable to a single signal.
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.result).toBe("noop");
+    expect(rows[1]?.result).toBe("noop");
+    expect(rows[0]?.idempotency_key).toBe(rows[1]?.idempotency_key);
+  });
+
+  it("a different role with the same paused signal emits its own noop row", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    await runDaemonPrelude({
+      store,
+      clock,
+      ledger,
+      callerId: "tw",
+      targetId: "test-target",
+      role: "turn-worker",
+    });
+    await runDaemonPrelude({
+      store,
+      clock,
+      ledger,
+      callerId: "dc",
+      targetId: "test-target",
+      role: "dialogue-coordinator",
+    });
+    const rows = await readLedgerRows(store);
+    expect(rows.map((r) => r.result)).toEqual(["noop", "noop"]);
+    expect(rows[0]?.result_detail).toMatch(/role=turn-worker/);
+    expect(rows[1]?.result_detail).toMatch(/role=dialogue-coordinator/);
+  });
+
+  it("STOPPED → action=stopped (caller graceful-exits)", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-stop", signal_type: "stop" }),
+    );
+    const out = await runDaemonPrelude({
+      store,
+      clock,
+      ledger,
+      callerId: "test-caller",
+      targetId: "test-target",
+      role: "turn-worker",
+    });
+    expect(out).toEqual({ action: "stopped", state: "STOPPED" });
+    const rows = await readLedgerRows(store);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.to_state).toBe("STOPPED");
+  });
+});

--- a/tests/application/control-state.test.ts
+++ b/tests/application/control-state.test.ts
@@ -203,6 +203,55 @@ describe("applyControlSignal", () => {
     );
     expect(out).toEqual({ kind: "transitioned", from: "PAUSED", to: "STOPPED" });
   });
+
+  it("PR #74 codex P1: emits applied ledger row for actual transitions when audit context supplied", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    // Pause first.
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+      { ledger, callerId: "test-caller", targetId: "test-target" },
+    );
+    // Resume — this transition was previously invisible in the ledger.
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-resume", signal_type: "resume" }),
+      { ledger, callerId: "test-caller", targetId: "test-target" },
+    );
+    const rows = await readLedgerRows(store);
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toMatchObject({
+      action_kind: "pause_resume",
+      result: "applied",
+      from_state: "RUNNING",
+      to_state: "PAUSED",
+    });
+    expect(rows[1]).toMatchObject({
+      action_kind: "pause_resume",
+      result: "applied",
+      from_state: "PAUSED",
+      to_state: "RUNNING",
+    });
+  });
+
+  it("PR #74 codex P1: noop transitions do NOT emit an applied ledger row", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    // resume from RUNNING is a noop.
+    const out = await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-resume", signal_type: "resume" }),
+      { ledger, callerId: "test-caller", targetId: "test-target" },
+    );
+    expect(out.kind).toBe("noop");
+    expect(await readLedgerRows(store)).toEqual([]);
+  });
 });
 
 describe("runDaemonPrelude", () => {

--- a/tests/integration/control-state-drain.test.ts
+++ b/tests/integration/control-state-drain.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Phase 7b — drain wiring for the control-state machine.
+ *
+ * Validates RGC-SIGNALS pause/resume/stop envelopes pulled by the FS adapter
+ * drive `<workdir>/control/state.json` only when `applyControlState: true`.
+ * Phase-5a callers (no opt-in) still see envelope-only persistence — the
+ * legacy contract.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FsHumanSignal } from "../../src/adapters/human-signal/fs.js";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import {
+  CONTROL_STATE_PATH,
+  readControlState,
+} from "../../src/application/control-state.js";
+import {
+  dropSignal,
+  runHumanSignalDrain,
+} from "../../src/application/human-signal-drain.js";
+import {
+  HumanSignalEnvelope,
+  type HumanSignalEnvelope as HumanSignalEnvelopeT,
+} from "../../src/domain/schema/human-signal.js";
+import { FixedClock } from "../../src/ports/clock.js";
+
+function workdir() {
+  return mkdtempSync(join(tmpdir(), "control-drain-"));
+}
+
+function controlSignal(
+  partial: Partial<HumanSignalEnvelopeT> & {
+    signal_id: string;
+    signal_type: "pause" | "resume" | "stop";
+  },
+): HumanSignalEnvelopeT {
+  return HumanSignalEnvelope.parse({
+    target_kind: "system",
+    target_id: "system",
+    actor: "operator",
+    created_at: "2026-05-09T00:00:00.000Z",
+    source: "fs_drop",
+    ...partial,
+  });
+}
+
+describe("drain — control-state apply (Phase 7b)", () => {
+  it("pause envelope drives RUNNING → PAUSED when applyControlState=true", async () => {
+    const w = workdir();
+    const store = new FsStore({ workdir: w });
+    const sig = new FsHumanSignal(store);
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+
+    await dropSignal(
+      store,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    const out = await runHumanSignalDrain({
+      store,
+      signal: sig,
+      clock,
+      applyControlState: true,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0]?.kind).toBe("applied");
+    if (out[0]?.kind === "applied") {
+      expect(out[0].control?.kind).toBe("transitioned");
+    }
+    expect((await readControlState(store, clock)).state).toBe("PAUSED");
+  });
+
+  it("legacy callers (applyControlState omitted) leave control state untouched", async () => {
+    const w = workdir();
+    const store = new FsStore({ workdir: w });
+    const sig = new FsHumanSignal(store);
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+
+    await dropSignal(
+      store,
+      controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    const out = await runHumanSignalDrain({ store, signal: sig, clock });
+    expect(out.length).toBe(1);
+    if (out[0]?.kind === "applied") {
+      expect(out[0].control).toBeUndefined();
+    }
+    // No state.json written.
+    expect(await store.exists(CONTROL_STATE_PATH)).toBe(false);
+  });
+
+  it("stop envelope drives RUNNING → STOPPED", async () => {
+    const w = workdir();
+    const store = new FsStore({ workdir: w });
+    const sig = new FsHumanSignal(store);
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+
+    await dropSignal(
+      store,
+      controlSignal({ signal_id: "sig-stop", signal_type: "stop" }),
+    );
+    await runHumanSignalDrain({
+      store,
+      signal: sig,
+      clock,
+      applyControlState: true,
+    });
+    expect((await readControlState(store, clock)).state).toBe("STOPPED");
+  });
+
+  it("stop with non-system target is invalid (envelope validation rejects)", async () => {
+    const w = workdir();
+    const store = new FsStore({ workdir: w });
+    const sig = new FsHumanSignal(store);
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+
+    await dropSignal(
+      store,
+      controlSignal({
+        signal_id: "sig-stop",
+        signal_type: "stop",
+        target_kind: "milestone",
+        target_id: "01HZM00000000000000000000A",
+      }),
+    );
+    const out = await runHumanSignalDrain({
+      store,
+      signal: sig,
+      clock,
+      applyControlState: true,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0]?.kind).toBe("invalid");
+    // Control state stays at RUNNING (default).
+    expect((await readControlState(store, clock)).state).toBe("RUNNING");
+  });
+
+  it("pause then resume in one drain restores RUNNING", async () => {
+    const w = workdir();
+    const store = new FsStore({ workdir: w });
+    const sig = new FsHumanSignal(store);
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+
+    await dropSignal(
+      store,
+      controlSignal({
+        signal_id: "sig-pause",
+        signal_type: "pause",
+        created_at: "2026-05-09T00:01:00.000Z",
+      }),
+    );
+    await dropSignal(
+      store,
+      controlSignal({
+        signal_id: "sig-resume",
+        signal_type: "resume",
+        created_at: "2026-05-09T00:02:00.000Z",
+      }),
+    );
+    const out = await runHumanSignalDrain({
+      store,
+      signal: sig,
+      clock,
+      applyControlState: true,
+    });
+    expect(out.length).toBe(2);
+    expect((await readControlState(store, clock)).state).toBe("RUNNING");
+  });
+});

--- a/tests/integration/control-state-drain.test.ts
+++ b/tests/integration/control-state-drain.test.ts
@@ -136,6 +136,43 @@ describe("drain — control-state apply (Phase 7b)", () => {
     expect((await readControlState(store, clock)).state).toBe("RUNNING");
   });
 
+  it("PR #74 codex P0: bindable signal without binding caller is deferred (not consumed)", async () => {
+    const w = workdir();
+    const store = new FsStore({ workdir: w });
+    const sig = new FsHumanSignal(store);
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+
+    // Drop an approve envelope — bindable, but no binding deps supplied.
+    await dropSignal(
+      store,
+      HumanSignalEnvelope.parse({
+        signal_id: "sig-approve",
+        signal_type: "approve",
+        target_kind: "milestone",
+        target_id: "01HZM00000000000000000000A",
+        related_object_id: "01HZSC00000000000000000001",
+        actor: "alice",
+        created_at: "2026-05-09T00:00:00.000Z",
+        source: "fs_drop",
+      }),
+    );
+    const out = await runHumanSignalDrain({
+      store,
+      signal: sig,
+      clock,
+      applyControlState: true,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0]?.kind).toBe("deferred");
+    if (out[0]?.kind === "deferred") {
+      expect(out[0].reason).toBe("no_binding_caller");
+    }
+    // Signal stays pending so the outer-coordinator's next cycle picks it up.
+    const pending = await sig.listPending();
+    expect(pending.length).toBe(1);
+    expect(pending[0]?.signal_id).toBe("sig-approve");
+  });
+
   it("pause then resume in one drain restores RUNNING", async () => {
     const w = workdir();
     const store = new FsStore({ workdir: w });

--- a/tests/integration/daemon-control-state.test.ts
+++ b/tests/integration/daemon-control-state.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Phase 7b (G1-4) — daemon prelude wiring + control-state gate.
+ *
+ * Asserts the planning §검증 trio:
+ *   (a) pause signal drop + next loop emits a noop ledger row + outcome
+ *   (b) resume signal restores normal pickup
+ *   (c) stop signal triggers graceful shutdown + lockdir release
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import { daemonMain } from "../../src/cli/daemon.js";
+import {
+  applyControlSignal,
+  readControlState,
+} from "../../src/application/control-state.js";
+import {
+  dropSignal,
+  runHumanSignalDrain,
+} from "../../src/application/human-signal-drain.js";
+import { LEDGER_TRANSITIONS_PATH } from "../../src/application/persistence-layout.js";
+import {
+  HumanSignalEnvelope,
+  type HumanSignalEnvelope as HumanSignalEnvelopeT,
+} from "../../src/domain/schema/human-signal.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { FixedClock } from "../../src/ports/clock.js";
+import { FsHumanSignal } from "../../src/adapters/human-signal/fs.js";
+
+const TARGET_ID = "demo-target";
+
+function writeTarget(workdir: string): string {
+  const target = {
+    identity: {
+      target_id: TARGET_ID,
+      workdir_path: workdir,
+      audit_hash_seed: "seed-7b",
+    },
+    agent_profiles: {
+      atlas: { runner: "fake" },
+      forge: { runner: "fake" },
+      sentinel: { runner: "fake" },
+      scout: { runner: "fake" },
+    },
+  };
+  const path = join(workdir, "target.json");
+  writeFileSync(path, JSON.stringify(target), "utf8");
+  return path;
+}
+
+function captureStdout(): { restore: () => void; lines: () => string[] } {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  const spy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(((c: string | Uint8Array) => {
+      chunks.push(typeof c === "string" ? c : Buffer.from(c).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write);
+  return {
+    restore: () => {
+      spy.mockRestore();
+      void orig;
+    },
+    lines: () =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter((s) => s.length > 0),
+  };
+}
+
+function controlSignal(
+  partial: Partial<HumanSignalEnvelopeT> & {
+    signal_id: string;
+    signal_type: "pause" | "resume" | "stop";
+  },
+): HumanSignalEnvelopeT {
+  return HumanSignalEnvelope.parse({
+    target_kind: "system",
+    target_id: "system",
+    actor: "operator",
+    created_at: "2026-05-09T00:00:00.000Z",
+    source: "fs_drop",
+    ...partial,
+  });
+}
+
+async function readLedgerRows(store: FsStore): Promise<LedgerRow[]> {
+  const body = await store.readText(LEDGER_TRANSITIONS_PATH);
+  if (body == null) return [];
+  return body
+    .split("\n")
+    .filter((s) => s.length > 0)
+    .map((s) => LedgerRow.parse(JSON.parse(s)));
+}
+
+describe("Phase 7b — daemon control-state prelude gate", () => {
+  let prevAllowFake: string | undefined;
+  let prevFixtureDir: string | undefined;
+
+  beforeEach(() => {
+    prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    prevFixtureDir = process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
+    process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+  });
+
+  afterEach(() => {
+    if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+    if (prevFixtureDir == null) delete process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
+    else process.env.LLM_TEAM_FAKE_FIXTURE_DIR = prevFixtureDir;
+  });
+
+  it("(a) pause signal drop → next pickup emits noop outcome + pause_resume ledger row", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase7b-pause-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase7b-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir);
+
+    // Drop a pause signal BEFORE the daemon starts so its drain sees it.
+    const store = new FsStore({ workdir });
+    await dropSignal(
+      store,
+      controlSignal({ signal_id: "sig-pause-1", signal_type: "pause" }),
+    );
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase7b-tw",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+
+    const lines = cap.lines();
+    const last = lines.at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: { kind: string; detail?: string };
+    };
+    expect(parsed.role).toBe("turn-worker");
+    expect(parsed.outcome.kind).toBe("noop");
+    expect(parsed.outcome.detail).toBe("paused");
+
+    // Ledger contains a pause_resume row.
+    const rows = await readLedgerRows(store);
+    const pauseRows = rows.filter((r) => r.action_kind === "pause_resume");
+    expect(pauseRows.length).toBeGreaterThan(0);
+    expect(pauseRows[0]?.to_state).toBe("PAUSED");
+  });
+
+  it("(b) resume signal restores normal pickup", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase7b-resume-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase7b-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir);
+
+    // Pre-set the state to PAUSED via a direct apply, then drop the resume
+    // signal. The daemon's drain will pick it up and revert to RUNNING
+    // before the prelude gate runs.
+    const store = new FsStore({ workdir });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause-pre", signal_type: "pause" }),
+    );
+    expect((await readControlState(store, clock)).state).toBe("PAUSED");
+
+    await dropSignal(
+      store,
+      controlSignal({
+        signal_id: "sig-resume-1",
+        signal_type: "resume",
+        created_at: "2026-05-09T00:01:00.000Z",
+      }),
+    );
+
+    const cap = captureStdout();
+    try {
+      const code = await daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase7b-tw",
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      cap.restore();
+    }
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: { kind: string; detail?: string };
+    };
+    // After resume, the pickup proceeds — empty store yields a real `noop`
+    // outcome from turn-worker (not the paused detail).
+    expect(parsed.outcome.kind).toBe("noop");
+    expect(parsed.outcome.detail).not.toBe("paused");
+    // State.json now back to RUNNING.
+    expect((await readControlState(store, clock)).state).toBe("RUNNING");
+  });
+
+  it("(c) stop signal → graceful daemon shutdown + lockdir released", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase7b-stop-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase7b-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir);
+
+    const store = new FsStore({ workdir });
+    await dropSignal(
+      store,
+      controlSignal({ signal_id: "sig-stop-1", signal_type: "stop" }),
+    );
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        // Note: no --once. The stop signal must end the loop on its own.
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase7b-tw",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: { kind: string };
+    };
+    expect(parsed.outcome.kind).toBe("stopped");
+
+    // Lockdir released (graceful shutdown).
+    expect(existsSync(join(workdir, "log", "daemon-turn-worker.pid.lock"))).toBe(
+      false,
+    );
+    // STOPPED is terminal — re-launching the daemon must continue to gate.
+    expect(
+      (await readControlState(store, new FixedClock(0))).state,
+    ).toBe("STOPPED");
+  });
+
+  it("STOPPED persists across daemon launches (re-run still gates)", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase7b-stop2-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase7b-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir);
+    const store = new FsStore({ workdir });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-stop-pre", signal_type: "stop" }),
+    );
+
+    const cap = captureStdout();
+    try {
+      const code = await daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase7b-tw",
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      cap.restore();
+    }
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      outcome: { kind: string };
+    };
+    expect(parsed.outcome.kind).toBe("stopped");
+  });
+});

--- a/tests/integration/human-signal-concurrency.test.ts
+++ b/tests/integration/human-signal-concurrency.test.ts
@@ -43,7 +43,11 @@ function workdir() {
 }
 
 describe("human-signal drain (Phase 5a)", () => {
-  it("drains a single approve signal and marks it processed", async () => {
+  it("defers a single approve signal when no binding caller is supplied", async () => {
+    // PR #74 codex P0 (gpt5.5): bindable signals (approve/reject/request_rework)
+    // drained without binding deps stay pending and emit `deferred` so the
+    // outer-coordinator's next cycle picks them up. Pre-PR-74 behavior was
+    // markProcessed=applied which silently consumed the signal.
     const store = new FsStore({ workdir: workdir() });
     const sig = new FsHumanSignal(store);
     const clock = new FixedClock(Date.parse("2026-05-08T00:00:00.000Z"));
@@ -59,11 +63,12 @@ describe("human-signal drain (Phase 5a)", () => {
 
     const out = await runHumanSignalDrain({ store, signal: sig, clock });
     expect(out.length).toBe(1);
-    expect(out[0]?.kind).toBe("applied");
+    expect(out[0]?.kind).toBe("deferred");
 
-    // Second drain returns nothing — already in processed/.
-    const out2 = await runHumanSignalDrain({ store, signal: sig, clock });
-    expect(out2).toEqual([]);
+    // Signal stays pending — listPending re-emits on next cycle.
+    const stillPending = await sig.listPending();
+    expect(stillPending.length).toBe(1);
+    expect(stillPending[0]?.signal_id).toBe("sig-1");
   });
 
   it("rejects approve without related_object_id as invalid", async () => {
@@ -132,14 +137,16 @@ describe("human-signal drain (Phase 5a)", () => {
     const sig = new FsHumanSignal(store);
     const clock = new FixedClock(Date.parse("2026-05-08T00:00:00.000Z"));
 
-    // Drop 10 envelopes concurrently.
+    // PR #74 codex P0: use a non-bindable signal type so the markProcessed
+    // lock guard is exercised here. Bindable types (approve/reject/request_rework)
+    // are deferred when no binding caller is supplied — see the dedicated
+    // "defers a single approve signal" test above.
     const drops = Array.from({ length: 10 }, (_, i) =>
       dropSignal(
         store,
         env({
           signal_id: `sig-${i}`,
-          signal_type: "approve",
-          related_object_id: "01HZSM0000000000000000000A",
+          signal_type: "request_recover",
           created_at: `2026-05-08T0${i}:00:00.000Z`,
         }),
       ),
@@ -221,12 +228,13 @@ describe("human-signal drain (Phase 5a)", () => {
     const sig = new FsHumanSignal(store);
     const clock = new FixedClock(Date.parse("2026-05-08T00:00:00.000Z"));
 
+    // PR #74 codex P0: use a non-bindable signal so the drain marks it
+    // processed (bindable types defer without a binding caller).
     await dropSignal(
       store,
       env({
         signal_id: "sig-1",
-        signal_type: "approve",
-        related_object_id: "01HZSM0000000000000000000A",
+        signal_type: "request_recover",
       }),
     );
     await runHumanSignalDrain({ store, signal: sig, clock });


### PR DESCRIPTION
## Summary
- 영속 RGC-SIGNALS 제어 상태 (`<workdir>/control/state.json`) 와 daemon prelude 헬퍼를 도입해 모든 daemon role 의 pickup 직전 drain → control gate 가 일관 적용된다.
- `pause` / `resume` / `stop` envelope 가 처음으로 실효 효과 (lock-protected RUNNING/PAUSED/STOPPED 전이) 를 갖는다. 기존 phase-5a 의 envelope-only 동작은 opt-in 플래그로 보존.
- PAUSED → `pause_resume` noop ledger row + outcome `{kind:"noop", detail:"paused"}`, STOPPED → graceful daemon exit + lockdir release.

## Changes
| Module | Artifact | Notes |
|---|---|---|
| domain/schema | `src/domain/schema/control-state.ts` | `ControlStateRecord` zod schema (3-state enum + signal_id, changed_by, changed_at) |
| application | `src/application/control-state.ts` | `readControlState` / `applyControlSignal` (with `withFileLock` + signal_id idempotency) / `runDaemonPrelude` helper (action_kind=`pause_resume` noop row) |
| application | `src/application/human-signal-drain.ts` | optional `applyControlState: true` opt-in; control envelopes drive state machine BEFORE markProcessed; `stop` joins SYSTEM_ONLY validation |
| cli | `src/cli/daemon.ts` | 모든 role 의 cycle prelude: drain (outer-coordinator 만 binding 활성) → prelude gate → pickup. STOPPED → return 0 (graceful) |

## Tests
- [x] `tests/application/control-state.test.ts` — 14 unit tests covering default RUNNING, transitions, idempotency, prelude ledger emission
- [x] `tests/integration/control-state-drain.test.ts` — 5 drain integration tests (opt-in vs legacy, pause+resume round-trip, invalid stop)
- [x] `tests/integration/daemon-control-state.test.ts` — 4 daemon-loop end-to-end tests for planning §검증 (a) pause noop / (b) resume restoration / (c) stop graceful shutdown / STOPPED persistence
- [x] `npm test` clean — **655 passing** (was 632 on main)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean

## Conformance refs
- RGC-SIGNALS (RGC-PAUSE 활성 트랙)
- Invariants #4 (signal envelope persistence) / #8 (Caller-only operational write)
- Plan §G1-4 (`runHumanSignalDrain` 미배선 + 전역 control state 부재 gap 종결)

## Notes
- `pause_resume` ledger row 의 idempotency_key 는 `(role, state, signal_id)` 결합 — operator 가 동일 signal 로 paused 상태에 머무는 동안의 cycle 카운트는 row 갯수로 추적 가능 (ledger 의 `noop` 결과는 dedup 하지 않음). 새 pause signal 은 새 idempotency_key 를 만든다.
- outer-coordinator 만 drain binding 을 활성화 — 기타 role 은 `human_approval` 신호를 deferred 로 두어 outer-coordinator 이 pickup 하도록 보장 (5b.2 contract 유지).
- README contract matrix 갱신은 별도 KAC 갱신 cycle 에서 다룬다 (phase 7b 범위 외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)