### PR TITLE
feat(phase-8b): KAC-SLICE-TELEMETRY emit + Discovery N+1 inject + pin drift (G2-3)

### DIFF
--- a/src/application/caller-dispatch.ts
+++ b/src/application/caller-dispatch.ts
@@ -48,6 +48,7 @@ import {
   promoteSliceMergeToApproved,
   type SliceMergeOpDeps,
 } from "./slice-merge.js";
+import { emitSliceTelemetry } from "./slice-telemetry.js";
 
 export interface DispatchInput {
   parent_loop: ParentLoop;
@@ -150,6 +151,26 @@ export async function dispatchOutcome(
   return { kind: "applied", effects: entry.effects, details };
 }
 
+/**
+ * Phase 8b — KAC-SLICE-TELEMETRY emit hook. Invoked AFTER the terminal
+ * Slice state transition for each dispatch effect so the partition snapshot
+ * reflects the post-transition state (Inv #3: Discovery N+1 manifest pin
+ * sees the live Delivery slice partition). Failures are non-fatal — the
+ * telemetry is read-side enrichment with warn-grade enforcement.
+ */
+async function emitTelemetryAfterTransition(
+  milestoneId: string,
+  smOpDeps: SliceMergeOpDeps,
+): Promise<void> {
+  try {
+    await emitSliceTelemetry({ milestone_id: milestoneId }, smOpDeps);
+  } catch {
+    // Swallow — telemetry emit is read-side enrichment; surfacing here
+    // would abort the dispatch after the slice transition has already
+    // committed.
+  }
+}
+
 async function runEffect(
   effect: DispatchEffect,
   input: DispatchInput,
@@ -172,6 +193,7 @@ async function runEffect(
         loop_kind: "inner",
         session_id: input.sessionId,
       });
+      await emitTelemetryAfterTransition(input.slice.milestone_id, smOpDeps);
       return {
         effect: "open_slice_merge_for_review",
         sliceMergeId: sm.slice_merge_id,
@@ -192,6 +214,7 @@ async function runEffect(
         loop_kind: "inner",
         session_id: input.sessionId,
       });
+      await emitTelemetryAfterTransition(input.slice.milestone_id, smOpDeps);
       return {
         effect: "close_slice_merge_blocked",
         sliceMergeId: input.sliceMerge.slice_merge_id,
@@ -243,6 +266,7 @@ async function runEffect(
           loop_kind: "middle",
           session_id: input.sessionId,
         });
+        await emitTelemetryAfterTransition(input.slice.milestone_id, smOpDeps);
         return {
           effect: "promote_slice_merge_to_approved_then_integrate",
           integrate: {
@@ -267,6 +291,7 @@ async function runEffect(
         loop_kind: "middle",
         session_id: input.sessionId,
       });
+      await emitTelemetryAfterTransition(input.slice.milestone_id, smOpDeps);
       return {
         effect: "promote_slice_merge_to_approved_then_integrate",
         integrate: {
@@ -293,6 +318,7 @@ async function runEffect(
         session_id: input.sessionId,
         clear_current_session: true,
       });
+      await emitTelemetryAfterTransition(input.slice.milestone_id, smOpDeps);
       return {
         effect: "reset_slice_for_rebuild",
         sliceMergeId: input.sliceMerge.slice_merge_id,

--- a/src/application/cross-slot-stale.ts
+++ b/src/application/cross-slot-stale.ts
@@ -46,6 +46,7 @@ import {
   type Milestone as MilestoneT,
   type MilestoneState,
 } from "../domain/schema/milestone.js";
+import { SliceTelemetry } from "../domain/schema/knowledge.js";
 import { newMonotonicId } from "../domain/ids.js";
 import type { ClockPort } from "../ports/clock.js";
 import type { StorePort } from "../ports/store.js";
@@ -275,37 +276,53 @@ async function detectDriftForSession(
   latestDeliveryUpdate: string,
   store: StorePort,
 ): Promise<DriftKind | null> {
-  const pin = await loadInjectedTelemetryPin(sess, store);
-  if (pin != null) {
-    // Find the Delivery milestone that this Discovery session was paired
-    // with — the inject path always picks the most-recently-updated
-    // Delivery in the same target. We mirror that selection here. If no
-    // matching Delivery exists anymore (e.g. archived), drop back to the
-    // conservative trigger.
-    const candidates = deliveryFamily
-      .filter(
+  const inject = await loadInjectedTelemetryPin(sess, store);
+  if (inject != null) {
+    // PR #77 P1 fix: pin the comparison to the *original* Delivery
+    // milestone the manifest was built against. The previous logic
+    // re-selected "most-recently-updated Delivery in the target" at
+    // detection time, which could swap to a different Delivery and
+    // produce false-stale (different milestone's telemetry compared) or
+    // missed-stale (the pinned milestone got rotated past). We resolve
+    // the pinned telemetry record (by its `telemetry_id` = manifest
+    // entry's object_id) to recover its `milestone_id`, then compare
+    // against that milestone's *current* telemetry only.
+    const pinnedDeliveryMilestoneId = await resolvePinnedDeliveryMilestoneId(
+      inject.telemetryId,
+      store,
+    );
+    if (pinnedDeliveryMilestoneId != null) {
+      // Confirm the pinned Delivery still exists and matches this
+      // Discovery's target (else fall through to the conservative
+      // trigger).
+      const pinnedDeliveryStillKnown = deliveryFamily.some(
         (m) =>
           m.target_id === discoveryMilestone.target_id &&
-          m.milestone_id !== discoveryMilestone.milestone_id,
-      )
-      .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
-    const deliveryN = candidates[0];
-    if (deliveryN != null) {
-      const live = await loadLatestSliceTelemetry(store, deliveryN.milestone_id);
-      if (live != null && live.audit_hash !== pin) {
-        return { kind: "telemetry_pin_drift", value: live.audit_hash };
-      }
-      if (live != null && live.audit_hash === pin) {
-        // Pin matches live telemetry — explicit "no drift" signal. Skip
-        // the fallback trigger so a moved Delivery updated_at without a
-        // material slice change does not re-stale.
-        return null;
-      }
-      // live==null but a pin existed: Delivery telemetry was rotated /
-      // archived — treat as drift.
-      if (live == null) {
+          m.milestone_id !== discoveryMilestone.milestone_id &&
+          m.milestone_id === pinnedDeliveryMilestoneId,
+      );
+      if (pinnedDeliveryStillKnown) {
+        const live = await loadLatestSliceTelemetry(
+          store,
+          pinnedDeliveryMilestoneId,
+        );
+        if (live != null && live.audit_hash !== inject.pin) {
+          return { kind: "telemetry_pin_drift", value: live.audit_hash };
+        }
+        if (live != null && live.audit_hash === inject.pin) {
+          // Pin matches live telemetry — explicit "no drift" signal. Skip
+          // the fallback trigger so a moved Delivery updated_at without a
+          // material slice change does not re-stale.
+          return null;
+        }
+        // live==null but a pin existed: Delivery telemetry was rotated /
+        // archived — treat as drift.
         return { kind: "telemetry_pin_drift", value: "<missing>" };
       }
+    } else {
+      // The pinned telemetry record itself is gone — treat as drift so
+      // the Discovery session re-resolves its base on next pickup.
+      return { kind: "telemetry_pin_drift", value: "<missing>" };
     }
   }
   // Fallback — phase-6a conservative trigger. Over-fires by design;
@@ -318,14 +335,16 @@ async function detectDriftForSession(
 }
 
 /**
- * Resolve the slice_telemetry manifest entry's `revision_pin` from the
- * session's most-recent SessionTurn's `input_manifest_id`. Returns null
- * when no turn exists yet or the manifest has no slice_telemetry entry.
+ * Resolve the slice_telemetry manifest entry from the session's most-recent
+ * SessionTurn's `input_manifest_id`. Returns the entry's `revision_pin`
+ * (the pinned `audit_hash`) and `object_id` (the pinned `telemetry_id`).
+ * Returns null when no turn exists yet or the manifest has no slice_telemetry
+ * entry.
  */
 async function loadInjectedTelemetryPin(
   sess: DialogueSessionT,
   store: StorePort,
-): Promise<string | null> {
+): Promise<{ pin: string; telemetryId: string } | null> {
   if (sess.current_turn_index <= 0) return null;
   // current_turn_index points at the *next* turn; the latest persisted
   // turn is current_turn_index - 1.
@@ -351,5 +370,24 @@ async function loadInjectedTelemetryPin(
     return null;
   }
   const entry = manifest.entries.find((e) => e.object_kind === "slice_telemetry");
-  return entry?.revision_pin ?? null;
+  if (entry == null) return null;
+  return { pin: entry.revision_pin, telemetryId: entry.object_id };
+}
+
+/**
+ * Read a persisted SliceTelemetry record by its `telemetry_id` and return
+ * the Delivery `milestone_id` it was emitted against. Returns null when
+ * the file is missing or unparseable.
+ */
+async function resolvePinnedDeliveryMilestoneId(
+  telemetryId: string,
+  store: StorePort,
+): Promise<string | null> {
+  const body = await store.readText(layout.sliceTelemetry(telemetryId));
+  if (body == null) return null;
+  try {
+    return SliceTelemetry.parse(JSON.parse(body)).milestone_id;
+  } catch {
+    return null;
+  }
 }

--- a/src/application/cross-slot-stale.ts
+++ b/src/application/cross-slot-stale.ts
@@ -1,28 +1,32 @@
 /**
- * RGC-CROSS-SLOT-STALE — cross-slot staleness detection (phase 6a).
+ * RGC-CROSS-SLOT-STALE — cross-slot staleness detection.
  *
  * Detects when a Discovery N+1 outer session has read-base-revision-pinned
  * an artefact from Delivery N that has since changed. When detected, the
  * affected Discovery N+1 SESSION_OPEN session is transitioned to
  * AWAITING_REVALIDATION (per RGC-CROSS-SLOT-STALE Caller Action table).
  *
- * Detection signal (FS-only, phase 6a — full revision pin replay arrives
- * with phase 5c/6b telemetry):
+ * Detection signal — phase 8b (KAC-SLICE-TELEMETRY pin comparison):
  *
  *   - For each SESSION_OPEN whose `parent_loop = "outer"` and whose
- *     `parent_object_kind = "milestone"`:
- *       - find the milestone the session belongs to.
- *       - if the milestone is in a Discovery / Specification state AND a
- *         peer Delivery milestone (state ∈ {M_DELIVERY_BUILDING,
- *         M_DELIVERY_VALIDATING, M_DONE}) was updated AFTER the Discovery
- *         session's `updated_at`, mark the Discovery session as stale.
+ *     `parent_object_kind = "milestone"` and whose milestone is in a
+ *     Discovery / Specification state:
  *
- *   - The conservative "any newer Delivery update" trigger is intentional
- *     — phase 6a does not yet track manifest read_base_revision_pin (that
- *     arrives with KAC-SLICE-TELEMETRY inject in phase 5c). The trigger
- *     can therefore over-fire (false-stale); RGC-CROSS-SLOT-STALE allows
- *     warn-grade enforcement (`telemetry_enrichment_missing=warn`) so
- *     this conservative behaviour is contract-compliant.
+ *     1. Resolve the session's *latest* SessionTurn → its `input_manifest_id`.
+ *     2. Read the manifest; locate the entry whose `object_kind` is
+ *        `slice_telemetry` (injected by `outer-turn.ts` for the live
+ *        Delivery N).
+ *     3. Look up the Delivery milestone's *current* SliceTelemetry (via
+ *        `loadLatestSliceTelemetry`) and compare its `audit_hash` to the
+ *        manifest entry's `revision_pin`. Drift → AWAITING_REVALIDATION.
+ *
+ *   - Fallback (no telemetry inject yet — fresh Discovery session whose
+ *     first turn has not run, or no Delivery has emitted telemetry): the
+ *     conservative phase-6a trigger ("any newer Delivery update than the
+ *     Discovery session's updated_at") is preserved. This preserves
+ *     dual-slot safety while telemetry catches up — KAC-SLICE-TELEMETRY
+ *     is `telemetry_enrichment_missing=warn`, so over-firing here remains
+ *     contract-compliant.
  *
  * Atomicity: each session is transitioned under
  * `withFileLock(sessionMetadata)` with a read-check-write. The function is
@@ -34,6 +38,10 @@ import {
   type DialogueSession as DialogueSessionT,
 } from "../domain/schema/dialogue-session.js";
 import {
+  ContextManifest,
+  type ContextManifest as ContextManifestT,
+} from "../domain/schema/manifest.js";
+import {
   Milestone,
   type Milestone as MilestoneT,
   type MilestoneState,
@@ -44,6 +52,7 @@ import type { StorePort } from "../ports/store.js";
 import { idempotencyKey } from "./idempotency.js";
 import type { LedgerAppender } from "./ledger.js";
 import { layout } from "./persistence-layout.js";
+import { loadLatestSliceTelemetry } from "./slice-telemetry.js";
 
 const DISCOVERY_FAMILY: readonly MilestoneState[] = [
   "M_DISCOVERY_DRAFT",
@@ -138,7 +147,8 @@ export async function detectCrossSlotStaleSessions(
   // Skip the pass; an explicit check rather than relying on the reduce
   // below makes the intent visible to readers.
   if (deliveryFamily.length === 0) return { staledSessionIds: [] };
-  // Latest Delivery activity timestamp — the conservative trigger.
+  // Latest Delivery activity timestamp — the fallback trigger when no
+  // KAC-SLICE-TELEMETRY pin is available for comparison.
   const latestDeliveryUpdate = deliveryFamily.reduce(
     (acc, m) => (m.updated_at > acc ? m.updated_at : acc),
     deliveryFamily[0]!.updated_at,
@@ -151,7 +161,15 @@ export async function detectCrossSlotStaleSessions(
     const milestone = byId.get(sess.parent_object_id);
     if (milestone == null) continue;
     if (!DISCOVERY_FAMILY.includes(milestone.state)) continue;
-    if (sess.updated_at >= latestDeliveryUpdate) continue;
+
+    const driftKind = await detectDriftForSession(
+      sess,
+      milestone,
+      deliveryFamily,
+      latestDeliveryUpdate,
+      deps.store,
+    );
+    if (driftKind == null) continue;
 
     const sessionPath = layout.sessionMetadata(sess.session_id);
     const transitioned = await deps.store.withFileLock(
@@ -210,7 +228,13 @@ export async function detectCrossSlotStaleSessions(
         parts: {
           kind: "cross_slot_stale",
           session_id: sess.session_id,
-          delivery_revision: latestDeliveryUpdate,
+          // Idempotency key keys on the trigger that fired so a session
+          // re-flagged via a different drift kind would still produce a
+          // distinct ledger row. `telemetry_pin_drift` carries the new
+          // pin; `delivery_updated_at` falls back to the latest Delivery
+          // updated_at (phase-6a conservative trigger).
+          drift_kind: driftKind.kind,
+          drift_value: driftKind.value,
         },
       }),
       lease_token: null,
@@ -223,4 +247,109 @@ export async function detectCrossSlotStaleSessions(
   }
 
   return { staledSessionIds: staledIds };
+}
+
+/**
+ * Per-session drift signal.
+ *
+ * `kind="telemetry_pin_drift"` — the Discovery session's latest manifest
+ * referenced a SliceTelemetry whose audit_hash no longer matches the
+ * Delivery milestone's current SliceTelemetry. `value` records the new
+ * audit_hash.
+ *
+ * `kind="delivery_updated_at"` — fallback (phase-6a conservative trigger):
+ * Delivery activity timestamp moved past the Discovery session's
+ * `updated_at`, and either no telemetry inject was present yet OR a
+ * telemetry pin was present but the Discovery session's updated_at also
+ * pre-dates the latest Delivery activity. `value` records the latest
+ * Delivery `updated_at`.
+ */
+type DriftKind =
+  | { kind: "telemetry_pin_drift"; value: string }
+  | { kind: "delivery_updated_at"; value: string };
+
+async function detectDriftForSession(
+  sess: DialogueSessionT,
+  discoveryMilestone: MilestoneT,
+  deliveryFamily: readonly MilestoneT[],
+  latestDeliveryUpdate: string,
+  store: StorePort,
+): Promise<DriftKind | null> {
+  const pin = await loadInjectedTelemetryPin(sess, store);
+  if (pin != null) {
+    // Find the Delivery milestone that this Discovery session was paired
+    // with — the inject path always picks the most-recently-updated
+    // Delivery in the same target. We mirror that selection here. If no
+    // matching Delivery exists anymore (e.g. archived), drop back to the
+    // conservative trigger.
+    const candidates = deliveryFamily
+      .filter(
+        (m) =>
+          m.target_id === discoveryMilestone.target_id &&
+          m.milestone_id !== discoveryMilestone.milestone_id,
+      )
+      .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+    const deliveryN = candidates[0];
+    if (deliveryN != null) {
+      const live = await loadLatestSliceTelemetry(store, deliveryN.milestone_id);
+      if (live != null && live.audit_hash !== pin) {
+        return { kind: "telemetry_pin_drift", value: live.audit_hash };
+      }
+      if (live != null && live.audit_hash === pin) {
+        // Pin matches live telemetry — explicit "no drift" signal. Skip
+        // the fallback trigger so a moved Delivery updated_at without a
+        // material slice change does not re-stale.
+        return null;
+      }
+      // live==null but a pin existed: Delivery telemetry was rotated /
+      // archived — treat as drift.
+      if (live == null) {
+        return { kind: "telemetry_pin_drift", value: "<missing>" };
+      }
+    }
+  }
+  // Fallback — phase-6a conservative trigger. Over-fires by design;
+  // KAC-SLICE-TELEMETRY allows warn-grade enforcement so this stays
+  // contract-compliant until every Discovery session has an injected pin.
+  if (sess.updated_at < latestDeliveryUpdate) {
+    return { kind: "delivery_updated_at", value: latestDeliveryUpdate };
+  }
+  return null;
+}
+
+/**
+ * Resolve the slice_telemetry manifest entry's `revision_pin` from the
+ * session's most-recent SessionTurn's `input_manifest_id`. Returns null
+ * when no turn exists yet or the manifest has no slice_telemetry entry.
+ */
+async function loadInjectedTelemetryPin(
+  sess: DialogueSessionT,
+  store: StorePort,
+): Promise<string | null> {
+  if (sess.current_turn_index <= 0) return null;
+  // current_turn_index points at the *next* turn; the latest persisted
+  // turn is current_turn_index - 1.
+  const lastIdx = sess.current_turn_index - 1;
+  const turnBody = await store.readText(
+    layout.sessionTurn(sess.session_id, lastIdx),
+  );
+  if (turnBody == null) return null;
+  let manifestId: string;
+  try {
+    const turn = JSON.parse(turnBody) as { input_manifest_id?: unknown };
+    if (typeof turn.input_manifest_id !== "string") return null;
+    manifestId = turn.input_manifest_id;
+  } catch {
+    return null;
+  }
+  const manifestBody = await store.readText(layout.manifest(manifestId));
+  if (manifestBody == null) return null;
+  let manifest: ContextManifestT;
+  try {
+    manifest = ContextManifest.parse(JSON.parse(manifestBody));
+  } catch {
+    return null;
+  }
+  const entry = manifest.entries.find((e) => e.object_kind === "slice_telemetry");
+  return entry?.revision_pin ?? null;
 }

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -354,6 +354,7 @@ export async function runOneOuterTurn(
     session.session_id,
     deps.store,
     deliveryTelemetry?.telemetry ?? null,
+    deliveryTelemetry?.deliveryMilestoneId ?? null,
   );
   const manifestBuilder = new ManifestBuilder(pinResolver, deps.clock);
   const manifest = await manifestBuilder.build({
@@ -929,6 +930,7 @@ class OuterPinResolver implements RevisionPinResolver {
     private readonly sessionId: string,
     private readonly store: StorePort,
     private readonly deliveryTelemetry: SliceTelemetryT | null,
+    private readonly deliveryMilestoneId: string | null,
   ) {}
   async resolve(entry: ManifestEntryDraft): Promise<string> {
     if (entry.object_kind === "milestone") {
@@ -957,13 +959,24 @@ class OuterPinResolver implements RevisionPinResolver {
       // KAC-SLICE-TELEMETRY (phase 8b): pin = telemetry audit_hash. Drift
       // (Delivery emits a new audit_hash) trips the manifest stale-pin
       // gate AND RGC-CROSS-SLOT-STALE in `cross-slot-stale.ts`.
-      if (
-        this.deliveryTelemetry != null &&
-        this.deliveryTelemetry.telemetry_id === entry.object_id
-      ) {
-        return this.deliveryTelemetry.audit_hash;
+      //
+      // PR #77 P0-2 fix: re-read the live latest telemetry pointer for the
+      // pinned Delivery milestone. ManifestBuilder.recheckPins() resolves
+      // each entry again after callAgent, so without this live re-read a
+      // mid-turn Delivery emit (new audit_hash on the same milestone)
+      // would not trip the stale gate — the resolver would keep returning
+      // the snapshot's audit_hash. We compare by Delivery milestone_id
+      // rather than telemetry_id because the telemetry_id rotates on every
+      // emit; the milestone is the stable identity for "Delivery N".
+      if (this.deliveryMilestoneId == null) {
+        return `missing:${entry.object_id}`;
       }
-      return `missing:${entry.object_id}`;
+      const live = await loadLatestSliceTelemetry(
+        this.store,
+        this.deliveryMilestoneId,
+      );
+      if (live == null) return `missing:${entry.object_id}`;
+      return live.audit_hash;
     }
     return this.milestone.updated_at;
   }

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -52,7 +52,7 @@ import {
   type Participant,
 } from "../domain/schema/dialogue-session.js";
 import type { Envelope } from "../domain/schema/envelope.js";
-import type { Milestone as MilestoneT } from "../domain/schema/milestone.js";
+import { Milestone, type Milestone as MilestoneT } from "../domain/schema/milestone.js";
 import type { CallerRoutingDecision } from "../domain/schema/session-turn.js";
 import type { ClockPort } from "../ports/clock.js";
 import type { LlmRunnerPort } from "../ports/llm-runner.js";
@@ -88,6 +88,8 @@ import {
   aggregateValidationEvidence,
   type ScoutEvidenceResult,
 } from "./scout-observer.js";
+import { loadLatestSliceTelemetry } from "./slice-telemetry.js";
+import type { SliceTelemetry as SliceTelemetryT } from "../domain/schema/knowledge.js";
 
 export interface OuterTurnDeps {
   store: StorePort;
@@ -330,7 +332,29 @@ export async function runOneOuterTurn(
       purpose: `prior turn ${i} (${t.agent_role_in_session})${rcSuffix}`,
     });
   }
-  const pinResolver = new OuterPinResolver(milestone, session.session_id, deps.store);
+  // KAC-SLICE-TELEMETRY (phase 8b) — Discovery N+1 / Specification N+1
+  // manifests inject the live SliceTelemetry from the active Delivery N
+  // milestone in the same target (read-only). The pin records the
+  // telemetry's audit_hash so RGC-CROSS-SLOT-STALE can detect drift.
+  const deliveryTelemetry =
+    phase === "Discovery" || phase === "Specification"
+      ? await loadDeliveryTelemetryForInject(milestone, deps.store)
+      : null;
+  if (deliveryTelemetry != null) {
+    drafts.push({
+      object_kind: "slice_telemetry",
+      object_id: deliveryTelemetry.telemetry.telemetry_id,
+      fetch_scope: "body",
+      required: false,
+      purpose: `Delivery N=${deliveryTelemetry.deliveryMilestoneId} live slice telemetry (read-only)`,
+    });
+  }
+  const pinResolver = new OuterPinResolver(
+    milestone,
+    session.session_id,
+    deps.store,
+    deliveryTelemetry?.telemetry ?? null,
+  );
   const manifestBuilder = new ManifestBuilder(pinResolver, deps.clock);
   const manifest = await manifestBuilder.build({
     session_id: session.session_id,
@@ -904,6 +928,7 @@ class OuterPinResolver implements RevisionPinResolver {
     private readonly milestone: MilestoneT,
     private readonly sessionId: string,
     private readonly store: StorePort,
+    private readonly deliveryTelemetry: SliceTelemetryT | null,
   ) {}
   async resolve(entry: ManifestEntryDraft): Promise<string> {
     if (entry.object_kind === "milestone") {
@@ -928,8 +953,70 @@ class OuterPinResolver implements RevisionPinResolver {
       if (body == null) return `missing:${entry.object_id}`;
       return `len=${body.length}:${body.slice(0, 32).replace(/\s+/g, "")}`;
     }
+    if (entry.object_kind === "slice_telemetry") {
+      // KAC-SLICE-TELEMETRY (phase 8b): pin = telemetry audit_hash. Drift
+      // (Delivery emits a new audit_hash) trips the manifest stale-pin
+      // gate AND RGC-CROSS-SLOT-STALE in `cross-slot-stale.ts`.
+      if (
+        this.deliveryTelemetry != null &&
+        this.deliveryTelemetry.telemetry_id === entry.object_id
+      ) {
+        return this.deliveryTelemetry.audit_hash;
+      }
+      return `missing:${entry.object_id}`;
+    }
     return this.milestone.updated_at;
   }
+}
+
+/**
+ * Resolve the live Delivery N SliceTelemetry to inject into a Discovery /
+ * Specification N+1 manifest. Returns null when no Delivery family
+ * milestone (M_DELIVERY_BUILDING / VALIDATING / DONE) shares the target
+ * OR when the latest such milestone has no SliceTelemetry emitted yet
+ * (KAC-SLICE-TELEMETRY allows `telemetry_enrichment_missing=warn`).
+ */
+async function loadDeliveryTelemetryForInject(
+  discoveryMilestone: MilestoneT,
+  store: StorePort,
+): Promise<{
+  telemetry: SliceTelemetryT;
+  deliveryMilestoneId: string;
+} | null> {
+  const deliveryFamily: readonly string[] = [
+    "M_DELIVERY_BUILDING",
+    "M_DELIVERY_VALIDATING",
+    "M_DONE",
+  ];
+  let names: string[];
+  try {
+    names = await store.list("milestones");
+  } catch {
+    return null;
+  }
+  const candidates: MilestoneT[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const body = await store.readText(`milestones/${name}`);
+    if (body == null) continue;
+    let m: MilestoneT;
+    try {
+      m = Milestone.parse(JSON.parse(body));
+    } catch {
+      continue;
+    }
+    if (m.target_id !== discoveryMilestone.target_id) continue;
+    if (m.milestone_id === discoveryMilestone.milestone_id) continue;
+    if (!deliveryFamily.includes(m.state)) continue;
+    candidates.push(m);
+  }
+  if (candidates.length === 0) return null;
+  // Most-recently-updated Delivery is "Delivery N" for inject purposes.
+  candidates.sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+  const deliveryN = candidates[0]!;
+  const telemetry = await loadLatestSliceTelemetry(store, deliveryN.milestone_id);
+  if (telemetry == null) return null;
+  return { telemetry, deliveryMilestoneId: deliveryN.milestone_id };
 }
 
 function decideRouting(envelope: Envelope): CallerRoutingDecision {

--- a/src/application/persistence-layout.ts
+++ b/src/application/persistence-layout.ts
@@ -69,6 +69,16 @@ export const layout = {
   sliceTelemetry(telemetryId: string): string {
     return `knowledge/slice_telemetry/${requireUlid("telemetry_id", telemetryId)}.json`;
   },
+  /**
+   * KAC-SLICE-TELEMETRY (phase 8b) — pointer file holding the latest
+   * SliceTelemetry telemetry_id for a given Delivery milestone. Discovery
+   * N+1 manifest inject and RGC-CROSS-SLOT-STALE drift detection both read
+   * this pointer to resolve the live telemetry without scanning the
+   * directory. The pointer body is `{ "telemetry_id": <ULID> }`.
+   */
+  latestSliceTelemetryByMilestone(milestoneId: string): string {
+    return `knowledge/slice_telemetry/by_milestone/${requireUlid("milestone_id", milestoneId)}.json`;
+  },
   featureRequest(requestId: string): string {
     return `feature_requests/${requireUlid("request_id", requestId)}.json`;
   },

--- a/src/application/slice-merge.ts
+++ b/src/application/slice-merge.ts
@@ -15,6 +15,7 @@
  * matrix effects.
  */
 import { newMonotonicId } from "../domain/ids.js";
+import { Slice } from "../domain/schema/slice.js";
 import {
   SliceMerge,
   type SliceMerge as SliceMergeT,
@@ -27,6 +28,7 @@ import type { WorkspacePort } from "../ports/workspace.js";
 import { idempotencyKey } from "./idempotency.js";
 import type { LedgerAppender } from "./ledger.js";
 import { layout } from "./persistence-layout.js";
+import { emitSliceTelemetry } from "./slice-telemetry.js";
 import { runInnerVerification } from "./verification-runner.js";
 
 export interface SliceMergeOpDeps {
@@ -35,6 +37,45 @@ export interface SliceMergeOpDeps {
   ledger: LedgerAppender;
   callerId: string;
   targetId: string;
+}
+
+/**
+ * Phase 8b — KAC-SLICE-TELEMETRY emit hook. Each SliceMerge transition
+ * pairs with a Slice state transition (caller-dispatch.ts), so emitting
+ * here covers SLICE_REVIEWING / SLICE_INTEGRATING / SLICE_VALIDATED /
+ * SLICE_BLOCKED / SLICE_BUILDING (rebuild) re-shape moments. The emit is
+ * idempotent — a no-op call (no partition change) returns the prior
+ * telemetry without writing.
+ *
+ * Failures are non-fatal: telemetry emit is read-side enrichment for
+ * Discovery N+1, and `telemetry_enrichment_missing=warn` (KAC-SLICE-
+ * TELEMETRY) keeps it warn-grade. A surfaced error from the emit could
+ * abort the SliceMerge transition, leaving the slice in an inconsistent
+ * state — far worse than missing telemetry on this cycle.
+ */
+async function emitTelemetryAfterTransition(
+  sliceId: string,
+  deps: SliceMergeOpDeps,
+): Promise<void> {
+  const slicePath = layout.slice(sliceId);
+  let body: string | null;
+  try {
+    body = await deps.store.readText(slicePath);
+  } catch {
+    return;
+  }
+  if (body == null) return;
+  let milestoneId: string;
+  try {
+    milestoneId = Slice.parse(JSON.parse(body)).milestone_id;
+  } catch {
+    return;
+  }
+  try {
+    await emitSliceTelemetry({ milestone_id: milestoneId }, deps);
+  } catch {
+    // Swallow — see header rationale.
+  }
 }
 
 /** SM_READY_FOR_REVIEW → SM_APPROVED + records review_session_id. */
@@ -99,6 +140,7 @@ export async function promoteSliceMergeToApproved(
     result_detail: null,
     timestamp: deps.clock.isoNow(),
   });
+  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }
 
@@ -238,6 +280,7 @@ export async function integrateSliceMerge(
     result_detail: null,
     timestamp: deps.clock.isoNow(),
   });
+  await emitTelemetryAfterTransition(merged.slice_id, deps);
   return {
     result: "merged",
     sliceMerge: merged,
@@ -301,6 +344,7 @@ async function markSliceMergeStale(
     result_detail: reason.slice(0, 200),
     timestamp: deps.clock.isoNow(),
   });
+  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }
 
@@ -371,6 +415,7 @@ export async function closeSliceMergeRequestChanges(
     result_detail: null,
     timestamp: deps.clock.isoNow(),
   });
+  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }
 
@@ -433,5 +478,6 @@ export async function closeSliceMergeBlocked(
     result_detail: input.cause.slice(0, 200),
     timestamp: deps.clock.isoNow(),
   });
+  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }

--- a/src/application/slice-merge.ts
+++ b/src/application/slice-merge.ts
@@ -15,7 +15,6 @@
  * matrix effects.
  */
 import { newMonotonicId } from "../domain/ids.js";
-import { Slice } from "../domain/schema/slice.js";
 import {
   SliceMerge,
   type SliceMerge as SliceMergeT,
@@ -28,7 +27,6 @@ import type { WorkspacePort } from "../ports/workspace.js";
 import { idempotencyKey } from "./idempotency.js";
 import type { LedgerAppender } from "./ledger.js";
 import { layout } from "./persistence-layout.js";
-import { emitSliceTelemetry } from "./slice-telemetry.js";
 import { runInnerVerification } from "./verification-runner.js";
 
 export interface SliceMergeOpDeps {
@@ -37,45 +35,6 @@ export interface SliceMergeOpDeps {
   ledger: LedgerAppender;
   callerId: string;
   targetId: string;
-}
-
-/**
- * Phase 8b — KAC-SLICE-TELEMETRY emit hook. Each SliceMerge transition
- * pairs with a Slice state transition (caller-dispatch.ts), so emitting
- * here covers SLICE_REVIEWING / SLICE_INTEGRATING / SLICE_VALIDATED /
- * SLICE_BLOCKED / SLICE_BUILDING (rebuild) re-shape moments. The emit is
- * idempotent — a no-op call (no partition change) returns the prior
- * telemetry without writing.
- *
- * Failures are non-fatal: telemetry emit is read-side enrichment for
- * Discovery N+1, and `telemetry_enrichment_missing=warn` (KAC-SLICE-
- * TELEMETRY) keeps it warn-grade. A surfaced error from the emit could
- * abort the SliceMerge transition, leaving the slice in an inconsistent
- * state — far worse than missing telemetry on this cycle.
- */
-async function emitTelemetryAfterTransition(
-  sliceId: string,
-  deps: SliceMergeOpDeps,
-): Promise<void> {
-  const slicePath = layout.slice(sliceId);
-  let body: string | null;
-  try {
-    body = await deps.store.readText(slicePath);
-  } catch {
-    return;
-  }
-  if (body == null) return;
-  let milestoneId: string;
-  try {
-    milestoneId = Slice.parse(JSON.parse(body)).milestone_id;
-  } catch {
-    return;
-  }
-  try {
-    await emitSliceTelemetry({ milestone_id: milestoneId }, deps);
-  } catch {
-    // Swallow — see header rationale.
-  }
 }
 
 /** SM_READY_FOR_REVIEW → SM_APPROVED + records review_session_id. */
@@ -140,7 +99,6 @@ export async function promoteSliceMergeToApproved(
     result_detail: null,
     timestamp: deps.clock.isoNow(),
   });
-  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }
 
@@ -280,7 +238,6 @@ export async function integrateSliceMerge(
     result_detail: null,
     timestamp: deps.clock.isoNow(),
   });
-  await emitTelemetryAfterTransition(merged.slice_id, deps);
   return {
     result: "merged",
     sliceMerge: merged,
@@ -344,7 +301,6 @@ async function markSliceMergeStale(
     result_detail: reason.slice(0, 200),
     timestamp: deps.clock.isoNow(),
   });
-  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }
 
@@ -415,7 +371,6 @@ export async function closeSliceMergeRequestChanges(
     result_detail: null,
     timestamp: deps.clock.isoNow(),
   });
-  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }
 
@@ -478,6 +433,5 @@ export async function closeSliceMergeBlocked(
     result_detail: input.cause.slice(0, 200),
     timestamp: deps.clock.isoNow(),
   });
-  await emitTelemetryAfterTransition(updated.slice_id, deps);
   return updated;
 }

--- a/src/application/slice-telemetry.ts
+++ b/src/application/slice-telemetry.ts
@@ -88,127 +88,144 @@ export async function emitSliceTelemetry(
   input: EmitSliceTelemetryInput,
   deps: SliceTelemetryDeps,
 ): Promise<EmitSliceTelemetryResult> {
-  const slices = await listSlicesForMilestone(deps.store, input.milestone_id);
+  // PR #77 P1 fix: serialise emits per Delivery milestone via the pointer
+  // file lock. Without this the (load prior) → (writeAtomic file) →
+  // (writeAtomic pointer) sequence is split into separate steps, so two
+  // concurrent emits can both observe the same prior and persist distinct
+  // telemetry_id / audit_hash records (each with its own ledger row) for
+  // the same partition snapshot. Locking the pointer path is sufficient
+  // because every reader (manifest inject, cross-slot drift) goes through
+  // the pointer to resolve the live telemetry.
+  const pointerPath = layout.latestSliceTelemetryByMilestone(input.milestone_id);
+  return await deps.store.withFileLock(pointerPath, async () => {
+    const slices = await listSlicesForMilestone(deps.store, input.milestone_id);
 
-  const in_progress: TelemetryInProgressSlice[] = [];
-  const validated: TelemetryValidatedSlice[] = [];
-  const blocked: TelemetryBlockedSlice[] = [];
-  for (const s of slices) {
-    if (IN_PROGRESS_STATES.has(s.state)) {
-      in_progress.push({
-        slice_id: s.slice_id,
-        slice_kind: s.slice_kind,
-        state: s.state,
-        current_session_id: s.current_session_id,
-      });
-    } else if (s.state === "SLICE_VALIDATED") {
-      validated.push({
-        slice_id: s.slice_id,
-        slice_kind: s.slice_kind,
-        // SOC-MERGE-POLICY: the slice's `dod_revision_pin` carries the
-        // post-merge validated revision. trunk_base_revision pre-dates the
-        // merge so we prefer dod_revision_pin when present.
-        validated_revision: s.dod_revision_pin,
-      });
-    } else if (s.state === "SLICE_BLOCKED") {
-      blocked.push({
-        slice_id: s.slice_id,
-        slice_kind: s.slice_kind,
-        abandoned_reason: s.abandoned_reason,
-      });
+    const in_progress: TelemetryInProgressSlice[] = [];
+    const validated: TelemetryValidatedSlice[] = [];
+    const blocked: TelemetryBlockedSlice[] = [];
+    for (const s of slices) {
+      if (IN_PROGRESS_STATES.has(s.state)) {
+        in_progress.push({
+          slice_id: s.slice_id,
+          slice_kind: s.slice_kind,
+          state: s.state,
+          current_session_id: s.current_session_id,
+        });
+      } else if (s.state === "SLICE_VALIDATED") {
+        validated.push({
+          slice_id: s.slice_id,
+          slice_kind: s.slice_kind,
+          // SOC-MERGE-POLICY: the slice's `dod_revision_pin` carries the
+          // post-merge validated revision. trunk_base_revision pre-dates the
+          // merge so we prefer dod_revision_pin when present.
+          validated_revision: s.dod_revision_pin,
+        });
+      } else if (s.state === "SLICE_BLOCKED") {
+        blocked.push({
+          slice_id: s.slice_id,
+          slice_kind: s.slice_kind,
+          abandoned_reason: s.abandoned_reason,
+        });
+      }
     }
-  }
 
-  // Sort each partition by slice_id so the audit_hash is deterministic.
-  in_progress.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
-  validated.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
-  blocked.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+    // Sort each partition by slice_id so the audit_hash is deterministic.
+    in_progress.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+    validated.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+    blocked.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
 
-  const telemetry_id = newMonotonicId(deps.clock.now());
-  const generated_at = deps.clock.isoNow();
-  const body = {
-    telemetry_id,
-    milestone_id: input.milestone_id,
-    generated_at,
-    in_progress_slices: in_progress,
-    validated_slices: validated,
-    blocked_slices: blocked,
-    recent_session_outcomes: [...(input.recent_session_outcomes ?? [])],
-    edge_cases: [...(input.edge_cases ?? [])],
-    recent_metric_runs: [...(input.recent_metric_runs ?? [])],
-  };
-  // body-only audit_hash — KAC-MANIFEST consumers must recompute it from
-  // the persisted record minus audit_hash. The id+generated_at are
-  // intentionally part of the body-hash because they bind the audit chain
-  // to a specific persisted instance — but that means a no-op call would
-  // compute a *new* hash every invocation. The idempotency check below
-  // recomputes the hash *with the prior id+generated_at* to dedup.
-  const audit_hash = bodyAuditHash(body);
-  const built: SliceTelemetryT = SliceTelemetry.parse({ ...body, audit_hash });
+    const telemetry_id = newMonotonicId(deps.clock.now());
+    const generated_at = deps.clock.isoNow();
+    const body = {
+      telemetry_id,
+      milestone_id: input.milestone_id,
+      generated_at,
+      in_progress_slices: in_progress,
+      validated_slices: validated,
+      blocked_slices: blocked,
+      recent_session_outcomes: [...(input.recent_session_outcomes ?? [])],
+      edge_cases: [...(input.edge_cases ?? [])],
+      recent_metric_runs: [...(input.recent_metric_runs ?? [])],
+    };
+    // body-only audit_hash — KAC-MANIFEST consumers must recompute it from
+    // the persisted record minus audit_hash. The id+generated_at are
+    // intentionally part of the body-hash because they bind the audit chain
+    // to a specific persisted instance — but that means a no-op call would
+    // compute a *new* hash every invocation. The idempotency check below
+    // recomputes the hash *with the prior id+generated_at* to dedup.
+    const audit_hash = bodyAuditHash(body);
+    const built: SliceTelemetryT = SliceTelemetry.parse({ ...body, audit_hash });
 
-  // Idempotent: if a prior telemetry exists for this milestone AND its
-  // partition shape is identical, reuse it. Identity is checked by
-  // recomputing the prior body's audit_hash against a copy of the prior
-  // record with this call's `telemetry_id` / `generated_at` substituted —
-  // i.e. compare the partition fields only.
-  const prior = await loadLatestSliceTelemetry(deps.store, input.milestone_id);
-  if (prior != null && partitionEquivalent(prior, built)) {
-    return { telemetry: prior, persisted: false };
-  }
+    // Idempotent: if a prior telemetry exists for this milestone AND its
+    // partition shape is identical, reuse it. Identity is checked by
+    // recomputing the prior body's audit_hash against a copy of the prior
+    // record with this call's `telemetry_id` / `generated_at` substituted —
+    // i.e. compare the partition fields only.
+    const prior = await loadLatestSliceTelemetry(deps.store, input.milestone_id);
+    if (prior != null && partitionEquivalent(prior, built)) {
+      return { telemetry: prior, persisted: false };
+    }
 
-  await deps.store.writeAtomic(
-    layout.sliceTelemetry(telemetry_id),
-    JSON.stringify(built, null, 2),
-  );
-  await deps.store.writeAtomic(
-    layout.latestSliceTelemetryByMilestone(input.milestone_id),
-    JSON.stringify({ telemetry_id }, null, 2),
-  );
-  await deps.ledger.appendTransition({
-    transition_id: newMonotonicId(deps.clock.now()),
-    target_id: deps.targetId,
-    object_id: telemetry_id,
-    object_kind: "system",
-    from_state: prior?.audit_hash ?? null,
-    to_state: audit_hash,
-    loop_kind: null,
-    phase: null,
-    slice_id: null,
-    slice_kind: null,
-    dod_revision: null,
-    session_id: null,
-    turn_index: null,
-    slot_kind: null,
-    agent_profile_id: null,
-    contribution_kind: null,
-    action_kind: "external_observation",
-    final_verdict: null,
-    caller_id: deps.callerId,
-    manifest_id: null,
-    input_revision_pins: [],
-    output_hash: null,
-    verification_run_id: null,
-    metric_run_id: null,
-    idempotency_key: idempotencyKey({
-      scope: "external_observation",
-      parts: {
-        kind: "slice_telemetry_emit",
-        milestone_id: input.milestone_id,
-        audit_hash,
-      },
-    }),
-    lease_token: null,
-    lease_kind: null,
-    result: "applied",
-    result_detail: null,
-    timestamp: deps.clock.isoNow(),
+    await deps.store.writeAtomic(
+      layout.sliceTelemetry(telemetry_id),
+      JSON.stringify(built, null, 2),
+    );
+    await deps.store.writeAtomic(
+      layout.latestSliceTelemetryByMilestone(input.milestone_id),
+      JSON.stringify({ telemetry_id }, null, 2),
+    );
+    await deps.ledger.appendTransition({
+      transition_id: newMonotonicId(deps.clock.now()),
+      target_id: deps.targetId,
+      object_id: telemetry_id,
+      object_kind: "system",
+      from_state: prior?.audit_hash ?? null,
+      to_state: audit_hash,
+      loop_kind: null,
+      phase: null,
+      slice_id: null,
+      slice_kind: null,
+      dod_revision: null,
+      session_id: null,
+      turn_index: null,
+      slot_kind: null,
+      agent_profile_id: null,
+      contribution_kind: null,
+      action_kind: "external_observation",
+      final_verdict: null,
+      caller_id: deps.callerId,
+      manifest_id: null,
+      input_revision_pins: [],
+      output_hash: null,
+      verification_run_id: null,
+      metric_run_id: null,
+      idempotency_key: idempotencyKey({
+        scope: "external_observation",
+        parts: {
+          kind: "slice_telemetry_emit",
+          milestone_id: input.milestone_id,
+          audit_hash,
+        },
+      }),
+      lease_token: null,
+      lease_kind: null,
+      result: "applied",
+      result_detail: null,
+      timestamp: deps.clock.isoNow(),
+    });
+    return { telemetry: built, persisted: true };
   });
-  return { telemetry: built, persisted: true };
 }
 
 /**
  * Resolve the latest SliceTelemetry for `milestone_id` via the pointer
  * file. Returns null if no telemetry has been emitted yet.
+ *
+ * PR #77 P1 fix: recompute `audit_hash` from the persisted body (minus
+ * audit_hash) and reject the record when it disagrees with the stored
+ * value. Without this check, an actor able to write the telemetry file
+ * could forge an `audit_hash` and bypass the manifest stale-pin gate +
+ * RGC-CROSS-SLOT-STALE drift comparison.
  */
 export async function loadLatestSliceTelemetry(
   store: StorePort,
@@ -227,11 +244,16 @@ export async function loadLatestSliceTelemetry(
   if (typeof pointer.telemetry_id !== "string") return null;
   const body = await store.readText(layout.sliceTelemetry(pointer.telemetry_id));
   if (body == null) return null;
+  let parsed: SliceTelemetryT;
   try {
-    return SliceTelemetry.parse(JSON.parse(body));
+    parsed = SliceTelemetry.parse(JSON.parse(body));
   } catch {
     return null;
   }
+  const { audit_hash, ...rest } = parsed;
+  const recomputed = bodyAuditHash(rest);
+  if (recomputed !== audit_hash) return null;
+  return parsed;
 }
 
 async function listSlicesForMilestone(

--- a/src/application/slice-telemetry.ts
+++ b/src/application/slice-telemetry.ts
@@ -1,0 +1,279 @@
+/**
+ * Phase 8b — KAC-SLICE-TELEMETRY emit + lookup.
+ *
+ * Producer: Delivery slice state transitions (slice-merge.ts) call
+ * `emitSliceTelemetry(milestoneId)` so the Discovery N+1 manifest inject
+ * (outer-turn.ts) and RGC-CROSS-SLOT-STALE (cross-slot-stale.ts) see live
+ * progress.
+ *
+ * Build rule: scan all slices for `milestoneId`; partition by state into
+ *   - in_progress  ∈ {SLICE_PENDING, SLICE_READY, SLICE_BUILDING,
+ *                     SLICE_REVIEWING, SLICE_INTEGRATING}
+ *   - validated    ∈ {SLICE_VALIDATED}
+ *   - blocked      ∈ {SLICE_BLOCKED}
+ * `recent_session_outcomes` / `edge_cases` / `recent_metric_runs` ride along
+ * as caller-supplied lists (default empty for the slice-merge wiring).
+ *
+ * Persistence:
+ *   1. Compute body-only sha256 (`bodyAuditHash`) over the canonical-json
+ *      record minus `audit_hash` — same convention as decisions and
+ *      RefactorBacklog so KAC-MANIFEST consumers can recompute the pin.
+ *   2. Read the pointer file (`layout.latestSliceTelemetryByMilestone`); if
+ *      the existing telemetry's `audit_hash` matches, return it (idempotent
+ *      no-op — no second file, no ledger row).
+ *   3. Otherwise persist `layout.sliceTelemetry(<new_id>)` and overwrite the
+ *      pointer atomically. Append a single ledger row keyed by
+ *      `(kind=slice_telemetry_emit, milestone_id, audit_hash)`.
+ *
+ * The audit_hash itself is the dedup signal — when nothing material changed
+ * we skip the write so the pointer doesn't churn.
+ */
+import {
+  SliceTelemetry,
+  type SliceTelemetry as SliceTelemetryT,
+  type TelemetryBlockedSlice,
+  type TelemetryInProgressSlice,
+  type TelemetryValidatedSlice,
+  type TelemetrySessionOutcome,
+} from "../domain/schema/knowledge.js";
+import { newMonotonicId } from "../domain/ids.js";
+import { Slice, type Slice as SliceT } from "../domain/schema/slice.js";
+import type { ClockPort } from "../ports/clock.js";
+import type { StorePort } from "../ports/store.js";
+import { idempotencyKey } from "./idempotency.js";
+import { bodyAuditHash } from "./knowledge.js";
+import type { LedgerAppender } from "./ledger.js";
+import { layout } from "./persistence-layout.js";
+
+export interface SliceTelemetryDeps {
+  store: StorePort;
+  clock: ClockPort;
+  ledger: LedgerAppender;
+  callerId: string;
+  targetId: string;
+}
+
+export interface EmitSliceTelemetryInput {
+  milestone_id: string;
+  /**
+   * Optional supplementary fields. Slice partition is always recomputed
+   * from the live Slice store; the caller may pass session outcomes,
+   * recent metric runs and edge-case patterns it has aggregated.
+   */
+  recent_session_outcomes?: readonly TelemetrySessionOutcome[];
+  edge_cases?: readonly string[];
+  recent_metric_runs?: readonly string[];
+}
+
+export interface EmitSliceTelemetryResult {
+  telemetry: SliceTelemetryT;
+  /** True when a new telemetry file was written. False on idempotent reuse. */
+  persisted: boolean;
+}
+
+const IN_PROGRESS_STATES = new Set([
+  "SLICE_PENDING",
+  "SLICE_READY",
+  "SLICE_BUILDING",
+  "SLICE_REVIEWING",
+  "SLICE_INTEGRATING",
+]);
+
+/**
+ * Build + persist a fresh SliceTelemetry for `milestone_id`. Returns the
+ * existing telemetry unchanged when the freshly-built body audit_hash
+ * matches the pointer's recorded audit_hash.
+ */
+export async function emitSliceTelemetry(
+  input: EmitSliceTelemetryInput,
+  deps: SliceTelemetryDeps,
+): Promise<EmitSliceTelemetryResult> {
+  const slices = await listSlicesForMilestone(deps.store, input.milestone_id);
+
+  const in_progress: TelemetryInProgressSlice[] = [];
+  const validated: TelemetryValidatedSlice[] = [];
+  const blocked: TelemetryBlockedSlice[] = [];
+  for (const s of slices) {
+    if (IN_PROGRESS_STATES.has(s.state)) {
+      in_progress.push({
+        slice_id: s.slice_id,
+        slice_kind: s.slice_kind,
+        state: s.state,
+        current_session_id: s.current_session_id,
+      });
+    } else if (s.state === "SLICE_VALIDATED") {
+      validated.push({
+        slice_id: s.slice_id,
+        slice_kind: s.slice_kind,
+        // SOC-MERGE-POLICY: the slice's `dod_revision_pin` carries the
+        // post-merge validated revision. trunk_base_revision pre-dates the
+        // merge so we prefer dod_revision_pin when present.
+        validated_revision: s.dod_revision_pin,
+      });
+    } else if (s.state === "SLICE_BLOCKED") {
+      blocked.push({
+        slice_id: s.slice_id,
+        slice_kind: s.slice_kind,
+        abandoned_reason: s.abandoned_reason,
+      });
+    }
+  }
+
+  // Sort each partition by slice_id so the audit_hash is deterministic.
+  in_progress.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+  validated.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+  blocked.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+
+  const telemetry_id = newMonotonicId(deps.clock.now());
+  const generated_at = deps.clock.isoNow();
+  const body = {
+    telemetry_id,
+    milestone_id: input.milestone_id,
+    generated_at,
+    in_progress_slices: in_progress,
+    validated_slices: validated,
+    blocked_slices: blocked,
+    recent_session_outcomes: [...(input.recent_session_outcomes ?? [])],
+    edge_cases: [...(input.edge_cases ?? [])],
+    recent_metric_runs: [...(input.recent_metric_runs ?? [])],
+  };
+  // body-only audit_hash — KAC-MANIFEST consumers must recompute it from
+  // the persisted record minus audit_hash. The id+generated_at are
+  // intentionally part of the body-hash because they bind the audit chain
+  // to a specific persisted instance — but that means a no-op call would
+  // compute a *new* hash every invocation. The idempotency check below
+  // recomputes the hash *with the prior id+generated_at* to dedup.
+  const audit_hash = bodyAuditHash(body);
+  const built: SliceTelemetryT = SliceTelemetry.parse({ ...body, audit_hash });
+
+  // Idempotent: if a prior telemetry exists for this milestone AND its
+  // partition shape is identical, reuse it. Identity is checked by
+  // recomputing the prior body's audit_hash against a copy of the prior
+  // record with this call's `telemetry_id` / `generated_at` substituted —
+  // i.e. compare the partition fields only.
+  const prior = await loadLatestSliceTelemetry(deps.store, input.milestone_id);
+  if (prior != null && partitionEquivalent(prior, built)) {
+    return { telemetry: prior, persisted: false };
+  }
+
+  await deps.store.writeAtomic(
+    layout.sliceTelemetry(telemetry_id),
+    JSON.stringify(built, null, 2),
+  );
+  await deps.store.writeAtomic(
+    layout.latestSliceTelemetryByMilestone(input.milestone_id),
+    JSON.stringify({ telemetry_id }, null, 2),
+  );
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.targetId,
+    object_id: telemetry_id,
+    object_kind: "system",
+    from_state: prior?.audit_hash ?? null,
+    to_state: audit_hash,
+    loop_kind: null,
+    phase: null,
+    slice_id: null,
+    slice_kind: null,
+    dod_revision: null,
+    session_id: null,
+    turn_index: null,
+    slot_kind: null,
+    agent_profile_id: null,
+    contribution_kind: null,
+    action_kind: "external_observation",
+    final_verdict: null,
+    caller_id: deps.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: null,
+    metric_run_id: null,
+    idempotency_key: idempotencyKey({
+      scope: "external_observation",
+      parts: {
+        kind: "slice_telemetry_emit",
+        milestone_id: input.milestone_id,
+        audit_hash,
+      },
+    }),
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: null,
+    timestamp: deps.clock.isoNow(),
+  });
+  return { telemetry: built, persisted: true };
+}
+
+/**
+ * Resolve the latest SliceTelemetry for `milestone_id` via the pointer
+ * file. Returns null if no telemetry has been emitted yet.
+ */
+export async function loadLatestSliceTelemetry(
+  store: StorePort,
+  milestone_id: string,
+): Promise<SliceTelemetryT | null> {
+  const pointerBody = await store.readText(
+    layout.latestSliceTelemetryByMilestone(milestone_id),
+  );
+  if (pointerBody == null) return null;
+  let pointer: { telemetry_id?: unknown };
+  try {
+    pointer = JSON.parse(pointerBody) as { telemetry_id?: unknown };
+  } catch {
+    return null;
+  }
+  if (typeof pointer.telemetry_id !== "string") return null;
+  const body = await store.readText(layout.sliceTelemetry(pointer.telemetry_id));
+  if (body == null) return null;
+  try {
+    return SliceTelemetry.parse(JSON.parse(body));
+  } catch {
+    return null;
+  }
+}
+
+async function listSlicesForMilestone(
+  store: StorePort,
+  milestone_id: string,
+): Promise<SliceT[]> {
+  let names: string[];
+  try {
+    names = await store.list("slices");
+  } catch {
+    return [];
+  }
+  const out: SliceT[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const body = await store.readText(`slices/${name}`);
+    if (body == null) continue;
+    try {
+      const slice = Slice.parse(JSON.parse(body));
+      if (slice.milestone_id === milestone_id) out.push(slice);
+    } catch {
+      // skip malformed slice
+    }
+  }
+  return out;
+}
+
+function partitionEquivalent(
+  a: SliceTelemetryT,
+  b: SliceTelemetryT,
+): boolean {
+  return (
+    a.milestone_id === b.milestone_id &&
+    JSON.stringify(a.in_progress_slices) ===
+      JSON.stringify(b.in_progress_slices) &&
+    JSON.stringify(a.validated_slices) ===
+      JSON.stringify(b.validated_slices) &&
+    JSON.stringify(a.blocked_slices) === JSON.stringify(b.blocked_slices) &&
+    JSON.stringify(a.recent_session_outcomes) ===
+      JSON.stringify(b.recent_session_outcomes) &&
+    JSON.stringify(a.edge_cases) === JSON.stringify(b.edge_cases) &&
+    JSON.stringify(a.recent_metric_runs) ===
+      JSON.stringify(b.recent_metric_runs)
+  );
+}

--- a/src/domain/schema/manifest.ts
+++ b/src/domain/schema/manifest.ts
@@ -32,6 +32,11 @@ export const ManifestEntryObjectKind = z.enum([
   "code_tree",
   "context_summary",
   "decision",
+  // KAC-SLICE-TELEMETRY (phase 8b) — Discovery N+1 manifest entry that
+  // references the latest SliceTelemetry of the live Delivery N. Read-only
+  // by contract; the entry's `revision_pin` is the SliceTelemetry's
+  // `audit_hash`, which RGC-CROSS-SLOT-STALE compares to detect drift.
+  "slice_telemetry",
 ]);
 export type ManifestEntryObjectKind = z.infer<typeof ManifestEntryObjectKind>;
 

--- a/tests/application/persistence-layout.test.ts
+++ b/tests/application/persistence-layout.test.ts
@@ -85,6 +85,10 @@ describe("persistence-layout", () => {
     expect(layout.sliceTelemetry(TELEM_ID)).toBe(
       `knowledge/slice_telemetry/${TELEM_ID}.json`,
     );
+    expect(layout.latestSliceTelemetryByMilestone(M_ID)).toBe(
+      `knowledge/slice_telemetry/by_milestone/${M_ID}.json`,
+    );
+    expect(() => layout.latestSliceTelemetryByMilestone("bad")).toThrow(/ULID/);
     expect(layout.featureRequest(REQ_ID)).toBe(
       `feature_requests/${REQ_ID}.json`,
     );

--- a/tests/integration/slice-telemetry-pin-drift.test.ts
+++ b/tests/integration/slice-telemetry-pin-drift.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Phase 8b — KAC-SLICE-TELEMETRY emit + Discovery N+1 manifest inject +
+ * RGC-CROSS-SLOT-STALE pin drift integration tests.
+ *
+ * Covers (G2-3 verification):
+ *   1. emitSliceTelemetry(milestoneId) builds in_progress / validated /
+ *      blocked partitions from live Slices and persists a pointer keyed by
+ *      milestone_id. Audit hash is the body-only sha256 of the canonical
+ *      record minus audit_hash.
+ *   2. emitSliceTelemetry is idempotent — a second call with no slice
+ *      partition change reuses the prior record (no second file written,
+ *      no second ledger row).
+ *   3. integrateSliceMerge → SLICE_VALIDATED emits new telemetry whose
+ *      audit_hash differs from the pre-merge telemetry — proving the
+ *      slice-merge.ts wiring.
+ *   4. detectCrossSlotStaleSessions transitions a Discovery session whose
+ *      latest manifest's slice_telemetry pin no longer matches the live
+ *      Delivery telemetry → AWAITING_REVALIDATION (pin drift trigger).
+ *   5. detectCrossSlotStaleSessions is a no-op when the pin matches the
+ *      live telemetry, even if the Delivery milestone's `updated_at`
+ *      moved forward (the conservative phase-6a trigger is suppressed
+ *      once a real pin is available — pin equality is the authoritative
+ *      "no drift" signal).
+ */
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "../../src/adapters/store/memory.js";
+import { detectCrossSlotStaleSessions } from "../../src/application/cross-slot-stale.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import {
+  LEDGER_TRANSITIONS_PATH,
+  layout,
+} from "../../src/application/persistence-layout.js";
+import {
+  emitSliceTelemetry,
+  loadLatestSliceTelemetry,
+} from "../../src/application/slice-telemetry.js";
+import { promoteSliceMergeToApproved } from "../../src/application/slice-merge.js";
+import { DialogueSession } from "../../src/domain/schema/dialogue-session.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import {
+  ContextManifest,
+  type ContextManifest as ContextManifestT,
+} from "../../src/domain/schema/manifest.js";
+import { Milestone } from "../../src/domain/schema/milestone.js";
+import { Slice } from "../../src/domain/schema/slice.js";
+import { SliceMerge } from "../../src/domain/schema/slice-merge.js";
+import { FixedClock } from "../../src/ports/clock.js";
+import { CollectingLogger } from "../../src/ports/logger.js";
+
+const ISO_BASE = "2026-05-08T00:00:00.000Z";
+const TARGET_ID = "demo";
+const M_DELIVERY = "01HZM30000000000000000000A";
+const M_DISCOVERY = "01HZM40000000000000000000A";
+const SLICE_A = "01HZS00000000000000000000A";
+const SLICE_B = "01HZS00000000000000000000B";
+const SLICE_C = "01HZS00000000000000000000C";
+const SM_ID = "01HZSM0000000000000000000A";
+const SESSION_REVIEW = "01HZSE0000000000000000000Z";
+const SESSION_DISCOVERY = "01HZSE0000000000000000000A";
+const MANIFEST_INJECT = "01HZMN0000000000000000000A";
+const VERIF_ID = "01HZVR0000000000000000000A";
+
+function makeDeps(store: MemoryStore, clock: FixedClock) {
+  const logger = new CollectingLogger();
+  const ledger = new FileLedger({ store, logger });
+  return {
+    store,
+    clock,
+    ledger,
+    callerId: "test-telemetry",
+    targetId: TARGET_ID,
+  };
+}
+
+async function dropMilestone(
+  store: MemoryStore,
+  id: string,
+  state: string,
+  updated_at: string,
+): Promise<void> {
+  const m = Milestone.parse({
+    milestone_id: id,
+    target_id: TARGET_ID,
+    title: `m-${id.slice(-1)}`,
+    state,
+    slot_kind: null,
+    intake_source_kind: "feature_request",
+    intake_source_id: id,
+    spec_revision_pin: null,
+    context_summary_id: null,
+    external_refs: [],
+    created_at: ISO_BASE,
+    updated_at,
+  });
+  await store.writeAtomic(layout.milestone(id), JSON.stringify(m, null, 2));
+}
+
+async function dropSlice(
+  store: MemoryStore,
+  id: string,
+  milestoneId: string,
+  state:
+    | "SLICE_PENDING"
+    | "SLICE_READY"
+    | "SLICE_BUILDING"
+    | "SLICE_REVIEWING"
+    | "SLICE_INTEGRATING"
+    | "SLICE_VALIDATED"
+    | "SLICE_BLOCKED",
+  abandoned_reason: string | null = null,
+): Promise<void> {
+  const s = Slice.parse({
+    slice_id: id,
+    milestone_id: milestoneId,
+    slice_kind: "feature",
+    value_statement: `slice ${id.slice(-1)}`,
+    ac_ids: [],
+    acceptance_tests: [],
+    declared_scope: [],
+    declared_metric_threshold: null,
+    interface_break: false,
+    dependencies: [],
+    trunk_base_revision: "trunk-pin",
+    dod_revision_pin: `dod-${id.slice(-1)}`,
+    state,
+    current_session_id: null,
+    spawning_proposal_id: null,
+    abandoned_reason,
+    external_refs: [],
+    created_at: ISO_BASE,
+    updated_at: ISO_BASE,
+  });
+  await store.writeAtomic(layout.slice(id), JSON.stringify(s, null, 2));
+}
+
+async function readLedgerRows(store: MemoryStore) {
+  const body = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+  return body
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => LedgerRow.parse(JSON.parse(l)));
+}
+
+describe("emitSliceTelemetry — partition + persistence", () => {
+  it("partitions slices by state and writes a pointer keyed by milestone_id", async () => {
+    const store = new MemoryStore();
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+    const deps = makeDeps(store, clock);
+
+    await dropMilestone(store, M_DELIVERY, "M_DELIVERY_BUILDING", ISO_BASE);
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_BUILDING");
+    await dropSlice(store, SLICE_B, M_DELIVERY, "SLICE_VALIDATED");
+    await dropSlice(store, SLICE_C, M_DELIVERY, "SLICE_BLOCKED", "rebase exhausted");
+
+    const out = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+    expect(out.persisted).toBe(true);
+    expect(out.telemetry.in_progress_slices.map((s) => s.slice_id)).toEqual([
+      SLICE_A,
+    ]);
+    expect(out.telemetry.validated_slices.map((s) => s.slice_id)).toEqual([
+      SLICE_B,
+    ]);
+    expect(out.telemetry.blocked_slices.map((s) => s.slice_id)).toEqual([
+      SLICE_C,
+    ]);
+    expect(out.telemetry.audit_hash).toMatch(/^[0-9a-f]{64}$/);
+
+    // Pointer file resolves to the same telemetry.
+    const reread = await loadLatestSliceTelemetry(store, M_DELIVERY);
+    expect(reread?.telemetry_id).toBe(out.telemetry.telemetry_id);
+    expect(reread?.audit_hash).toBe(out.telemetry.audit_hash);
+
+    // One ledger row recorded the emit.
+    const rows = await readLedgerRows(store);
+    const emitRows = rows.filter(
+      (r) =>
+        r.action_kind === "external_observation" &&
+        r.idempotency_key.includes("kind=slice_telemetry_emit"),
+    );
+    expect(emitRows.length).toBe(1);
+  });
+
+  it("idempotent re-emit with same partition does not write a second file or ledger row", async () => {
+    const store = new MemoryStore();
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+    const deps = makeDeps(store, clock);
+    await dropMilestone(store, M_DELIVERY, "M_DELIVERY_BUILDING", ISO_BASE);
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_BUILDING");
+
+    const first = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+    expect(first.persisted).toBe(true);
+
+    clock.advance(1000);
+    const second = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+    expect(second.persisted).toBe(false);
+    // Same telemetry returned (audit_hash equal).
+    expect(second.telemetry.audit_hash).toBe(first.telemetry.audit_hash);
+    expect(second.telemetry.telemetry_id).toBe(first.telemetry.telemetry_id);
+
+    // Only one telemetry file under the directory.
+    const files = await store.list("knowledge/slice_telemetry");
+    const telemFiles = files.filter((n) => n.endsWith(".json"));
+    expect(telemFiles.length).toBe(1);
+
+    // Only one emit ledger row.
+    const rows = await readLedgerRows(store);
+    const emitRows = rows.filter(
+      (r) =>
+        r.action_kind === "external_observation" &&
+        r.idempotency_key.includes("kind=slice_telemetry_emit"),
+    );
+    expect(emitRows.length).toBe(1);
+  });
+
+  it("partition shape change triggers a fresh persisted telemetry with a new audit_hash", async () => {
+    const store = new MemoryStore();
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+    const deps = makeDeps(store, clock);
+    await dropMilestone(store, M_DELIVERY, "M_DELIVERY_BUILDING", ISO_BASE);
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_BUILDING");
+
+    const first = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+
+    // Slice A flips to SLICE_VALIDATED.
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_VALIDATED");
+    clock.advance(2000);
+    const second = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+    expect(second.persisted).toBe(true);
+    expect(second.telemetry.audit_hash).not.toBe(first.telemetry.audit_hash);
+    expect(second.telemetry.in_progress_slices).toEqual([]);
+    expect(second.telemetry.validated_slices.map((s) => s.slice_id)).toEqual([
+      SLICE_A,
+    ]);
+  });
+});
+
+describe("slice-merge.ts wiring — emit on transition", () => {
+  it("promoteSliceMergeToApproved emits a fresh SliceTelemetry for the slice's milestone", async () => {
+    const store = new MemoryStore();
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+    const deps = makeDeps(store, clock);
+
+    await dropMilestone(store, M_DELIVERY, "M_DELIVERY_BUILDING", ISO_BASE);
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_REVIEWING");
+    const sm = SliceMerge.parse({
+      slice_merge_id: SM_ID,
+      slice_id: SLICE_A,
+      target_id: TARGET_ID,
+      state: "SM_READY_FOR_REVIEW",
+      inner_session_id: SESSION_REVIEW,
+      review_session_id: null,
+      verification_run_id: VERIF_ID,
+      pre_merge_workspace_revision: "pre-merge-revision",
+      merge_revision: null,
+      merged_at: null,
+      merged_by_caller_id: null,
+      lease_token: null,
+      created_at: ISO_BASE,
+      updated_at: ISO_BASE,
+    });
+    await store.writeAtomic(
+      layout.sliceMerge(SM_ID),
+      JSON.stringify(sm, null, 2),
+    );
+
+    expect(await loadLatestSliceTelemetry(store, M_DELIVERY)).toBeNull();
+    await promoteSliceMergeToApproved(
+      { sliceMerge: sm, reviewSessionId: SESSION_REVIEW, sliceKind: "feature" },
+      deps,
+    );
+    const telem = await loadLatestSliceTelemetry(store, M_DELIVERY);
+    expect(telem).not.toBeNull();
+    expect(telem!.in_progress_slices.map((s) => s.slice_id)).toContain(SLICE_A);
+  });
+});
+
+describe("RGC-CROSS-SLOT-STALE — pin drift detection", () => {
+  /**
+   * Build a Discovery session whose latest SessionTurn references a manifest
+   * carrying a slice_telemetry entry with `revision_pin = pinAuditHash`.
+   * The session's `current_turn_index = 1` so loadInjectedTelemetryPin
+   * resolves turn index 0.
+   */
+  async function seedDiscoveryWithPin(
+    store: MemoryStore,
+    milestoneIdToPin: string,
+    pinAuditHash: string,
+  ): Promise<void> {
+    const session = DialogueSession.parse({
+      session_id: SESSION_DISCOVERY,
+      parent_object_kind: "milestone",
+      parent_object_id: M_DISCOVERY,
+      parent_loop: "outer",
+      purpose: "design",
+      participants: [
+        { agent_profile_id: "atlas", role: "lead" },
+        { agent_profile_id: "sentinel", role: "reviewer" },
+      ],
+      session_termination: {
+        finalization_rule: "quorum_then_lead",
+        required_evidence: [],
+        composite_rule: "finalization_only",
+        quorum_min_approvals: 1,
+      },
+      workspace_revision_pin: "trunk-pin",
+      current_turn_index: 1,
+      state: "SESSION_OPEN",
+      max_turns: 8,
+      created_at: ISO_BASE,
+      updated_at: ISO_BASE,
+    });
+    await store.writeAtomic(
+      layout.sessionMetadata(SESSION_DISCOVERY),
+      JSON.stringify(session, null, 2),
+    );
+
+    const manifest: ContextManifestT = ContextManifest.parse({
+      manifest_id: MANIFEST_INJECT,
+      session_id: SESSION_DISCOVERY,
+      turn_index: 0,
+      purpose: "design",
+      target: { object_kind: "milestone", object_id: M_DISCOVERY },
+      entries: [
+        {
+          object_kind: "milestone",
+          object_id: M_DISCOVERY,
+          fetch_scope: "body",
+          revision_pin: ISO_BASE,
+          required: true,
+          purpose: "primary input",
+        },
+        {
+          object_kind: "slice_telemetry",
+          object_id: "01HZTM0000000000000000000A",
+          fetch_scope: "body",
+          revision_pin: pinAuditHash,
+          required: false,
+          purpose: `Delivery N=${milestoneIdToPin} live slice telemetry (read-only)`,
+        },
+      ],
+      created_at: ISO_BASE,
+    });
+    await store.writeAtomic(
+      layout.manifest(MANIFEST_INJECT),
+      JSON.stringify(manifest, null, 2),
+    );
+
+    // Minimal SessionTurn referencing the manifest.
+    const turnBody = {
+      session_id: SESSION_DISCOVERY,
+      turn_index: 0,
+      input_manifest_id: MANIFEST_INJECT,
+    };
+    await store.writeAtomic(
+      layout.sessionTurn(SESSION_DISCOVERY, 0),
+      JSON.stringify(turnBody, null, 2),
+    );
+  }
+
+  it("transitions Discovery session to AWAITING_REVALIDATION when telemetry audit_hash drifts", async () => {
+    const store = new MemoryStore();
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+    const deps = makeDeps(store, clock);
+
+    await dropMilestone(store, M_DELIVERY, "M_DELIVERY_BUILDING", ISO_BASE);
+    await dropMilestone(store, M_DISCOVERY, "M_DISCOVERY_DRAFT", ISO_BASE);
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_BUILDING");
+
+    // Initial telemetry — Discovery session pins to this audit_hash.
+    const t0 = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+    await seedDiscoveryWithPin(store, M_DELIVERY, t0.telemetry.audit_hash);
+
+    // Delivery progresses — slice flips to SLICE_VALIDATED, new emit
+    // produces a different audit_hash.
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_VALIDATED");
+    clock.advance(60_000);
+    await dropMilestone(
+      store,
+      M_DELIVERY,
+      "M_DELIVERY_BUILDING",
+      "2026-05-08T00:01:00.000Z",
+    );
+    const t1 = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+    expect(t1.telemetry.audit_hash).not.toBe(t0.telemetry.audit_hash);
+
+    const out = await detectCrossSlotStaleSessions(deps);
+    expect(out.staledSessionIds).toEqual([SESSION_DISCOVERY]);
+
+    const reread = DialogueSession.parse(
+      JSON.parse((await store.readText(layout.sessionMetadata(SESSION_DISCOVERY)))!),
+    );
+    expect(reread.state).toBe("AWAITING_REVALIDATION");
+
+    const rows = await readLedgerRows(store);
+    const recover = rows.find((r) => r.action_kind === "recover");
+    expect(recover?.result_detail).toBe("cross_slot_stale");
+    // Drift kind recorded in idempotency key.
+    expect(recover?.idempotency_key).toContain("drift_kind=telemetry_pin_drift");
+  });
+
+  it("no-op when injected pin matches the live Delivery telemetry, even if Delivery updated_at moved", async () => {
+    const store = new MemoryStore();
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+    const deps = makeDeps(store, clock);
+
+    // Discovery session created BEFORE the latest Delivery update — under
+    // the phase-6a conservative trigger this would flag stale. With a
+    // matching telemetry pin, the new authoritative signal suppresses it.
+    await dropMilestone(
+      store,
+      M_DELIVERY,
+      "M_DELIVERY_BUILDING",
+      "2026-05-08T01:00:00.000Z",
+    );
+    await dropMilestone(
+      store,
+      M_DISCOVERY,
+      "M_DISCOVERY_DRAFT",
+      "2026-05-08T00:30:00.000Z",
+    );
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_BUILDING");
+
+    const t0 = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
+    await seedDiscoveryWithPin(store, M_DELIVERY, t0.telemetry.audit_hash);
+
+    const out = await detectCrossSlotStaleSessions(deps);
+    expect(out.staledSessionIds).toEqual([]);
+  });
+});

--- a/tests/integration/slice-telemetry-pin-drift.test.ts
+++ b/tests/integration/slice-telemetry-pin-drift.test.ts
@@ -34,7 +34,12 @@ import {
   emitSliceTelemetry,
   loadLatestSliceTelemetry,
 } from "../../src/application/slice-telemetry.js";
-import { promoteSliceMergeToApproved } from "../../src/application/slice-merge.js";
+import { dispatchOutcome } from "../../src/application/caller-dispatch.js";
+import { FakeVerification } from "../../src/adapters/verification/fake.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { DialogueSession } from "../../src/domain/schema/dialogue-session.js";
 import { LedgerRow } from "../../src/domain/schema/ledger.js";
 import {
@@ -234,23 +239,29 @@ describe("emitSliceTelemetry — partition + persistence", () => {
   });
 });
 
-describe("slice-merge.ts wiring — emit on transition", () => {
-  it("promoteSliceMergeToApproved emits a fresh SliceTelemetry for the slice's milestone", async () => {
+describe("caller-dispatch wiring — emit after slice transition", () => {
+  it("inner CONVERGED tests_green dispatch emits SliceTelemetry capturing the post-transition (SLICE_REVIEWING) partition", async () => {
+    // PR #77 P0-1 fix: emit hook moved out of slice-merge.ts and into
+    // caller-dispatch.ts so the partition snapshot reflects the *post*
+    // Slice state transition. Calling slice-merge ops directly no longer
+    // emits — dispatchOutcome is the contract surface.
     const store = new MemoryStore();
     const clock = new FixedClock(Date.parse(ISO_BASE));
-    const deps = makeDeps(store, clock);
+    const ledgerDeps = makeDeps(store, clock);
 
     await dropMilestone(store, M_DELIVERY, "M_DELIVERY_BUILDING", ISO_BASE);
-    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_REVIEWING");
+    // Seed slice in SLICE_BUILDING — the dispatch will move it to
+    // SLICE_REVIEWING and the emit must observe SLICE_REVIEWING.
+    await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_BUILDING");
     const sm = SliceMerge.parse({
       slice_merge_id: SM_ID,
       slice_id: SLICE_A,
       target_id: TARGET_ID,
-      state: "SM_READY_FOR_REVIEW",
+      state: "SM_DRAFT",
       inner_session_id: SESSION_REVIEW,
       review_session_id: null,
-      verification_run_id: VERIF_ID,
-      pre_merge_workspace_revision: "pre-merge-revision",
+      verification_run_id: null,
+      pre_merge_workspace_revision: null,
       merge_revision: null,
       merged_at: null,
       merged_by_caller_id: null,
@@ -262,15 +273,39 @@ describe("slice-merge.ts wiring — emit on transition", () => {
       layout.sliceMerge(SM_ID),
       JSON.stringify(sm, null, 2),
     );
+    const slicePath = layout.slice(SLICE_A);
+    const sliceBody = await store.readText(slicePath);
+    const slice = Slice.parse(JSON.parse(sliceBody!));
 
     expect(await loadLatestSliceTelemetry(store, M_DELIVERY)).toBeNull();
-    await promoteSliceMergeToApproved(
-      { sliceMerge: sm, reviewSessionId: SESSION_REVIEW, sliceKind: "feature" },
-      deps,
+
+    const wsRoot = mkdtempSync(join(tmpdir(), "slice-telemetry-wiring-"));
+    await dispatchOutcome(
+      {
+        parent_loop: "inner",
+        phase_or_purpose: "tdd_build",
+        session_state: "CONVERGED",
+        final_verdict: "tests_green",
+        slice,
+        sliceMerge: sm,
+        sessionId: SESSION_REVIEW,
+        verificationRunId: VERIF_ID,
+        preMergeRevision: "pre-merge-revision",
+        environmentFingerprint: "fp",
+      },
+      {
+        ...ledgerDeps,
+        workspace: new FakeWorkspace(wsRoot),
+        verification: new FakeVerification(clock),
+      },
     );
     const telem = await loadLatestSliceTelemetry(store, M_DELIVERY);
     expect(telem).not.toBeNull();
-    expect(telem!.in_progress_slices.map((s) => s.slice_id)).toContain(SLICE_A);
+    // Post-transition: SLICE_REVIEWING (not SLICE_BUILDING from before
+    // dispatch). This is the Inv #3 contract — Discovery N+1 sees the
+    // post-transition partition.
+    const ip = telem!.in_progress_slices.find((s) => s.slice_id === SLICE_A);
+    expect(ip?.state).toBe("SLICE_REVIEWING");
   });
 });
 
@@ -285,6 +320,7 @@ describe("RGC-CROSS-SLOT-STALE — pin drift detection", () => {
     store: MemoryStore,
     milestoneIdToPin: string,
     pinAuditHash: string,
+    pinnedTelemetryId: string = "01HZTM0000000000000000000A",
   ): Promise<void> {
     const session = DialogueSession.parse({
       session_id: SESSION_DISCOVERY,
@@ -331,7 +367,7 @@ describe("RGC-CROSS-SLOT-STALE — pin drift detection", () => {
         },
         {
           object_kind: "slice_telemetry",
-          object_id: "01HZTM0000000000000000000A",
+          object_id: pinnedTelemetryId,
           fetch_scope: "body",
           revision_pin: pinAuditHash,
           required: false,
@@ -368,7 +404,12 @@ describe("RGC-CROSS-SLOT-STALE — pin drift detection", () => {
 
     // Initial telemetry — Discovery session pins to this audit_hash.
     const t0 = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
-    await seedDiscoveryWithPin(store, M_DELIVERY, t0.telemetry.audit_hash);
+    await seedDiscoveryWithPin(
+      store,
+      M_DELIVERY,
+      t0.telemetry.audit_hash,
+      t0.telemetry.telemetry_id,
+    );
 
     // Delivery progresses — slice flips to SLICE_VALIDATED, new emit
     // produces a different audit_hash.
@@ -421,7 +462,12 @@ describe("RGC-CROSS-SLOT-STALE — pin drift detection", () => {
     await dropSlice(store, SLICE_A, M_DELIVERY, "SLICE_BUILDING");
 
     const t0 = await emitSliceTelemetry({ milestone_id: M_DELIVERY }, deps);
-    await seedDiscoveryWithPin(store, M_DELIVERY, t0.telemetry.audit_hash);
+    await seedDiscoveryWithPin(
+      store,
+      M_DELIVERY,
+      t0.telemetry.audit_hash,
+      t0.telemetry.telemetry_id,
+    );
 
     const out = await detectCrossSlotStaleSessions(deps);
     expect(out.staledSessionIds).toEqual([]);


### PR DESCRIPTION
## Summary
Phase 8b (G2-3) closes the KAC-SLICE-TELEMETRY emit + Discovery N+1 manifest inject + RGC-CROSS-SLOT-STALE pin-drift gap. Delivery slice transitions now publish a fresh `SliceTelemetry`; Discovery / Specification manifests inject the live Delivery N telemetry as a read-only entry whose `revision_pin` carries the telemetry's `audit_hash`; cross-slot-stale uses pin comparison instead of the phase-6a conservative trigger so a Delivery slice mutation propagates to Discovery N+1 as `AWAITING_REVALIDATION` end-to-end.

## Changes
| Module | Artifact | Notes |
|---|---|---|
| `src/application/slice-telemetry.ts` (new) | `emitSliceTelemetry`, `loadLatestSliceTelemetry` | builds in_progress / validated / blocked partitions from live Slices, body-only `audit_hash`, idempotent re-emit when partition unchanged, single-line ledger row keyed `(kind=slice_telemetry_emit, milestone_id, audit_hash)` |
| `src/application/slice-merge.ts` | `emitTelemetryAfterTransition` invoked from all 4 SliceMerge transitions | covers SLICE_REVIEWING / INTEGRATING / VALIDATED / BLOCKED / BUILDING-rebuild rotations. Emit failures swallowed — warn-grade per KAC-SLICE-TELEMETRY |
| `src/application/outer-turn.ts` | Discovery / Specification manifest inject + `OuterPinResolver` slice_telemetry resolution | finds most-recently-updated Delivery family milestone in same target, attaches its latest SliceTelemetry, pins to `audit_hash` |
| `src/application/cross-slot-stale.ts` | phase-6a comment removed; pin-drift trigger wired | reads Discovery session's last SessionTurn → manifest → slice_telemetry entry → compares `revision_pin` to live telemetry. Falls back to phase-6a trigger only when no pin is available; pin-match suppresses fallback |
| `src/domain/schema/manifest.ts` | `ManifestEntryObjectKind += slice_telemetry` | enables manifest entry references to live telemetry |
| `src/application/persistence-layout.ts` | `latestSliceTelemetryByMilestone` pointer file path | resolves milestone → telemetry without directory scan |
| `tests/integration/slice-telemetry-pin-drift.test.ts` (new) | 6 integration tests | partition build, idempotency, partition-change rotation, slice-merge.ts wiring, pin-drift staleness, pin-match no-op |
| `tests/application/persistence-layout.test.ts` | new layout assertion | new pointer path + ULID rejection |

## Tests
- 686 passing (was 680) — 6 new phase-8b integration tests + 1 layout assertion
- typecheck clean
- build clean

```
Test Files  80 passed (80)
     Tests  686 passed (686)
```

## Conformance refs
- **KAC-SLICE-TELEMETRY** — `docs/contracts/knowledge-contract.md#KAC-SLICE-TELEMETRY`. Emit + Discovery N+1 inject paths now wired; the contract's `telemetry_enrichment_missing=warn` enforcement is preserved by swallowed emit errors and the conservative phase-6a fallback in cross-slot-stale.
- **RGC-CROSS-SLOT-STALE** — `docs/contracts/reliability-and-gate-contract.md#RGC-CROSS-SLOT-STALE`. The Caller Action (`Discovery N+1 SESSION_OPEN → AWAITING_REVALIDATION`) now fires on real `audit_hash` drift; the conservative phase-6a trigger remains as a fallback for sessions without an injected pin.
- **Inv #3 dual-slot serialization** — Delivery slice mutation → Discovery N+1 revalidation roundtrip is exercised by `slice-telemetry-pin-drift.test.ts > transitions Discovery session to AWAITING_REVALIDATION when telemetry audit_hash drifts`.
- **Plan §검증 G2-3** — Delivery telemetry mutation → Discovery N+1 next pickup → AWAITING_REVALIDATION proven by the integration test above.

## Notes
- `emitSliceTelemetry` partition idempotency uses canonical-JSON equality of partition fields; `recent_session_outcomes` / `edge_cases` / `recent_metric_runs` are caller-supplied (default empty for the slice-merge wiring) so a Delivery state churn that doesn't change slice partitions is a true no-op.
- `cross-slot-stale.ts` preserves `result_detail = "cross_slot_stale"` to keep the existing dual-slot-promotion regression test green; drift kind (`telemetry_pin_drift` vs `delivery_updated_at`) is recorded in the ledger row's `idempotency_key` for forensic traceability.
- The phase-6a fallback fires only when (a) no SessionTurn exists yet on the Discovery session OR (b) the manifest carries no `slice_telemetry` entry. Once Discovery has run a turn with a real Delivery to pair with, pin equality is the authoritative no-drift signal — a Delivery `updated_at` move that did not change slice partitions will not re-stale the Discovery session.
- `slice-telemetry.ts` is also reusable from a periodic refresh (KAC-SLICE-TELEMETRY's `telemetry_refresh_interval` default 30min) by an external scheduler call — wiring is left to a follow-up phase per planning excerpt scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)