### PR TITLE
feat(phase-8c): AC-level traceability + Validation FAIL on partial AC coverage

### DIFF
--- a/docs/migration/phase-8c-vr-coverage-backfill.md
+++ b/docs/migration/phase-8c-vr-coverage-backfill.md
@@ -1,0 +1,56 @@
+# Phase 8c — VerificationRun `covers_ac_ids` backfill
+
+Phase 8c (KAC-TRACEABILITY, plan §G2-2) introduces AC-level traceability:
+each `Slice.ac_ids` entry must be evidenced by a `VerificationRun` whose
+`covers_ac_ids` contains the AC. A passing VR that does not list the AC
+converges Validation to FAIL via `aggregateAcTraceability` (status=`FAIL`).
+
+## Rollout impact
+
+- Pre-8c VRs persist with `covers_ac_ids: []` (zod default). Any slice
+  with declared `ac_ids` that points at one of these VRs renders every
+  declared AC as a FAIL row → next Validation aggregation derives FAIL.
+- This is the **intended** migration signal: pre-8c evidence cannot prove
+  AC coverage and must be re-emitted before a milestone can promote to
+  M_DONE.
+- However, deploying phase 8c into a target with live pre-8c VRs flips
+  Validation immediately. Operators need a rollout plan rather than a
+  surprise FAIL on the next M_DELIVERY_VALIDATING run.
+
+## Recommended deploy procedure
+
+1. **Pre-deploy audit.** Before merging the phase-8c branch, scan
+   `verifications/*.json` per active target and list any VR whose
+   `covers_ac_ids` is empty AND whose linked SliceMerge -> Slice has a
+   non-empty `ac_ids`. Each such row will FAIL on first aggregation.
+2. **Re-emit per slice.** For each impacted slice, run the inner
+   verification cycle (`turn-worker.ts`) to produce a fresh VR with
+   `covers_ac_ids` populated from `Slice.ac_ids` (the dispatch path now
+   forwards them via `IntegrateInput.coversAcIds`). The new SliceMerge
+   pointer makes the next aggregation pick up the fresh VR.
+3. **Confirm aggregation.** Trigger a Validation cycle on a representative
+   milestone and confirm `scout/ac_traceability/<milestone>.json` shows
+   no FAIL rows whose root cause is empty `covers_ac_ids`.
+4. **Operator escalation.** If a slice cannot be re-verified (e.g. its
+   workspace was archived), park the milestone via
+   `park_milestone_awaiting_human` rather than back-filling fake
+   `covers_ac_ids` directly into the VR JSON — the audit chain expects VR
+   bodies to be runner-authored.
+
+## Why no automatic backfill
+
+Mutating persisted `VerificationRun` bodies post-hoc would break the
+audit chain: each VR's `audit_hash` is part of the manifest revision
+pin used by KAC-MANIFEST. A dedicated re-run gives a fresh VR id and
+preserves traceability.
+
+## Code references
+
+- Aggregator: `src/application/scout-observer.ts`
+  (`aggregateAcTraceability`, `computeDerivedVerdict`).
+- Persisted manifest: `scout/ac_traceability/<milestone_id>.json` (see
+  `layout.acTraceabilityByMilestone`).
+- Dispatch FAIL routing: `src/application/outer-turn.ts`
+  (`buildDispatchInput` — phase 8c derives `responsibleSliceIds` from the
+  manifest's FAIL/MISSING rows when the lead is PASS but scout downgrades
+  to FAIL).

--- a/src/application/caller-dispatch.ts
+++ b/src/application/caller-dispatch.ts
@@ -258,6 +258,10 @@ async function runEffect(
           testCommands:
             input.testCommandsForReverify?.(innerPrep.agentCwd) ?? [],
           environmentFingerprint: input.environmentFingerprint,
+          // Phase 8c (KAC-TRACEABILITY): forward the slice's declared
+          // ac_ids so the canonical SliceMerge VerificationRun records AC
+          // coverage that scout-observer's AC-level aggregation can join on.
+          coversAcIds: input.slice.ac_ids,
         },
         { ...smOpDeps, workspace: deps.workspace, verification: deps.verification },
       );

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -86,6 +86,7 @@ import type { LlmAgentProfileId, AgentRole } from "../ports/llm-runner.js";
 import { idempotencyKey } from "./idempotency.js";
 import {
   aggregateValidationEvidence,
+  type AcTraceabilityRow,
   type ScoutEvidenceResult,
 } from "./scout-observer.js";
 import { loadLatestSliceTelemetry } from "./slice-telemetry.js";
@@ -1486,7 +1487,22 @@ async function buildDispatchInput(
         };
       }
       if (normalized === "validation_fail") {
-        const ids = parseStringArray(artifacts, "responsible_slice_ids");
+        const fromArtifacts = parseStringArray(artifacts, "responsible_slice_ids");
+        // Phase 8c (KAC-TRACEABILITY): when a PASS lead is downgraded to FAIL
+        // by scout's AC-level aggregation (`derivedVerdict === "FAIL"`), the
+        // lead envelope is itself PASS so it does not carry
+        // `responsible_slice_ids`. Without a fallback, `recover_milestone_to_
+        // building` would revert only the milestone state and leave the
+        // failing slices stuck in SLICE_VALIDATED. Derive responsible slice
+        // ids from the cached AcTraceabilityRow set (slices that have at
+        // least one FAIL/MISSING AC row) so the dispatch effect can revert
+        // them to SLICE_READY for re-work.
+        const fromAcTraceability =
+          fromArtifacts.length === 0 && cachedEvidence != null
+            ? collectAcFailureSliceIds(cachedEvidence.acTraceability)
+            : [];
+        const ids =
+          fromArtifacts.length > 0 ? fromArtifacts : fromAcTraceability;
         return ids.length > 0 ? { ...base, responsibleSliceIds: ids } : base;
       }
       return base;
@@ -1506,6 +1522,28 @@ function normalizeFinalVerdict(phase: OuterPhase, raw: string): string {
     default:
       return raw;
   }
+}
+
+/**
+ * Phase 8c (KAC-TRACEABILITY): collect distinct slice ids whose AC-level
+ * traceability rows show FAIL or MISSING. Used when a PASS lead envelope
+ * is downgraded to validation_fail by scout aggregation — the dispatch
+ * matrix's `recover_milestone_to_building` row reverts these slices to
+ * SLICE_READY for re-work. Order is preserved (sorted by slice_id from
+ * `aggregateAcTraceability`) and duplicates collapsed.
+ */
+function collectAcFailureSliceIds(
+  rows: readonly AcTraceabilityRow[],
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of rows) {
+    if (r.status === "PASS") continue;
+    if (seen.has(r.slice_id)) continue;
+    seen.add(r.slice_id);
+    out.push(r.slice_id);
+  }
+  return out;
 }
 
 function readString(rec: Record<string, unknown>, key: string): string | null {

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -222,6 +222,12 @@ export async function runOneOuterTurn(
   });
   // P0-4 fix (PR #69 review): Validation FAIL/STALE bypass (pre-eval). See
   // the post-turn branch below for rationale.
+  //
+  // Phase 8c (KAC-TRACEABILITY): when lead emitted PASS but scout AC-level
+  // aggregation derives FAIL (any AC row status=FAIL — slice failed OR
+  // partial AC mapping), force convergence on FAIL so the dispatch
+  // matrix's `validation_fail` row runs. This is plan §G2-2 검증: a
+  // fixture where only some ACs of a slice are PASS converges to FAIL.
   if (
     phase === "Validation" &&
     !preDecision.converged &&
@@ -233,6 +239,15 @@ export async function runOneOuterTurn(
         converged: true,
         final_verdict: leadVerdict,
         finalization_decision: "finalization_rule",
+      };
+    } else if (
+      leadVerdict === "PASS" &&
+      preEvidence?.derivedVerdict === "FAIL"
+    ) {
+      preDecision = {
+        converged: true,
+        final_verdict: "FAIL",
+        finalization_decision: "required_evidence",
       };
     }
   }
@@ -535,6 +550,19 @@ export async function runOneOuterTurn(
         converged: true,
         final_verdict: leadVerdict,
         finalization_decision: "finalization_rule",
+      };
+    } else if (
+      // Phase 8c (KAC-TRACEABILITY): post-turn AC-level downgrade. See
+      // the pre-eval branch above for rationale — kept symmetric so a
+      // session that converges in either window honours scout's AC
+      // aggregation FAIL.
+      leadVerdict === "PASS" &&
+      postEvidence?.derivedVerdict === "FAIL"
+    ) {
+      decision = {
+        converged: true,
+        final_verdict: "FAIL",
+        finalization_decision: "required_evidence",
       };
     }
   }

--- a/src/application/persistence-layout.ts
+++ b/src/application/persistence-layout.ts
@@ -63,6 +63,17 @@ export const layout = {
   contextSummary(milestoneId: string): string {
     return `knowledge/context_summaries/${requireUlid("milestone_id", milestoneId)}.json`;
   },
+  /**
+   * KAC-TRACEABILITY (phase 8c, plan §G2-2) — persisted snapshot of the
+   * AcTraceabilityRow set produced by `aggregateAcTraceability` for a
+   * given milestone. Read-side audits ((`AC-ID -> SliceMerge ->
+   * VerificationRun -> verdict`) consume this manifest without having to
+   * replay the aggregation against potentially-mutated slice/VR files.
+   * Overwritten on each Validation aggregation pass.
+   */
+  acTraceabilityByMilestone(milestoneId: string): string {
+    return `scout/ac_traceability/${requireUlid("milestone_id", milestoneId)}.json`;
+  },
   refactorProposal(proposalId: string): string {
     return `knowledge/refactor_proposals/${requireUlid("proposal_id", proposalId)}.json`;
   },

--- a/src/application/scout-observer.ts
+++ b/src/application/scout-observer.ts
@@ -53,13 +53,22 @@ export interface ScoutEvidenceInput {
  *
  *   - PASS    : the slice's latest SM_MERGED VerificationRun is `pass` and
  *               its `covers_ac_ids` lists this AC.
- *   - FAIL    : the slice's latest SM_MERGED VerificationRun is `fail` /
- *               `error`, OR the slice's VR is pass but does not declare
- *               coverage for this AC (an explicit AC mapping gap from a
- *               passing slice is a Validation FAIL, not MISSING).
+ *   - FAIL    : conflates two operationally distinct conditions, both of
+ *               which converge Validation to FAIL but mean different
+ *               things to the operator:
+ *                 (a) hard fail — the slice's latest SM_MERGED VR is
+ *                     `fail` / `error`. Re-run the slice's verification.
+ *                 (b) coverage gap — the slice's VR is `pass` but its
+ *                     `covers_ac_ids` does not include this AC. Re-emit
+ *                     a fresh VR for this slice with the AC mapped.
+ *               (operator surface: the row's `latest_vr_id` + actual VR
+ *               `result` field disambiguates the two flavours.)
  *   - MISSING : the slice itself has no SM_MERGED SliceMerge yet, or the
  *               SliceMerge has no `verification_run_id`, or the VR file is
- *               missing on disk. STALE-style absence at the AC level.
+ *               missing on disk. STALE-style absence at the AC level. As
+ *               of phase 8c, MISSING also converges Validation to FAIL —
+ *               an un-evidenced declared AC blocks milestone completion
+ *               just like an explicit FAIL.
  *
  * The status enum is fixed (PASS / FAIL / MISSING) per the phase-8c
  * constraint — no other states.
@@ -178,6 +187,25 @@ export async function aggregateValidationEvidence(
     );
   }
 
+  // PR #78 review (P1): persist the AC traceability manifest so read-side
+  // audits can reconstruct (AC-ID -> SliceMerge -> VR -> verdict) without
+  // re-walking slices/. Overwritten per Validation aggregation pass —
+  // the latest verdict per (milestone, AC) is the source of truth. STALE
+  // path skips persistence symmetric to the aggregate VR rule above.
+  if (derivedVerdict !== "STALE") {
+    const manifest = {
+      milestone_id: input.milestoneId,
+      aggregate_vr_id: aggregate.verification_run_id,
+      derived_verdict: derivedVerdict,
+      generated_at: deps.clock.isoNow(),
+      rows: acTraceability,
+    };
+    await deps.store.writeAtomic(
+      layout.acTraceabilityByMilestone(input.milestoneId),
+      JSON.stringify(manifest, null, 2),
+    );
+  }
+
   return {
     aggregate,
     perSlice,
@@ -206,14 +234,17 @@ function computeDerivedVerdict(args: {
   // slice are PASS converges Validation to FAIL — surface that here so the
   // downstream `evidence_only` gate sees `result=fail` and the FAIL bypass
   // routes through the dispatch matrix's `validation_fail` row.
+  // Phase 8c (KAC-TRACEABILITY): a milestone in M_DELIVERY_VALIDATING with
+  // BUILDING/REVIEWING slices that declare ACs surfaces those ACs as
+  // `MISSING` rows. Such ACs are un-evidenced — they cannot prove milestone
+  // completeness — so they must converge Validation to FAIL just like an
+  // explicit AC mapping gap. Note: the early `missingCount > 0` STALE
+  // branch above only counts SLICE_VALIDATED slices that lack SM/VR; a
+  // BUILDING slice declaring ACs slips past that check, so the AC-row
+  // sweep must downgrade to FAIL on MISSING as well as FAIL.
   for (const row of args.acTraceability) {
-    if (row.status === "FAIL") return "FAIL";
+    if (row.status === "FAIL" || row.status === "MISSING") return "FAIL";
   }
-  // MISSING rows alone do not flip a slice-green aggregate — they reflect
-  // slices that haven't yet validated. computeDerivedVerdict already
-  // returns STALE earlier (`missingCount > 0`) when the slice itself is
-  // missing evidence; an AC row whose slice is BUILDING/PENDING shows up
-  // as MISSING here without triggering FAIL.
   return "PASS";
 }
 
@@ -313,8 +344,16 @@ async function loadAllMilestoneSlices(
     let parsed: SliceT;
     try {
       parsed = Slice.parse(JSON.parse(body));
-    } catch {
-      continue;
+    } catch (err) {
+      // PR #78 review: silently dropping a corrupt slice file would leak
+      // declared ACs from AC-traceability — Validation could converge
+      // green while the un-readable slice's ACs are absent from the row
+      // set. Surface as a hard error so the aggregator fails loudly.
+      throw new Error(
+        `[scout-observer] corrupt slice file slices/${name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
     if (parsed.milestone_id !== milestoneId) continue;
     out.push(parsed);
@@ -351,8 +390,15 @@ async function loadMilestoneSlices(
     let parsed: SliceT;
     try {
       parsed = Slice.parse(JSON.parse(body));
-    } catch {
-      continue;
+    } catch (err) {
+      // PR #78 review: corrupt slice JSON must not silently drop a slice
+      // from the aggregation set — that would silently shrink the per-
+      // slice VR coverage that the aggregate VR claims, breaking audit.
+      throw new Error(
+        `[scout-observer] corrupt slice file slices/${name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
     if (parsed.milestone_id !== milestoneId) continue;
     if (parsed.state !== "SLICE_VALIDATED") continue;

--- a/src/application/scout-observer.ts
+++ b/src/application/scout-observer.ts
@@ -46,6 +46,34 @@ export interface ScoutEvidenceInput {
   milestoneId: string;
 }
 
+/**
+ * KAC-TRACEABILITY (phase 8c, plan §G2-2): per-AC traceability row joining
+ * a declared slice AC-ID through its latest SliceMerge → VerificationRun
+ * to a PASS / FAIL / MISSING verdict.
+ *
+ *   - PASS    : the slice's latest SM_MERGED VerificationRun is `pass` and
+ *               its `covers_ac_ids` lists this AC.
+ *   - FAIL    : the slice's latest SM_MERGED VerificationRun is `fail` /
+ *               `error`, OR the slice's VR is pass but does not declare
+ *               coverage for this AC (an explicit AC mapping gap from a
+ *               passing slice is a Validation FAIL, not MISSING).
+ *   - MISSING : the slice itself has no SM_MERGED SliceMerge yet, or the
+ *               SliceMerge has no `verification_run_id`, or the VR file is
+ *               missing on disk. STALE-style absence at the AC level.
+ *
+ * The status enum is fixed (PASS / FAIL / MISSING) per the phase-8c
+ * constraint — no other states.
+ */
+export type AcTraceabilityStatus = "PASS" | "FAIL" | "MISSING";
+
+export interface AcTraceabilityRow {
+  ac_id: string;
+  slice_id: string;
+  slice_merge_id: string | null;
+  latest_vr_id: string | null;
+  status: AcTraceabilityStatus;
+}
+
 export interface ScoutEvidenceResult {
   /** Synthesised aggregate VerificationRun, persisted under verifications/. */
   aggregate: VerificationRunT;
@@ -57,6 +85,13 @@ export interface ScoutEvidenceResult {
   slicesCovered: readonly ContextSummarySliceRef[];
   /** Slice ids that lacked SliceMerge / VerificationRun (cause STALE). */
   slicesMissing: readonly string[];
+  /**
+   * Phase 8c (KAC-TRACEABILITY): AC-level traceability rows aggregated
+   * across all milestone slices. Additive — does not replace the slice-
+   * level `slicesCovered` / `slicesMissing` summaries that downstream
+   * consumers (ContextSummary snapshot) already rely on.
+   */
+  acTraceability: readonly AcTraceabilityRow[];
 }
 
 /**
@@ -101,10 +136,21 @@ export async function aggregateValidationEvidence(
     });
   }
 
+  // Phase 8c (KAC-TRACEABILITY): AC-level traceability is computed across
+  // ALL milestone slices (not just SLICE_VALIDATED), since an AC declared
+  // by a still-building slice is `MISSING`, not absent. The slice-level
+  // `slicesCovered` / `slicesMissing` summaries above are unchanged.
+  const acTraceability = await aggregateAcTraceability(
+    input.milestoneId,
+    sliceMergesBySliceId,
+    deps.store,
+  );
+
   const derivedVerdict = computeDerivedVerdict({
     sliceCount: slices.length,
     perSlice,
     missingCount: slicesMissing.length,
+    acTraceability,
   });
 
   const aggregate: VerificationRunT = VerificationRun.parse({
@@ -138,6 +184,7 @@ export async function aggregateValidationEvidence(
     derivedVerdict,
     slicesCovered,
     slicesMissing,
+    acTraceability,
   };
 }
 
@@ -145,6 +192,7 @@ function computeDerivedVerdict(args: {
   sliceCount: number;
   perSlice: readonly VerificationRunT[];
   missingCount: number;
+  acTraceability: readonly AcTraceabilityRow[];
 }): ScoutDerivedVerdict {
   if (args.sliceCount === 0) return "STALE";
   if (args.missingCount > 0) return "STALE";
@@ -152,7 +200,127 @@ function computeDerivedVerdict(args: {
   for (const vr of args.perSlice) {
     if (vr.result !== "pass") return "FAIL";
   }
+  // Phase 8c (KAC-TRACEABILITY): even when every slice's VR is `pass`, a
+  // partial AC mapping (slice.ac_ids ⊃ vr.covers_ac_ids) leaves some ACs
+  // un-evidenced. Per plan §G2-2 검증, a fixture where only some ACs of a
+  // slice are PASS converges Validation to FAIL — surface that here so the
+  // downstream `evidence_only` gate sees `result=fail` and the FAIL bypass
+  // routes through the dispatch matrix's `validation_fail` row.
+  for (const row of args.acTraceability) {
+    if (row.status === "FAIL") return "FAIL";
+  }
+  // MISSING rows alone do not flip a slice-green aggregate — they reflect
+  // slices that haven't yet validated. computeDerivedVerdict already
+  // returns STALE earlier (`missingCount > 0`) when the slice itself is
+  // missing evidence; an AC row whose slice is BUILDING/PENDING shows up
+  // as MISSING here without triggering FAIL.
   return "PASS";
+}
+
+/**
+ * Phase 8c (KAC-TRACEABILITY, plan §G2-2): walk every milestone slice
+ * and emit one AcTraceabilityRow per declared `ac_id`.
+ *
+ * Status assignment:
+ *   - No SM_MERGED SliceMerge for the slice OR no `verification_run_id`
+ *     OR the VR file is unreadable → `MISSING` (slice_merge_id /
+ *     latest_vr_id may be null).
+ *   - SM_MERGED VR present + `result=pass` + AC listed in
+ *     `vr.covers_ac_ids` → `PASS`.
+ *   - SM_MERGED VR present + `result≠pass` → `FAIL` (slice itself failed,
+ *     all its ACs inherit FAIL).
+ *   - SM_MERGED VR present + `result=pass` but AC NOT listed in
+ *     `vr.covers_ac_ids` → `FAIL` (passing slice with incomplete AC
+ *     mapping; KAC-TRACEABILITY requires every declared AC to be
+ *     evidenced, otherwise Validation must FAIL).
+ *
+ * Backward compat: VRs persisted before phase 8c parse with
+ * `covers_ac_ids = []` (zod default). Such VRs have empty coverage; if
+ * the parent slice declares any AC, those rows render as `FAIL`. This
+ * is the correct migration signal — pre-8c VRs cannot prove AC coverage,
+ * so a Validation re-run that observes them must require operators to
+ * re-emit fresh evidence. (Operator surface: the FAIL row points at the
+ * specific (ac_id, slice_id, latest_vr_id) tuple that needs re-running.)
+ */
+export async function aggregateAcTraceability(
+  milestoneId: string,
+  sliceMergesBySliceId: Map<string, SliceMergeT[]>,
+  store: StorePort,
+): Promise<readonly AcTraceabilityRow[]> {
+  const slices = await loadAllMilestoneSlices(milestoneId, store);
+  const rows: AcTraceabilityRow[] = [];
+  for (const slice of slices) {
+    if (slice.ac_ids.length === 0) continue;
+    const sm = pickLatestMerged(sliceMergesBySliceId.get(slice.slice_id));
+    const vr =
+      sm != null && sm.verification_run_id != null
+        ? await readVerificationRun(sm.verification_run_id, store)
+        : null;
+    for (const acId of slice.ac_ids) {
+      if (sm == null || sm.verification_run_id == null || vr == null) {
+        rows.push({
+          ac_id: acId,
+          slice_id: slice.slice_id,
+          slice_merge_id: sm?.slice_merge_id ?? null,
+          latest_vr_id: sm?.verification_run_id ?? null,
+          status: "MISSING",
+        });
+        continue;
+      }
+      const status: AcTraceabilityStatus =
+        vr.result !== "pass"
+          ? "FAIL"
+          : vr.covers_ac_ids.includes(acId)
+            ? "PASS"
+            : "FAIL";
+      rows.push({
+        ac_id: acId,
+        slice_id: slice.slice_id,
+        slice_merge_id: sm.slice_merge_id,
+        latest_vr_id: sm.verification_run_id,
+        status,
+      });
+    }
+  }
+  rows.sort(
+    (a, b) =>
+      a.slice_id.localeCompare(b.slice_id) || a.ac_id.localeCompare(b.ac_id),
+  );
+  return rows;
+}
+
+/**
+ * Phase 8c helper — load every slice for a milestone irrespective of
+ * state. `loadMilestoneSlices` (slice-level aggregation) filters to
+ * SLICE_VALIDATED only; AC traceability needs to surface declared ACs of
+ * slices still BUILDING / REVIEWING as `MISSING` rows.
+ */
+async function loadAllMilestoneSlices(
+  milestoneId: string,
+  store: StorePort,
+): Promise<readonly SliceT[]> {
+  let entries: string[];
+  try {
+    entries = await store.list("slices");
+  } catch {
+    return [];
+  }
+  const out: SliceT[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    const body = await store.readText(`slices/${name}`);
+    if (body == null) continue;
+    let parsed: SliceT;
+    try {
+      parsed = Slice.parse(JSON.parse(body));
+    } catch {
+      continue;
+    }
+    if (parsed.milestone_id !== milestoneId) continue;
+    out.push(parsed);
+  }
+  out.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+  return out;
 }
 
 function collectFailedTests(

--- a/src/application/slice-merge.ts
+++ b/src/application/slice-merge.ts
@@ -110,6 +110,14 @@ export interface IntegrateInput {
   trunkRevision: string;
   testCommands: import("../ports/verification.js").CommandSpec[];
   environmentFingerprint: string;
+  /**
+   * Phase 8c (KAC-TRACEABILITY): AC-IDs the integrating slice declares.
+   * Forwarded to the rebase reverify VerificationRun so the SliceMerge's
+   * canonical `verification_run_id` records its AC coverage. Optional/
+   * default-empty preserves backward compat with callers that pre-date
+   * 8c.
+   */
+  coversAcIds?: readonly string[];
 }
 
 export type IntegrateOutcome =
@@ -164,6 +172,7 @@ export async function integrateSliceMerge(
       targetRevision: rebase.commit,
       testCommands: input.testCommands,
       environmentFingerprint: input.environmentFingerprint,
+      coversAcIds: input.coversAcIds ?? [],
     },
     {
       verification: deps.verification,

--- a/src/application/turn-worker.ts
+++ b/src/application/turn-worker.ts
@@ -352,12 +352,15 @@ async function runOneInnerTurnInner(
   });
 
   // Verification (#RGC-VERIFICATION inner = synchronous post-commit)
+  // Phase 8c (KAC-TRACEABILITY): forward the slice's declared ac_ids so the
+  // resulting VerificationRun records exactly which AC-IDs it covers.
   const verificationRun = await runInnerVerification(
     {
       targetId: deps.cfg.targetId,
       targetRevision: commit.commit,
       testCommands: deps.cfg.testCommands(prep.agentCwd),
       environmentFingerprint: deps.cfg.environmentFingerprint,
+      coversAcIds: slice.ac_ids,
     },
     {
       verification: deps.verification,

--- a/src/application/verification-runner.ts
+++ b/src/application/verification-runner.ts
@@ -30,6 +30,16 @@ export interface RunInnerVerificationInput {
   targetRevision: string;
   testCommands: CommandSpec[];
   environmentFingerprint: string;
+  /**
+   * KAC-TRACEABILITY (phase 8c, plan §G2-2): AC-IDs this verification is
+   * intended to cover. Recorded on the VerificationRun so the scout
+   * observer's AC-level aggregation (`aggregateAcTraceability`) can map a
+   * slice's declared `ac_ids` to PASS / FAIL / MISSING via the slice's
+   * latest SliceMerge → VerificationRun. Optional with default `[]` for
+   * backward compat with phase ≤ 8b call sites that did not yet wire AC
+   * coverage through.
+   */
+  coversAcIds?: readonly string[];
 }
 
 export interface VerificationRunnerDeps {
@@ -62,6 +72,7 @@ export async function persistVerification(
     result: outcome.result,
     failed_tests: outcome.failed_tests,
     log_ref: null,
+    covers_ac_ids: input.coversAcIds ?? [],
   });
   await deps.store.writeAtomic(
     layout.verification(run.verification_run_id),

--- a/src/domain/schema/verification.ts
+++ b/src/domain/schema/verification.ts
@@ -34,6 +34,16 @@ export const VerificationRun = z
     result: VerificationResult,
     failed_tests: z.array(FailedTest).default(() => []),
     log_ref: z.string().min(1).nullable().default(null),
+    /**
+     * KAC-TRACEABILITY (phase 8c, plan §G2-2): the AC-IDs this run is
+     * intended to cover. Populated by the inner verification-runner from
+     * `slice.ac_ids` for slice-scoped runs; aggregate scout runs leave it
+     * empty (the per-slice rows carry the mapping).
+     *
+     * Optional / default `[]` so any historical VerificationRun JSON written
+     * before phase 8c parses unchanged.
+     */
+    covers_ac_ids: z.array(z.string().min(1)).default(() => []),
   })
   .strict();
 export type VerificationRun = z.infer<typeof VerificationRun>;

--- a/tests/integration/context-summary-snapshot.test.ts
+++ b/tests/integration/context-summary-snapshot.test.ts
@@ -73,6 +73,9 @@ async function seedValidatedSlice(store: FsStore) {
         result: "pass",
         failed_tests: [],
         log_ref: null,
+        // Phase 8c (KAC-TRACEABILITY): slice declares ac_ids:["AC-1"], so
+        // the VR must record AC-1 coverage to keep AC-level aggregation PASS.
+        covers_ac_ids: ["AC-1"],
       }),
     ),
   );

--- a/tests/integration/outer-turn.test.ts
+++ b/tests/integration/outer-turn.test.ts
@@ -783,6 +783,14 @@ describe("runOneOuterTurn — Validation lead_only PASS finalizes M_DONE", () =>
     );
     // dispatch matrix `validation_fail` reverts the milestone to building.
     expect(m.state).toBe("M_DELIVERY_BUILDING");
+    // PR #78 review (P0): the failing slice must also be reverted to
+    // SLICE_READY. Without `responsibleSliceIds` derived from the AC
+    // traceability FAIL rows, the dispatch effect would only roll back
+    // the milestone and leave the slice stuck at SLICE_VALIDATED.
+    const reverted = Slice.parse(
+      JSON.parse((await env.store.readText(layout.slice(SLICE_A)))!),
+    );
+    expect(reverted.state).toBe("SLICE_READY");
   });
 
   it("sentinel lead FAIL → converges validation_fail → milestone reverts to M_DELIVERY_BUILDING (PR #69 P0-4)", async () => {

--- a/tests/integration/outer-turn.test.ts
+++ b/tests/integration/outer-turn.test.ts
@@ -238,6 +238,9 @@ async function seedValidatedSliceWithEvidence(store: FsStore) {
     result: "pass",
     failed_tests: [],
     log_ref: null,
+    // Phase 8c (KAC-TRACEABILITY): slice declares ac_ids:["AC-1"], so the
+    // VR must record AC-1 coverage to satisfy AC-level aggregation.
+    covers_ac_ids: ["AC-1"],
   });
   await store.writeAtomic(layout.verification(VR_A), JSON.stringify(vr));
   const sm = SliceMerge.parse({
@@ -684,6 +687,102 @@ describe("runOneOuterTurn — Validation lead_only PASS finalizes M_DONE", () =>
       }
     }
     expect(aggregates.length).toBe(1);
+  });
+
+  it("phase 8c (KAC-TRACEABILITY): partial AC coverage downgrades lead PASS → validation_fail", async () => {
+    // Plan §G2-2 검증: a fixture where only some ACs of a slice are PASS
+    // converges Validation to FAIL even when the lead emits PASS. The
+    // scout aggregation observes covers_ac_ids ⊊ slice.ac_ids and surfaces
+    // a FAIL row → derivedVerdict=FAIL → outer-turn AC bypass routes the
+    // session through dispatch matrix's `validation_fail` row.
+    const env = setup();
+    await seedMilestone(env.store, "M_DELIVERY_VALIDATING", { specPin: "spec-rev-1" });
+    // Slice declares two ACs but the seeded VR only covers AC-1 → AC-2 row=FAIL.
+    const VR_A = "01HZV0000000000000000000A1";
+    const SM_A = "01HZSM00000000000000000A11";
+    const slice = Slice.parse({
+      slice_id: SLICE_A,
+      milestone_id: MILESTONE_ID,
+      slice_kind: "feature",
+      value_statement: "two-AC slice",
+      ac_ids: ["AC-1", "AC-2"],
+      acceptance_tests: [
+        { path: "tests/ac1.test.ts", name: "ac1", ac_id: "AC-1" },
+        { path: "tests/ac2.test.ts", name: "ac2", ac_id: "AC-2" },
+      ],
+      declared_scope: ["src/x.ts"],
+      declared_metric_threshold: null,
+      interface_break: false,
+      dependencies: [],
+      trunk_base_revision: "trunk-base",
+      dod_revision_pin: "dod-pin",
+      state: "SLICE_VALIDATED",
+      current_session_id: null,
+      spawning_proposal_id: null,
+      abandoned_reason: null,
+      external_refs: [],
+      created_at: ISO,
+      updated_at: ISO,
+    });
+    await env.store.writeAtomic(layout.slice(SLICE_A), JSON.stringify(slice));
+    const vr = VerificationRun.parse({
+      verification_run_id: VR_A,
+      target_id: "demo",
+      target_revision: "rev-A1",
+      commands_or_checks: ["t"],
+      environment_fingerprint: "env",
+      started_at: ISO,
+      finished_at: ISO,
+      result: "pass",
+      failed_tests: [],
+      log_ref: null,
+      covers_ac_ids: ["AC-1"],
+    });
+    await env.store.writeAtomic(layout.verification(VR_A), JSON.stringify(vr));
+    const sm = SliceMerge.parse({
+      slice_merge_id: SM_A,
+      slice_id: SLICE_A,
+      target_id: "demo",
+      pre_merge_workspace_revision: "pre",
+      merge_revision: "merge-A1",
+      inner_session_id: null,
+      review_session_id: null,
+      verification_run_id: VR_A,
+      state: "SM_MERGED",
+      merged_at: ISO,
+      merged_by_caller_id: "caller-1",
+      lease_token: null,
+      audit_chain_predecessor_id: null,
+      external_refs: [],
+      created_at: ISO,
+      updated_at: ISO,
+    });
+    await env.store.writeAtomic(layout.sliceMerge(SM_A), JSON.stringify(sm));
+
+    const { adapter } = makeStub({
+      sentinel: [validationLead(MILESTONE_ID, "PASS")],
+    });
+    const llmRunner = new AdapterRunnerPort(adapter);
+    const out = await runOneOuterTurn({
+      store: env.store,
+      clock: env.clock,
+      llmRunner,
+      ledger: env.ledger,
+      callerId: "test",
+      targetId: "demo",
+    });
+    expect(out.kind).toBe("turn_persisted");
+    if (out.kind !== "turn_persisted") return;
+    expect(out.decision.converged).toBe(true);
+    if (!out.decision.converged) return;
+    expect(out.decision.final_verdict).toBe("FAIL");
+    expect(out.dispatch?.kind).toBe("applied");
+
+    const m = Milestone.parse(
+      JSON.parse((await env.store.readText(layout.milestone(MILESTONE_ID)))!),
+    );
+    // dispatch matrix `validation_fail` reverts the milestone to building.
+    expect(m.state).toBe("M_DELIVERY_BUILDING");
   });
 
   it("sentinel lead FAIL → converges validation_fail → milestone reverts to M_DELIVERY_BUILDING (PR #69 P0-4)", async () => {

--- a/tests/integration/scout-validation-evidence.test.ts
+++ b/tests/integration/scout-validation-evidence.test.ts
@@ -59,14 +59,19 @@ async function seedSlice(
   sliceId: string,
   state: "SLICE_VALIDATED" | "SLICE_BUILDING",
   milestoneId: string = MILESTONE_ID,
+  acIds: readonly string[] = ["AC-1"],
 ) {
   const s = Slice.parse({
     slice_id: sliceId,
     milestone_id: milestoneId,
     slice_kind: "feature",
     value_statement: `slice ${sliceId.slice(-2)}`,
-    ac_ids: ["AC-1"],
-    acceptance_tests: [{ path: "tests/x.test.ts", name: "x", ac_id: "AC-1" }],
+    ac_ids: [...acIds],
+    acceptance_tests: acIds.map((id) => ({
+      path: `tests/${id}.test.ts`,
+      name: id,
+      ac_id: id,
+    })),
     declared_scope: ["src/x.ts"],
     declared_metric_threshold: null,
     interface_break: false,
@@ -89,6 +94,7 @@ async function seedVerification(
   vrId: string,
   result: "pass" | "fail",
   failedTests: { path: string; name: string; message: string | null }[] = [],
+  coversAcIds: readonly string[] = ["AC-1"],
 ) {
   const vr = VerificationRun.parse({
     verification_run_id: vrId,
@@ -101,6 +107,11 @@ async function seedVerification(
     result,
     failed_tests: failedTests,
     log_ref: null,
+    // Phase 8c (KAC-TRACEABILITY): the seeded slice declares ac_ids:["AC-1"],
+    // so the VR must record AC-1 coverage to keep the aggregate PASS. The
+    // FAIL path tests keep the same coverage — Validation FAIL flows from
+    // `result=fail`, not from missing AC coverage.
+    covers_ac_ids: coversAcIds,
   });
   await store.writeAtomic(layout.verification(vrId), JSON.stringify(vr));
 }
@@ -279,5 +290,114 @@ describe("aggregateValidationEvidence — milestone scoping", () => {
     );
     expect(out.slicesCovered.map((s) => s.slice_id)).toEqual([SLICE_A]);
     expect(out.derivedVerdict).toBe("PASS");
+  });
+});
+
+// -------------------------- Phase 8c — KAC-TRACEABILITY -------------------
+
+describe("aggregateValidationEvidence — AC-level traceability rows", () => {
+  it("emits one row per declared ac_id with PASS status when VR covers it", async () => {
+    const env = setup();
+    await seedMilestone(env.store);
+    await seedSlice(env.store, SLICE_A, "SLICE_VALIDATED", MILESTONE_ID, [
+      "AC-1",
+      "AC-2",
+    ]);
+    await seedVerification(env.store, VR_A, "pass", [], ["AC-1", "AC-2"]);
+    await seedSliceMerge(env.store, SM_A, SLICE_A, VR_A);
+
+    const out = await aggregateValidationEvidence(
+      { milestoneId: MILESTONE_ID },
+      { store: env.store, clock: env.clock, targetId: "demo" },
+    );
+    expect(out.derivedVerdict).toBe("PASS");
+    expect(out.acTraceability).toHaveLength(2);
+    for (const row of out.acTraceability) {
+      expect(row.status).toBe("PASS");
+      expect(row.slice_id).toBe(SLICE_A);
+      expect(row.slice_merge_id).toBe(SM_A);
+      expect(row.latest_vr_id).toBe(VR_A);
+    }
+    expect(out.acTraceability.map((r) => r.ac_id).sort()).toEqual([
+      "AC-1",
+      "AC-2",
+    ]);
+  });
+
+  it("partial AC coverage on a passing slice → row=FAIL → derivedVerdict=FAIL (plan §G2-2)", async () => {
+    const env = setup();
+    await seedMilestone(env.store);
+    // Slice declares AC-1 and AC-2 but VR only covers AC-1.
+    await seedSlice(env.store, SLICE_A, "SLICE_VALIDATED", MILESTONE_ID, [
+      "AC-1",
+      "AC-2",
+    ]);
+    await seedVerification(env.store, VR_A, "pass", [], ["AC-1"]);
+    await seedSliceMerge(env.store, SM_A, SLICE_A, VR_A);
+
+    const out = await aggregateValidationEvidence(
+      { milestoneId: MILESTONE_ID },
+      { store: env.store, clock: env.clock, targetId: "demo" },
+    );
+    expect(out.derivedVerdict).toBe("FAIL");
+    expect(out.acTraceability).toHaveLength(2);
+    const byAc = new Map(out.acTraceability.map((r) => [r.ac_id, r]));
+    expect(byAc.get("AC-1")?.status).toBe("PASS");
+    expect(byAc.get("AC-2")?.status).toBe("FAIL");
+    // Aggregate VR result must reflect the FAIL so `evidence_only` gate
+    // sees verification_green=false downstream.
+    expect(out.aggregate.result).toBe("fail");
+  });
+
+  it("non-validated slice surfaces as MISSING rows (one per declared AC)", async () => {
+    const env = setup();
+    await seedMilestone(env.store);
+    await seedSlice(env.store, SLICE_A, "SLICE_BUILDING", MILESTONE_ID, [
+      "AC-1",
+      "AC-2",
+    ]);
+
+    const out = await aggregateValidationEvidence(
+      { milestoneId: MILESTONE_ID },
+      { store: env.store, clock: env.clock, targetId: "demo" },
+    );
+    // Slice not validated → derived STALE (slice-level absence) but the
+    // AC traceability rows are still emitted as MISSING for operator
+    // surface.
+    expect(out.derivedVerdict).toBe("STALE");
+    expect(out.acTraceability).toHaveLength(2);
+    for (const row of out.acTraceability) {
+      expect(row.status).toBe("MISSING");
+      expect(row.slice_merge_id).toBeNull();
+      expect(row.latest_vr_id).toBeNull();
+    }
+  });
+
+  it("VR fail result → all AC rows for that slice = FAIL", async () => {
+    const env = setup();
+    await seedMilestone(env.store);
+    await seedSlice(env.store, SLICE_A, "SLICE_VALIDATED", MILESTONE_ID, [
+      "AC-1",
+      "AC-2",
+    ]);
+    // Even though `covers_ac_ids` lists both, `result=fail` propagates
+    // FAIL to every declared AC of the slice.
+    await seedVerification(
+      env.store,
+      VR_A,
+      "fail",
+      [{ path: "tests/x.test.ts", name: "x", message: "boom" }],
+      ["AC-1", "AC-2"],
+    );
+    await seedSliceMerge(env.store, SM_A, SLICE_A, VR_A);
+
+    const out = await aggregateValidationEvidence(
+      { milestoneId: MILESTONE_ID },
+      { store: env.store, clock: env.clock, targetId: "demo" },
+    );
+    expect(out.derivedVerdict).toBe("FAIL");
+    for (const row of out.acTraceability) {
+      expect(row.status).toBe("FAIL");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Phase 8c (G2-2) wires Acceptance-Criteria-level traceability from `slice.ac_ids` through the inner verification runner all the way to the outer Validation gate. Closes the KAC-TRACEABILITY gap where a single VerificationRun could not record *which* AC-IDs it covered, so scout aggregation could only summarise at the slice level. With this PR, partial AC coverage on a slice that otherwise passes converges Validation to FAIL.

## Changes

| Module | Artifact | Notes |
|---|---|---|
| `src/domain/schema/verification.ts` | `VerificationRun.covers_ac_ids: string[]` | optional/default `[]`, backward-compat for pre-8c VRs |
| `src/application/verification-runner.ts` | `RunInnerVerificationInput.coversAcIds` | optional, threaded into the persisted VR |
| `src/application/turn-worker.ts` | passes `slice.ac_ids` to `runInnerVerification` | inner cycle wiring |
| `src/application/slice-merge.ts` | `IntegrateInput.coversAcIds` → reverify VR | SM_APPROVED → SM_MERGED path |
| `src/application/caller-dispatch.ts` | `coversAcIds: input.slice.ac_ids` | dispatch-time wiring |
| `src/application/scout-observer.ts` | `aggregateAcTraceability` + `ScoutEvidenceResult.acTraceability` | per-AC PASS/FAIL/MISSING rows; status enum is fixed |
| `src/application/scout-observer.ts` | `computeDerivedVerdict` honours AC FAIL | passing slice with incomplete AC mapping → derived FAIL, aggregate `result=fail` |
| `src/application/outer-turn.ts` | Validation FAIL bypass extended | lead PASS + scout AC FAIL → `final_verdict=FAIL`, `validation_fail` dispatch row runs (pre and post evaluation, symmetric) |

## Tests

New tests (5):
- `aggregateValidationEvidence — AC-level traceability rows`:
  - PASS rows when every declared AC is covered
  - **partial AC coverage on a passing slice → row=FAIL → derivedVerdict=FAIL** (plan §G2-2 검증)
  - non-validated slice surfaces as MISSING rows
  - VR fail result → all AC rows for that slice = FAIL
- `runOneOuterTurn` integration: partial AC coverage downgrades lead PASS to `validation_fail` and reverts the milestone to `M_DELIVERY_BUILDING`.

Existing fixtures updated (3, additive):
- `tests/integration/scout-validation-evidence.test.ts` — `seedVerification` now sets `covers_ac_ids: ["AC-1"]` to match the seeded slice.
- `tests/integration/outer-turn.test.ts` — `seedValidatedSliceWithEvidence` VR records AC-1 coverage.
- `tests/integration/context-summary-snapshot.test.ts` — `seedValidatedSlice` VR records AC-1 coverage.

Verification:
- [x] `npm run typecheck` clean
- [x] `npm test` — 691 passing (was 686)
- [x] `npm run build` clean

## Conformance refs

- `KAC-TRACEABILITY` — `docs/contracts/knowledge-contract.md#KAC-TRACEABILITY`
  - "AC-ID 별 PASS/FAIL 을 보고하지 않으면 Validation phase FAIL 이다" — now enforced via `computeDerivedVerdict` + outer-turn AC bypass.
  - mapping chain `AC-ID → Slice → SliceMerge → VerificationRun → Validation verdict` is materialised in `AcTraceabilityRow`.

## Notes

- `covers_ac_ids` defaults to `[]` to preserve backward compat with VRs persisted before phase 8c. Pre-8c VRs that belong to slices declaring any AC will surface as `FAIL` rows on the next Validation re-run — this is the intended migration signal (operator must re-emit fresh evidence).
- `aggregateAcTraceability` walks **all** milestone slices (not just `SLICE_VALIDATED`) so ACs declared on still-building slices show up as `MISSING` rows for operator surface; slice-level STALE semantics are unchanged.
- The status enum is strictly `PASS | FAIL | MISSING` per the phase-8c constraint — no other states added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)