### PR TITLE
feat(phase-7c): drift-observer daemon role (G1-2)

### DIFF
--- a/src/application/drift-observer.ts
+++ b/src/application/drift-observer.ts
@@ -51,6 +51,16 @@ export interface DriftObserverDeps {
   gitHost: GitHostPort;
   callerId: string;
   targetId: string;
+  /**
+   * PR #75 review (P1): provider tag of the wired IssueTracker / GitHost
+   * adapters (e.g. `"fs-mirror"`). Refs whose `provider` does not match are
+   * skipped to avoid the FsMirror adapter answering for a `provider: "github"`
+   * ref (which would return `null` and falsely flip the ref to `conflict`).
+   *
+   * The current daemon wiring is fs-mirror only; once GitHub adapters are
+   * wired here, this can become a multi-provider dispatcher.
+   */
+  adapterProvider: string;
 }
 
 export interface DriftObserverResult {
@@ -141,6 +151,8 @@ export async function runDriftObserverSweep(
     for (const ref of ms.external_refs) {
       if (ref.kind !== "milestone") continue;
       if (ref.sync_status === "conflict") continue;
+      // PR #75 review (P1): skip refs the wired adapter cannot answer for.
+      if (ref.provider !== deps.adapterProvider) continue;
       const observed = await deps.issueTracker.fetchMilestone({
         provider: ref.provider,
         id: ref.id,
@@ -175,6 +187,8 @@ export async function runDriftObserverSweep(
     for (const ref of sl.external_refs) {
       if (ref.kind !== "tracker") continue;
       if (ref.sync_status === "conflict") continue;
+      // PR #75 review (P1): skip refs the wired adapter cannot answer for.
+      if (ref.provider !== deps.adapterProvider) continue;
       const observed = await deps.issueTracker.fetchIssue({
         provider: ref.provider,
         id: ref.id,
@@ -209,6 +223,8 @@ export async function runDriftObserverSweep(
     for (const ref of sm.external_refs) {
       if (ref.kind !== "review_surface") continue;
       if (ref.sync_status === "conflict") continue;
+      // PR #75 review (P1): skip refs the wired adapter cannot answer for.
+      if (ref.provider !== deps.adapterProvider) continue;
       const observed = await deps.gitHost.fetchPullRequest({
         provider: ref.provider,
         id: ref.id,

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -77,8 +77,15 @@ interface CliArgs {
   callerId: string;
 }
 
+// PR #75 review (P1): drift-observer is an external surface poller and
+// should not run at the default 1s cadence. When `--cycle-interval-ms` is
+// omitted for `--role drift-observer`, fall back to ~60s.
+const DEFAULT_CYCLE_INTERVAL_MS = 1_000;
+const DRIFT_OBSERVER_DEFAULT_CYCLE_INTERVAL_MS = 60_000;
+
 function parseArgs(argv: readonly string[]): CliArgs {
   const a = [...argv];
+  let cycleIntervalMsExplicit = false;
   const out: Partial<CliArgs> & {
     fakeWorkspace: boolean;
     fakeVerification: boolean;
@@ -90,7 +97,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
     fakeWorkspace: false,
     fakeVerification: false,
     once: false,
-    cycleIntervalMs: 1_000,
+    cycleIntervalMs: DEFAULT_CYCLE_INTERVAL_MS,
     callerId: process.env.LLM_TEAM_CALLER_ID ?? `daemon-${process.pid}`,
     targetPath: "./target.json",
   };
@@ -127,6 +134,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
         if (!Number.isFinite(n) || n < 0)
           throw new Error("--cycle-interval-ms must be a non-negative integer");
         out.cycleIntervalMs = n;
+        cycleIntervalMsExplicit = true;
         break;
       }
       case "--fake-llm-fixtures":
@@ -152,6 +160,9 @@ function parseArgs(argv: readonly string[]): CliArgs {
     throw new Error(
       "--role is required (turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery | drift-observer)",
     );
+  if (out.role === "drift-observer" && !cycleIntervalMsExplicit) {
+    out.cycleIntervalMs = DRIFT_OBSERVER_DEFAULT_CYCLE_INTERVAL_MS;
+  }
   return out as CliArgs;
 }
 
@@ -428,6 +439,9 @@ async function main(argv: readonly string[]): Promise<number> {
             gitHost,
             callerId: args.callerId,
             targetId: cfg.identity.target_id,
+            // PR #75 review (P1): provider guard — only refs whose
+            // `provider` matches the wired adapter (fs-mirror) are swept.
+            adapterProvider: FsMirrorIssueTracker.provider,
           });
           outcomeJson = JSON.stringify({
             role: args.role,

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -3,6 +3,7 @@
  * Phase 4 daemon CLI — runs continuous loops with lease-protected pickup.
  *
  *   tsx src/cli/daemon.ts --role turn-worker | dialogue-coordinator | recovery
+ *     | drift-observer
  *     --target ./target.json [--workdir <path>]
  *     [--once] [--cycle-interval-ms 1000]
  *     [--fake-llm-fixtures <dir>] [--fake-workspace] [--fake-verification]
@@ -11,6 +12,10 @@
  *   - `turn-worker`         — phase-2 inner cycle (forge solo).
  *   - `dialogue-coordinator` — phase-3 middle review pickup.
  *   - `recovery`            — phase-4 sweeper. Cycles through expired leases.
+ *   - `drift-observer`      — phase-7c (G1-2). Polls external surfaces for
+ *     non-signal drift and writes `external_observation` ledger rows. Uses
+ *     the FsMirror IssueTracker / GitHost adapters; production GitHub-API
+ *     wiring is out of scope for this phase.
  *
  * Atomicity (RGC-DAEMON-STARTUP): every daemon role takes a per-role PID
  * lockdir under `<workdir>/log/daemon-<role>.pid.lock`. Sibling failure on
@@ -36,11 +41,14 @@ import { ShellVerification } from "../adapters/verification/shell.js";
 import { GitWorktreeWorkspace } from "../adapters/workspace/git-worktree.js";
 import { FakeWorkspace } from "../adapters/workspace/fake.js";
 import { FsHumanSignal } from "../adapters/human-signal/fs.js";
+import { FsMirrorIssueTracker } from "../adapters/issue-tracker/fs-mirror.js";
+import { FsMirrorGitHost } from "../adapters/git-host/fs-mirror.js";
 import { validateOrThrow } from "../application/config-validator.js";
 import { runDaemonPrelude } from "../application/control-state.js";
 import { runOneMiddleReviewTurn } from "../application/dialogue-coordinator.js";
 import { runOneDualTrackTurn } from "../application/dual-track-scheduler.js";
 import { runHumanSignalDrain } from "../application/human-signal-drain.js";
+import { runDriftObserverSweep } from "../application/drift-observer.js";
 import { FileLedger } from "../application/ledger.js";
 import { runOneOuterTurn } from "../application/outer-turn.js";
 import { LOG_DAEMON_PATH } from "../application/persistence-layout.js";
@@ -53,7 +61,8 @@ type DaemonRole =
   | "dialogue-coordinator"
   | "outer-coordinator"
   | "dual-track-scheduler"
-  | "recovery";
+  | "recovery"
+  | "drift-observer";
 
 interface CliArgs {
   role: DaemonRole;
@@ -95,10 +104,11 @@ function parseArgs(argv: readonly string[]): CliArgs {
           v !== "dialogue-coordinator" &&
           v !== "outer-coordinator" &&
           v !== "dual-track-scheduler" &&
-          v !== "recovery"
+          v !== "recovery" &&
+          v !== "drift-observer"
         )
           throw new Error(
-            `--role must be turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery (got ${v ?? "<missing>"})`,
+            `--role must be turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery | drift-observer (got ${v ?? "<missing>"})`,
           );
         out.role = v;
         break;
@@ -140,7 +150,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
   }
   if (out.role == null)
     throw new Error(
-      "--role is required (turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery)",
+      "--role is required (turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery | drift-observer)",
     );
   return out as CliArgs;
 }
@@ -197,7 +207,9 @@ async function main(argv: readonly string[]): Promise<number> {
     // `LLM_TEAM_ALLOW_FAKE_RUNNER=1`; production deployments never set it,
     // so a smuggled `runner: "fake"` in target.json fails fast.
     const needsLlmRunner =
-      args.role !== "recovery" && args.role !== "dual-track-scheduler";
+      args.role !== "recovery" &&
+      args.role !== "dual-track-scheduler" &&
+      args.role !== "drift-observer";
     const allowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER === "1";
     const llmRunner = args.fakeLlmFixtures
       ? new AdapterRunnerPort(new FakeAdapter({ fixtureDir: args.fakeLlmFixtures }))
@@ -397,6 +409,30 @@ async function main(argv: readonly string[]): Promise<number> {
         case "recovery": {
           // Recovery sweep already ran above — emit a noop outcome.
           outcomeJson = JSON.stringify({ role: args.role, outcome: { kind: "swept" } });
+          break;
+        }
+        case "drift-observer": {
+          // Phase 7c (G1-2) — poll external surfaces for non-signal drift.
+          // Uses FsMirror adapters; production GitHub-API wiring is out of
+          // scope for this phase. Slice/SliceMerge edits inside the sweep
+          // are protected by store.withFileLock, and the per-role lockdir
+          // already excludes a sibling drift-observer daemon, so no
+          // additional lease is required here.
+          const issueTracker = new FsMirrorIssueTracker(store);
+          const gitHost = new FsMirrorGitHost(store);
+          const out = await runDriftObserverSweep({
+            store,
+            clock,
+            ledger,
+            issueTracker,
+            gitHost,
+            callerId: args.callerId,
+            targetId: cfg.identity.target_id,
+          });
+          outcomeJson = JSON.stringify({
+            role: args.role,
+            outcome: { kind: "swept", conflicts: out.conflicts.length },
+          });
           break;
         }
       }

--- a/tests/integration/daemon-drift-observer.test.ts
+++ b/tests/integration/daemon-drift-observer.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Phase 7c (G1-2) — drift-observer daemon role.
+ *
+ * Asserts the planning §검증 trio:
+ *   (a) external (fs-mirror) drift on a Slice's tracker ref → next daemon
+ *       cycle emits `external_observation` ledger row + outcome
+ *       `{ kind: "swept", conflicts: 1 }`.
+ *   (b) STOPPED control-state gate suppresses pickup (drift sweep does NOT
+ *       run; `stopped` outcome instead). Confirms drift-observer reuses the
+ *       phase-7b prelude.
+ *   (c) sibling drift-observer daemons can not race — the second startup
+ *       fails on the per-role lockdir.
+ */
+import {
+  existsSync,
+  mkdtempSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FsMirrorIssueTracker } from "../../src/adapters/issue-tracker/fs-mirror.js";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import { daemonMain } from "../../src/cli/daemon.js";
+import { applyControlSignal } from "../../src/application/control-state.js";
+import { LEDGER_TRANSITIONS_PATH, layout } from "../../src/application/persistence-layout.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { HumanSignalEnvelope } from "../../src/domain/schema/human-signal.js";
+import { Slice } from "../../src/domain/schema/slice.js";
+import { FixedClock } from "../../src/ports/clock.js";
+
+const TARGET_ID = "demo-target";
+const ISO_BASE = "2026-05-09T00:00:00.000Z";
+const SLICE_ID = "01HZSA00000000000000000777";
+const MILESTONE_ID = "01HZMS00000000000000000777";
+
+function writeTarget(workdir: string): string {
+  const target = {
+    identity: {
+      target_id: TARGET_ID,
+      workdir_path: workdir,
+      audit_hash_seed: "seed-7c",
+    },
+    agent_profiles: {
+      atlas: { runner: "fake" },
+      forge: { runner: "fake" },
+      sentinel: { runner: "fake" },
+      scout: { runner: "fake" },
+    },
+  };
+  const path = join(workdir, "target.json");
+  writeFileSync(path, JSON.stringify(target), "utf8");
+  return path;
+}
+
+function captureStdout(): { restore: () => void; lines: () => string[] } {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  const spy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(((c: string | Uint8Array) => {
+      chunks.push(typeof c === "string" ? c : Buffer.from(c).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write);
+  return {
+    restore: () => {
+      spy.mockRestore();
+      void orig;
+    },
+    lines: () =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter((s) => s.length > 0),
+  };
+}
+
+async function readLedgerRows(store: FsStore): Promise<LedgerRow[]> {
+  const body = await store.readText(LEDGER_TRANSITIONS_PATH);
+  if (body == null) return [];
+  return body
+    .split("\n")
+    .filter((s) => s.length > 0)
+    .map((s) => LedgerRow.parse(JSON.parse(s)));
+}
+
+async function persistSliceWithTrackerRef(
+  store: FsStore,
+  trackerId: string,
+  initialRevision: string,
+): Promise<void> {
+  const sl = Slice.parse({
+    slice_id: SLICE_ID,
+    milestone_id: MILESTONE_ID,
+    slice_kind: "feature",
+    value_statement: "x",
+    ac_ids: [],
+    acceptance_tests: [],
+    declared_scope: [],
+    declared_metric_threshold: null,
+    interface_break: false,
+    dependencies: [],
+    trunk_base_revision: "deadbeef",
+    dod_revision_pin: "deadbeef",
+    state: "SLICE_BUILDING",
+    current_session_id: null,
+    spawning_proposal_id: null,
+    abandoned_reason: null,
+    external_refs: [
+      {
+        provider: "fs-mirror",
+        kind: "tracker",
+        id: trackerId,
+        sync_status: "synced",
+        last_seen_external_revision: initialRevision,
+        last_synced_internal_revision: "rev1",
+      },
+    ],
+    created_at: ISO_BASE,
+    updated_at: ISO_BASE,
+  });
+  await store.writeAtomic(layout.slice(SLICE_ID), JSON.stringify(sl, null, 2));
+}
+
+describe("Phase 7c — drift-observer daemon role", () => {
+  let prevAllowFake: string | undefined;
+
+  beforeEach(() => {
+    prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+  });
+
+  afterEach(() => {
+    if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+  });
+
+  it("(a) inbound drift on Slice tracker ref → external_observation ledger row + swept outcome", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase7c-drift-"));
+    const targetPath = writeTarget(workdir);
+    const store = new FsStore({ workdir });
+
+    const issueTracker = new FsMirrorIssueTracker(store);
+    const issue = await issueTracker.createIssue({
+      kind: "tracker",
+      title: "S",
+      body: "",
+      labels: ["slice-state/building"],
+    });
+    await persistSliceWithTrackerRef(store, issue.id, "1");
+    // Out-of-band external mutation: a human edits labels via the tracker
+    // (revision becomes 2). The daemon's drift sweep must catch this.
+    await issueTracker.__externalMutate(issue, (s) => ({
+      ...s,
+      labels: [...s.labels, "manually-tagged"],
+    }));
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "drift-observer",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--caller-id",
+        "phase7c-do",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: { kind: string; conflicts?: number };
+    };
+    expect(parsed.role).toBe("drift-observer");
+    expect(parsed.outcome.kind).toBe("swept");
+    expect(parsed.outcome.conflicts).toBe(1);
+
+    // Slice persisted with sync_status=conflict.
+    const persisted = Slice.parse(
+      JSON.parse((await store.readText(layout.slice(SLICE_ID)))!),
+    );
+    expect(persisted.external_refs[0]!.sync_status).toBe("conflict");
+
+    // Ledger has external_observation row.
+    const rows = await readLedgerRows(store);
+    const obs = rows.filter((r) => r.action_kind === "external_observation");
+    expect(obs.length).toBe(1);
+    expect(obs[0]!.object_kind).toBe("slice");
+    expect(obs[0]!.object_id).toBe(SLICE_ID);
+    expect(obs[0]!.result).toBe("applied");
+    expect(obs[0]!.result_detail).toBe("drift_revision_mismatch");
+  });
+
+  it("(b) STOPPED control-state suppresses drift sweep (prelude reused)", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase7c-stop-"));
+    const targetPath = writeTarget(workdir);
+    const store = new FsStore({ workdir });
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+
+    // Pre-set STOPPED control-state. The drift-observer daemon's prelude
+    // must short-circuit before the sweep runs.
+    await applyControlSignal(
+      store,
+      clock,
+      HumanSignalEnvelope.parse({
+        signal_id: "sig-stop-1",
+        signal_type: "stop",
+        target_kind: "system",
+        target_id: "system",
+        actor: "operator",
+        created_at: ISO_BASE,
+        source: "fs_drop",
+      }),
+    );
+
+    // Plant a drifting slice — this drift must NOT be picked up because the
+    // daemon is STOPPED.
+    const issueTracker = new FsMirrorIssueTracker(store);
+    const issue = await issueTracker.createIssue({
+      kind: "tracker",
+      title: "S",
+      body: "",
+      labels: [],
+    });
+    await persistSliceWithTrackerRef(store, issue.id, "1");
+    await issueTracker.__externalMutate(issue, (s) => ({
+      ...s,
+      labels: ["edited"],
+    }));
+
+    const cap = captureStdout();
+    try {
+      const code = await daemonMain([
+        "--role",
+        "drift-observer",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        // No --once: STOPPED must end the loop on its own.
+        "--cycle-interval-ms",
+        "0",
+        "--caller-id",
+        "phase7c-do",
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      cap.restore();
+    }
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as { outcome: { kind: string } };
+    expect(parsed.outcome.kind).toBe("stopped");
+
+    // Slice ref still synced — drift sweep was gated.
+    const persisted = Slice.parse(
+      JSON.parse((await store.readText(layout.slice(SLICE_ID)))!),
+    );
+    expect(persisted.external_refs[0]!.sync_status).toBe("synced");
+
+    // No external_observation rows in the ledger.
+    const rows = await readLedgerRows(store);
+    expect(
+      rows.filter((r) => r.action_kind === "external_observation").length,
+    ).toBe(0);
+
+    // Lockdir released on graceful shutdown.
+    expect(
+      existsSync(join(workdir, "log", "daemon-drift-observer.pid.lock")),
+    ).toBe(false);
+  });
+
+  it("(c) sibling drift-observer daemon fails on per-role lockdir", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase7c-lock-"));
+    const targetPath = writeTarget(workdir);
+
+    // Manually plant the lockdir as if a sibling daemon were running.
+    const { mkdirSync } = await import("node:fs");
+    const lockPath = join(workdir, "log", "daemon-drift-observer.pid.lock");
+    mkdirSync(lockPath, { recursive: true });
+
+    const cap = captureStdout();
+    try {
+      await expect(
+        daemonMain([
+          "--role",
+          "drift-observer",
+          "--target",
+          targetPath,
+          "--workdir",
+          workdir,
+          "--once",
+          "--cycle-interval-ms",
+          "0",
+          "--caller-id",
+          "phase7c-do",
+        ]),
+      ).rejects.toThrow(/another daemon role=drift-observer/);
+    } finally {
+      cap.restore();
+    }
+  });
+});

--- a/tests/integration/drift-observer.test.ts
+++ b/tests/integration/drift-observer.test.ts
@@ -139,6 +139,7 @@ describe("drift-observer (Phase 6b)", () => {
       gitHost,
       callerId: "drift",
       targetId: "demo",
+      adapterProvider: "fs-mirror",
     });
     expect(out.conflicts.length).toBe(1);
     expect(out.conflicts[0]!.reason).toBe("revision_mismatch");
@@ -176,6 +177,7 @@ describe("drift-observer (Phase 6b)", () => {
       gitHost,
       callerId: "drift",
       targetId: "demo",
+      adapterProvider: "fs-mirror",
     });
     expect(out.conflicts.length).toBe(1);
     expect(out.conflicts[0]!.reason).toBe("disappeared");
@@ -205,6 +207,7 @@ describe("drift-observer (Phase 6b)", () => {
       gitHost,
       callerId: "drift",
       targetId: "demo",
+      adapterProvider: "fs-mirror",
     });
     expect(out.conflicts.length).toBe(0);
     const after = await store.readText(LEDGER_TRANSITIONS_PATH);
@@ -233,6 +236,7 @@ describe("drift-observer (Phase 6b)", () => {
       gitHost,
       callerId: "drift",
       targetId: "demo",
+      adapterProvider: "fs-mirror",
     });
     const ledgerSize1 = (
       await store.readText(LEDGER_TRANSITIONS_PATH)
@@ -245,6 +249,7 @@ describe("drift-observer (Phase 6b)", () => {
       gitHost,
       callerId: "drift",
       targetId: "demo",
+      adapterProvider: "fs-mirror",
     });
     expect(out2.conflicts.length).toBe(0);
     const ledgerSize2 = (
@@ -278,6 +283,7 @@ describe("drift-observer (Phase 6b)", () => {
       gitHost,
       callerId: "drift",
       targetId: "demo",
+      adapterProvider: "fs-mirror",
     });
     expect(out.conflicts.length).toBe(1);
     expect(out.conflicts[0]!.object_kind).toBe("slice_merge");


### PR DESCRIPTION
## Summary
Phase 7c (G1-2) wires the existing `runDriftObserverSweep` (Phase 6b) into a new daemon role so external (non-signal) drift on Slice / SliceMerge / Milestone external_refs is continuously observed. The drift-observer role inherits the Phase 7b prelude (recovery sweep + human-signal drain + control-state gate), so PAUSED/STOPPED govern it identically to other roles.

## Changes
| Module | Artifact | Notes |
|---|---|---|
| `src/cli/daemon.ts` | `--role drift-observer` enum + parser branch | rejects non-roles with explicit error message |
| `src/cli/daemon.ts` | `needsLlmRunner` exclusion | drift-observer skips LLM runner assembly (no agent profiles consumed) |
| `src/cli/daemon.ts` | drift-observer switch case | calls `runDriftObserverSweep` with `FsMirrorIssueTracker` + `FsMirrorGitHost`; emits `{ kind: "swept", conflicts: N }` |
| `tests/integration/daemon-drift-observer.test.ts` | 3 new integration tests | (a) drift detection + `external_observation` ledger row, (b) STOPPED gate suppresses sweep, (c) per-role lockdir excludes sibling daemon |

## Tests
- 661 passing (was 658) — 3 new daemon-drift-observer integration tests
- typecheck clean
- build clean

```
Test Files  78 passed (78)
     Tests  661 passed (661)
```

## Conformance refs
- **RGC-LEDGER** `external_observation` — `docs/contracts/reliability-and-gate-contract.md`. Daemon role writes one ledger row per drift via the existing Phase 6b sweep, idempotency_key keyed on `(object_kind, object_id, provider, external_id, observed_revision, reason)`.
- **drift policy** — `docs/architecture/external-tracking-mapping.md` §5.1 (sync_status) + §6 (inbound non-signal events go to `conflict`; recovery is human governance signal only, no automatic mutation).
- **RGC-DAEMON-STARTUP** — per-role lockdir (`log/daemon-drift-observer.pid.lock`) excludes sibling daemons (test (c) covers).
- **RGC-SIGNALS / Inv #4 / #8** — drift-observer routes through `runDaemonPrelude` so PAUSED noop / STOPPED graceful-exit identical to Phase 7b roles (test (b) covers).
- **Plan §검증 G1-2** — GitHub fs-mirror adapter 로 inbound drift 시뮬레이션 → ledger row 검사. Test (a) drives this end-to-end.

## Notes
- Production GitHub-API wiring (`GitHubIssueTracker` / `GitHubGitHost`) is **out of scope** for this phase per planning constraints. The daemon hard-wires `FsMirror*` adapters for now; a future phase will add a target-config field selecting the concrete provider.
- drift-observer uses no `lease` and no `LLM runner`. Slice/SliceMerge mutations inside the sweep are protected by `store.withFileLock`, and the per-role lockdir prevents two drift-observer processes from racing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)