### PR TITLE
feat(phase-9b): scout periodic scan daemon role (G1-3)

### DIFF
--- a/src/application/scout-observer.ts
+++ b/src/application/scout-observer.ts
@@ -32,7 +32,13 @@ import {
 } from "../domain/schema/verification.js";
 import type { ClockPort } from "../ports/clock.js";
 import type { StorePort } from "../ports/store.js";
+import type { LedgerAppender } from "./ledger.js";
 import { layout } from "./persistence-layout.js";
+import {
+  scoutScan,
+  type ScoutScanCandidate,
+  type ScoutScanResult,
+} from "./refactor-backlog.js";
 
 export type ScoutDerivedVerdict = "PASS" | "FAIL" | "STALE";
 
@@ -472,4 +478,110 @@ async function readVerificationRun(
   } catch {
     return null;
   }
+}
+
+/**
+ * Phase 9b (G1-3) — scout periodic scan daemon role.
+ *
+ * KAC-REFACTOR-BACKLOG requires *정기 스캔* of architectural debt while
+ * Delivery is in progress (independent of outer Validation cadence). This
+ * sweep is the daemon entry point invoked by `--role scout-scanner` in
+ * `src/cli/daemon.ts`; it loads in-progress Delivery slices (states
+ * SLICE_PENDING / SLICE_READY / SLICE_BUILDING / SLICE_REVIEWING /
+ * SLICE_INTEGRATING — matches KAC-SLICE-TELEMETRY's `in_progress_slices`
+ * partition), hands them to an injected `scan` callback that produces
+ * RefactorBacklog candidates, and routes those candidates through
+ * `scoutScan` for fingerprint dedup + PROPOSED row persistence + ledger
+ * row emission.
+ *
+ * The actual metric-collection adapter (TCC-REFACTOR-METRICS) is still
+ * spec-only — it slots into `input.scan` in a later phase. Until then the
+ * daemon wiring uses a no-op scanner so the role runs idempotently with
+ * zero RefactorBacklog mutations; tests inject a concrete scan to assert
+ * the lifecycle end-to-end.
+ *
+ * Pure helper — `store` / `clock` / `ledger` only. The daemon's per-role
+ * lockdir (RGC-DAEMON-STARTUP) excludes a sibling scout-scanner; per the
+ * planning §lease note (`scope: "in_progress_slices"`), no slice-anchored
+ * lease is taken — RefactorBacklog writes are append-only and idempotent
+ * via `scoutScan`'s fingerprint dedup, and slice files are read-only here.
+ */
+const SCOUT_SCANNER_IN_PROGRESS_STATES = new Set<SliceT["state"]>([
+  "SLICE_PENDING",
+  "SLICE_READY",
+  "SLICE_BUILDING",
+  "SLICE_REVIEWING",
+  "SLICE_INTEGRATING",
+]);
+
+export interface ScoutScannerSweepDeps {
+  store: StorePort;
+  clock: ClockPort;
+  ledger: LedgerAppender;
+  callerId: string;
+  targetId: string;
+}
+
+export interface ScoutScannerSweepInput {
+  /**
+   * Convert the live in-progress Delivery slices into RefactorBacklog
+   * candidates. Receives the slice list (sorted by slice_id) so the
+   * adapter can derive metric-anchored proposals deterministically.
+   *
+   * Default daemon wiring passes a no-op scanner (returns []) — the
+   * production metric adapter is out of scope for phase 9b.
+   */
+  scan: (slices: readonly SliceT[]) => Promise<readonly ScoutScanCandidate[]>;
+}
+
+export interface ScoutScannerSweepResult extends ScoutScanResult {
+  /** in-progress slices observed this sweep (count). */
+  scannedSliceCount: number;
+}
+
+export async function runScoutScannerSweep(
+  input: ScoutScannerSweepInput,
+  deps: ScoutScannerSweepDeps,
+): Promise<ScoutScannerSweepResult> {
+  const slices = await loadInProgressSlices(deps.store);
+  const result = await scoutScan(
+    { scan: () => input.scan(slices) },
+    deps,
+  );
+  return {
+    ...result,
+    scannedSliceCount: slices.length,
+  };
+}
+
+async function loadInProgressSlices(
+  store: StorePort,
+): Promise<readonly SliceT[]> {
+  let entries: string[];
+  try {
+    entries = await store.list("slices");
+  } catch {
+    return [];
+  }
+  const out: SliceT[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    const body = await store.readText(`slices/${name}`);
+    if (body == null) continue;
+    let parsed: SliceT;
+    try {
+      parsed = Slice.parse(JSON.parse(body));
+    } catch {
+      // Corrupt slice files surface loudly elsewhere (aggregateAcTraceability
+      // / loadMilestoneSlices throw). The scanner is read-only and best-
+      // effort — silently skipping a malformed slice cannot lose evidence
+      // (RefactorBacklog has no per-slice invariant) and avoids a daemon
+      // crash loop on a transient half-written file.
+      continue;
+    }
+    if (!SCOUT_SCANNER_IN_PROGRESS_STATES.has(parsed.state)) continue;
+    out.push(parsed);
+  }
+  out.sort((a, b) => a.slice_id.localeCompare(b.slice_id));
+  return out;
 }

--- a/src/application/scout-observer.ts
+++ b/src/application/scout-observer.ts
@@ -539,19 +539,33 @@ export interface ScoutScannerSweepResult extends ScoutScanResult {
   scannedSliceCount: number;
 }
 
+/**
+ * Lock path for the scout-scanner sweep critical section. PR #80 review
+ * (P1, gpt5.5): although the production daemon role is currently the only
+ * caller and per-role lockdir already excludes a sibling daemon, the sweep
+ * function is exported and may be reused by other wirings. Wrap scan +
+ * scoutScan (read-before-write fingerprint dedup + PROPOSED append) in a
+ * scope-level `withFileLock` so concurrent callers cannot both pass dedup
+ * and double-append the same candidate.
+ */
+const SCOUT_SCANNER_SWEEP_LOCK_PATH =
+  "knowledge/refactor_proposals/.scout-scanner-sweep.lock";
+
 export async function runScoutScannerSweep(
   input: ScoutScannerSweepInput,
   deps: ScoutScannerSweepDeps,
 ): Promise<ScoutScannerSweepResult> {
-  const slices = await loadInProgressSlices(deps.store);
-  const result = await scoutScan(
-    { scan: () => input.scan(slices) },
-    deps,
-  );
-  return {
-    ...result,
-    scannedSliceCount: slices.length,
-  };
+  return deps.store.withFileLock(SCOUT_SCANNER_SWEEP_LOCK_PATH, async () => {
+    const slices = await loadInProgressSlices(deps.store);
+    const result = await scoutScan(
+      { scan: () => input.scan(slices) },
+      deps,
+    );
+    return {
+      ...result,
+      scannedSliceCount: slices.length,
+    };
+  });
 }
 
 async function loadInProgressSlices(

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -3,7 +3,7 @@
  * Phase 4 daemon CLI — runs continuous loops with lease-protected pickup.
  *
  *   tsx src/cli/daemon.ts --role turn-worker | dialogue-coordinator | recovery
- *     | drift-observer
+ *     | drift-observer | scout-scanner
  *     --target ./target.json [--workdir <path>]
  *     [--once] [--cycle-interval-ms 1000]
  *     [--fake-llm-fixtures <dir>] [--fake-workspace] [--fake-verification]
@@ -16,6 +16,12 @@
  *     non-signal drift and writes `external_observation` ledger rows. Uses
  *     the FsMirror IssueTracker / GitHost adapters; production GitHub-API
  *     wiring is out of scope for this phase.
+ *   - `scout-scanner`       — phase-9b (G1-3). Periodic KAC-REFACTOR-BACKLOG
+ *     scan over in-progress Delivery slices. Default cadence 5min when
+ *     `--cycle-interval-ms` is omitted. The actual metric-collection
+ *     adapter (TCC-REFACTOR-METRICS) is still spec-only — the daemon
+ *     wiring uses a no-op scanner so the role runs idempotently with
+ *     zero RefactorBacklog mutations until the adapter lands.
  *
  * Atomicity (RGC-DAEMON-STARTUP): every daemon role takes a per-role PID
  * lockdir under `<workdir>/log/daemon-<role>.pid.lock`. Sibling failure on
@@ -55,6 +61,7 @@ import { FileLedger } from "../application/ledger.js";
 import { runOneOuterTurn } from "../application/outer-turn.js";
 import { LOG_DAEMON_PATH } from "../application/persistence-layout.js";
 import { runRecoverySweep } from "../application/recovery.js";
+import { runScoutScannerSweep } from "../application/scout-observer.js";
 import { runOneInnerTurn } from "../application/turn-worker.js";
 import { SystemClock } from "../ports/clock.js";
 
@@ -64,7 +71,8 @@ type DaemonRole =
   | "outer-coordinator"
   | "dual-track-scheduler"
   | "recovery"
-  | "drift-observer";
+  | "drift-observer"
+  | "scout-scanner";
 
 interface CliArgs {
   role: DaemonRole;
@@ -84,6 +92,12 @@ interface CliArgs {
 // omitted for `--role drift-observer`, fall back to ~60s.
 const DEFAULT_CYCLE_INTERVAL_MS = 1_000;
 const DRIFT_OBSERVER_DEFAULT_CYCLE_INTERVAL_MS = 60_000;
+// Phase 9b (G1-3): scout-scanner is an architectural debt scanner over
+// in-progress Delivery slices. The planning §변경 spec pins the default
+// cadence to 5min — the scanner produces RefactorBacklog candidates and
+// running it at the daemon's 1s default would (a) waste churn on an
+// idempotent dedup path and (b) flood the ledger with no-op cycles.
+const SCOUT_SCANNER_DEFAULT_CYCLE_INTERVAL_MS = 300_000;
 
 function parseArgs(argv: readonly string[]): CliArgs {
   const a = [...argv];
@@ -114,10 +128,11 @@ function parseArgs(argv: readonly string[]): CliArgs {
           v !== "outer-coordinator" &&
           v !== "dual-track-scheduler" &&
           v !== "recovery" &&
-          v !== "drift-observer"
+          v !== "drift-observer" &&
+          v !== "scout-scanner"
         )
           throw new Error(
-            `--role must be turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery | drift-observer (got ${v ?? "<missing>"})`,
+            `--role must be turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery | drift-observer | scout-scanner (got ${v ?? "<missing>"})`,
           );
         out.role = v;
         break;
@@ -160,10 +175,13 @@ function parseArgs(argv: readonly string[]): CliArgs {
   }
   if (out.role == null)
     throw new Error(
-      "--role is required (turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery | drift-observer)",
+      "--role is required (turn-worker | dialogue-coordinator | outer-coordinator | dual-track-scheduler | recovery | drift-observer | scout-scanner)",
     );
   if (out.role === "drift-observer" && !cycleIntervalMsExplicit) {
     out.cycleIntervalMs = DRIFT_OBSERVER_DEFAULT_CYCLE_INTERVAL_MS;
+  }
+  if (out.role === "scout-scanner" && !cycleIntervalMsExplicit) {
+    out.cycleIntervalMs = SCOUT_SCANNER_DEFAULT_CYCLE_INTERVAL_MS;
   }
   return out as CliArgs;
 }
@@ -222,7 +240,8 @@ async function main(argv: readonly string[]): Promise<number> {
     const needsLlmRunner =
       args.role !== "recovery" &&
       args.role !== "dual-track-scheduler" &&
-      args.role !== "drift-observer";
+      args.role !== "drift-observer" &&
+      args.role !== "scout-scanner";
     const allowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER === "1";
     const llmRunner = args.fakeLlmFixtures
       ? new AdapterRunnerPort(new FakeAdapter({ fixtureDir: args.fakeLlmFixtures }))
@@ -442,6 +461,35 @@ async function main(argv: readonly string[]): Promise<number> {
         case "recovery": {
           // Recovery sweep already ran above — emit a noop outcome.
           outcomeJson = JSON.stringify({ role: args.role, outcome: { kind: "swept" } });
+          break;
+        }
+        case "scout-scanner": {
+          // Phase 9b (G1-3) — KAC-REFACTOR-BACKLOG periodic scan over
+          // in-progress Delivery slices. The default scan callback returns
+          // [] — TCC-REFACTOR-METRICS adapter wiring is out of scope for
+          // this phase, so the daemon role runs idempotently with zero
+          // RefactorBacklog mutations until the metric adapter lands. The
+          // sweep still exercises the dedup + ledger-emit path via
+          // `scoutScan` whenever a candidate-producing scan is supplied.
+          const out = await runScoutScannerSweep(
+            { scan: async () => [] },
+            {
+              store,
+              clock,
+              ledger,
+              callerId: args.callerId,
+              targetId: cfg.identity.target_id,
+            },
+          );
+          outcomeJson = JSON.stringify({
+            role: args.role,
+            outcome: {
+              kind: "swept",
+              proposed: out.proposed.length,
+              duplicates: out.duplicates.length,
+              scanned_slices: out.scannedSliceCount,
+            },
+          });
           break;
         }
         case "drift-observer": {

--- a/tests/integration/daemon-scout-scanner.test.ts
+++ b/tests/integration/daemon-scout-scanner.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Phase 9b (G1-3) — scout-scanner daemon role.
+ *
+ * Asserts the planning §검증 trio (mirrors phase-7c daemon-drift-observer):
+ *   (a) in-progress Delivery slice + non-trivial scan → next daemon cycle
+ *       persists a fresh PROPOSED RefactorBacklogItem and emits an
+ *       `external_observation` ledger row (the `scoutScan` lifecycle).
+ *       Driven via `runScoutScannerSweep` directly because the daemon CLI
+ *       wires a no-op scan (TCC-REFACTOR-METRICS adapter is spec-only).
+ *   (b) STOPPED control-state gate suppresses the sweep (no
+ *       RefactorBacklogItem written, no ledger row). Confirms the
+ *       scout-scanner role reuses the phase-7b prelude.
+ *   (c) sibling scout-scanner daemons can not race — the second startup
+ *       fails on the per-role lockdir (RGC-DAEMON-STARTUP).
+ *   (d) `--role scout-scanner` runs the daemon's no-op scan branch
+ *       end-to-end and emits `{ kind: "swept", proposed: 0, ... }`.
+ *   (e) `--cycle-interval-ms` default for scout-scanner is 5min when the
+ *       flag is omitted (planning §변경 cadence).
+ */
+import {
+  existsSync,
+  mkdtempSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import { daemonMain } from "../../src/cli/daemon.js";
+import { applyControlSignal } from "../../src/application/control-state.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import {
+  LEDGER_TRANSITIONS_PATH,
+  layout,
+} from "../../src/application/persistence-layout.js";
+import { listRefactorProposals } from "../../src/application/refactor-backlog.js";
+import { runScoutScannerSweep } from "../../src/application/scout-observer.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { HumanSignalEnvelope } from "../../src/domain/schema/human-signal.js";
+import { Slice } from "../../src/domain/schema/slice.js";
+import { CollectingLogger } from "../../src/ports/logger.js";
+import { FixedClock, SystemClock } from "../../src/ports/clock.js";
+
+const TARGET_ID = "demo-target";
+const ISO_BASE = "2026-05-09T00:00:00.000Z";
+const SLICE_ID = "01HZSA00000000000000000999";
+const MILESTONE_ID = "01HZMS00000000000000000999";
+
+function writeTarget(workdir: string): string {
+  const target = {
+    identity: {
+      target_id: TARGET_ID,
+      workdir_path: workdir,
+      audit_hash_seed: "seed-9b",
+    },
+    agent_profiles: {
+      atlas: { runner: "fake" },
+      forge: { runner: "fake" },
+      sentinel: { runner: "fake" },
+      scout: { runner: "fake" },
+    },
+  };
+  const path = join(workdir, "target.json");
+  writeFileSync(path, JSON.stringify(target), "utf8");
+  return path;
+}
+
+function captureStdout(): { restore: () => void; lines: () => string[] } {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  const spy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(((c: string | Uint8Array) => {
+      chunks.push(typeof c === "string" ? c : Buffer.from(c).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write);
+  return {
+    restore: () => {
+      spy.mockRestore();
+      void orig;
+    },
+    lines: () =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter((s) => s.length > 0),
+  };
+}
+
+async function readLedgerRows(store: FsStore): Promise<LedgerRow[]> {
+  const body = await store.readText(LEDGER_TRANSITIONS_PATH);
+  if (body == null) return [];
+  return body
+    .split("\n")
+    .filter((s) => s.length > 0)
+    .map((s) => LedgerRow.parse(JSON.parse(s)));
+}
+
+async function persistInProgressSlice(
+  store: FsStore,
+  state: "SLICE_BUILDING" | "SLICE_REVIEWING" | "SLICE_VALIDATED",
+  sliceId: string = SLICE_ID,
+): Promise<void> {
+  const sl = Slice.parse({
+    slice_id: sliceId,
+    milestone_id: MILESTONE_ID,
+    slice_kind: "feature",
+    value_statement: "x",
+    ac_ids: [],
+    acceptance_tests: [],
+    declared_scope: [],
+    declared_metric_threshold: null,
+    interface_break: false,
+    dependencies: [],
+    trunk_base_revision: "deadbeef",
+    dod_revision_pin: "deadbeef",
+    state,
+    current_session_id: null,
+    spawning_proposal_id: null,
+    abandoned_reason: null,
+    external_refs: [],
+    created_at: ISO_BASE,
+    updated_at: ISO_BASE,
+  });
+  await store.writeAtomic(layout.slice(sliceId), JSON.stringify(sl, null, 2));
+}
+
+describe("Phase 9b — scout-scanner daemon role", () => {
+  let prevAllowFake: string | undefined;
+
+  beforeEach(() => {
+    prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+  });
+
+  afterEach(() => {
+    if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+  });
+
+  it("(a) runScoutScannerSweep persists PROPOSED RefactorBacklog row + ledger external_observation row, dedups on second pass", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase9b-scan-"));
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new CollectingLogger();
+    const ledger = new FileLedger({ store, logger });
+    const deps = {
+      store,
+      clock,
+      ledger,
+      callerId: "phase9b-ss",
+      targetId: TARGET_ID,
+    };
+
+    await persistInProgressSlice(store, "SLICE_BUILDING");
+    // SLICE_VALIDATED slice must NOT be picked up by the scanner — the
+    // KAC-SLICE-TELEMETRY in_progress partition excludes validated.
+    await persistInProgressSlice(
+      store,
+      "SLICE_VALIDATED",
+      "01HZSA00000000000000000VR2",
+    );
+
+    let receivedSliceCount = 0;
+    const scan = async (slices: readonly { slice_id: string }[]) => {
+      receivedSliceCount = slices.length;
+      return slices.map((s) => ({
+        scope: `slice:${s.slice_id}`,
+        suggested_refactor: "extract helper",
+        rationale: "complexity > 20",
+        code_location: "src/x.ts",
+      }));
+    };
+
+    const r1 = await runScoutScannerSweep({ scan }, deps);
+    expect(r1.scannedSliceCount).toBe(1);
+    expect(receivedSliceCount).toBe(1);
+    expect(r1.proposed.length).toBe(1);
+    expect(r1.duplicates.length).toBe(0);
+
+    // RefactorBacklog row persisted as PROPOSED.
+    const all = await listRefactorProposals(store);
+    expect(all.length).toBe(1);
+    expect(all[0]!.state).toBe("PROPOSED");
+    expect(all[0]!.proposed_by).toBe("scout");
+    expect(all[0]!.scope).toBe(`slice:${SLICE_ID}`);
+
+    // Ledger row emitted (external_observation scope, refactor_proposed kind).
+    const rows = await readLedgerRows(store);
+    const obs = rows.filter((r) => r.action_kind === "external_observation");
+    expect(obs.length).toBe(1);
+    expect(obs[0]!.object_kind).toBe("system");
+    expect(obs[0]!.object_id).toBe(all[0]!.proposal_id);
+
+    // Second sweep over the same slice ⇒ fingerprint dedup, no new rows.
+    const r2 = await runScoutScannerSweep({ scan }, deps);
+    expect(r2.proposed.length).toBe(0);
+    expect(r2.duplicates.length).toBe(1);
+    const all2 = await listRefactorProposals(store);
+    expect(all2.length).toBe(1);
+  });
+
+  it("(b) STOPPED control-state suppresses scout-scanner sweep (prelude reused)", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase9b-stop-"));
+    const targetPath = writeTarget(workdir);
+    const store = new FsStore({ workdir });
+    const clock = new FixedClock(Date.parse(ISO_BASE));
+
+    await applyControlSignal(
+      store,
+      clock,
+      HumanSignalEnvelope.parse({
+        signal_id: "sig-stop-9b",
+        signal_type: "stop",
+        target_kind: "system",
+        target_id: "system",
+        actor: "operator",
+        created_at: ISO_BASE,
+        source: "fs_drop",
+      }),
+    );
+
+    // Plant an in-progress slice — must NOT be scanned because STOPPED.
+    await persistInProgressSlice(store, "SLICE_BUILDING");
+
+    const cap = captureStdout();
+    try {
+      const code = await daemonMain([
+        "--role",
+        "scout-scanner",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--cycle-interval-ms",
+        "0",
+        "--caller-id",
+        "phase9b-ss",
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      cap.restore();
+    }
+
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as { outcome: { kind: string } };
+    expect(parsed.outcome.kind).toBe("stopped");
+
+    const proposals = await listRefactorProposals(store);
+    expect(proposals.length).toBe(0);
+
+    const rows = await readLedgerRows(store);
+    expect(
+      rows.filter((r) => r.action_kind === "external_observation").length,
+    ).toBe(0);
+
+    expect(
+      existsSync(join(workdir, "log", "daemon-scout-scanner.pid.lock")),
+    ).toBe(false);
+  });
+
+  it("(c) sibling scout-scanner daemon fails on per-role lockdir", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase9b-lock-"));
+    const targetPath = writeTarget(workdir);
+
+    const { mkdirSync } = await import("node:fs");
+    const lockPath = join(workdir, "log", "daemon-scout-scanner.pid.lock");
+    mkdirSync(lockPath, { recursive: true });
+
+    const cap = captureStdout();
+    try {
+      await expect(
+        daemonMain([
+          "--role",
+          "scout-scanner",
+          "--target",
+          targetPath,
+          "--workdir",
+          workdir,
+          "--once",
+          "--cycle-interval-ms",
+          "0",
+          "--caller-id",
+          "phase9b-ss",
+        ]),
+      ).rejects.toThrow(/another daemon role=scout-scanner/);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("(d) daemon CLI no-op scan emits {kind:'swept', proposed:0, scanned_slices:N}", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "phase9b-cli-"));
+    const targetPath = writeTarget(workdir);
+    const store = new FsStore({ workdir });
+    await persistInProgressSlice(store, "SLICE_BUILDING");
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "scout-scanner",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--caller-id",
+        "phase9b-ss",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: {
+        kind: string;
+        proposed?: number;
+        duplicates?: number;
+        scanned_slices?: number;
+      };
+    };
+    expect(parsed.role).toBe("scout-scanner");
+    expect(parsed.outcome.kind).toBe("swept");
+    expect(parsed.outcome.proposed).toBe(0);
+    expect(parsed.outcome.duplicates).toBe(0);
+    expect(parsed.outcome.scanned_slices).toBe(1);
+
+    // No-op scan ⇒ no RefactorBacklog rows persisted.
+    const proposals = await listRefactorProposals(store);
+    expect(proposals.length).toBe(0);
+  });
+
+  it("(e) --cycle-interval-ms default is 300_000ms (5min) for scout-scanner", async () => {
+    // The default-cadence guarantee is in-process state of the parser; we
+    // observe it indirectly by running a `--once` cycle without an explicit
+    // interval and asserting the daemon still terminates cleanly. The
+    // numerical constant is asserted by the parseArgs branch above; here
+    // we exercise the full code path without a flag override to confirm
+    // the daemon does not block on the trailing setTimeout (--once breaks
+    // before the sleep, so a 5min default cannot stall the test).
+    const workdir = mkdtempSync(join(tmpdir(), "phase9b-cad-"));
+    const targetPath = writeTarget(workdir);
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "scout-scanner",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--caller-id",
+        "phase9b-ss",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 9b (G1-3) wires `scoutScan` (Phase 5c) into a new `--role scout-scanner` daemon so KAC-REFACTOR-BACKLOG candidates are produced *periodically while Delivery is in progress* — independent of the outer Validation cadence (`outer-turn`'s inline `aggregateValidationEvidence` path is unchanged). The new role inherits the Phase 7b prelude (recovery sweep + human-signal drain + control-state gate), so PAUSED/STOPPED govern it identically to the other daemon roles.

## Changes
| Module | Artifact | Notes |
|---|---|---|
| `src/application/scout-observer.ts` | `runScoutScannerSweep` + `loadInProgressSlices` | reads in-progress Delivery slices (PENDING/READY/BUILDING/REVIEWING/INTEGRATING — matches KAC-SLICE-TELEMETRY's `in_progress_slices` partition), forwards them to an injected `scan` callback, routes resulting candidates through the existing `scoutScan` (fingerprint dedup + PROPOSED persistence + `external_observation` ledger row). The outer-Validation inline call path is untouched — daemon role is a separate entry point that only consumes the same `scoutScan` lifecycle. |
| `src/cli/daemon.ts` | `--role scout-scanner` enum + parser branch | rejects non-roles with explicit error message; updated header doc. |
| `src/cli/daemon.ts` | `SCOUT_SCANNER_DEFAULT_CYCLE_INTERVAL_MS = 300_000` | planning §변경 cadence pin (5min) when `--cycle-interval-ms` is omitted. Mirrors the phase-7c `drift-observer` default-cadence pattern. |
| `src/cli/daemon.ts` | `needsLlmRunner` exclusion | scout-scanner skips LLM runner assembly (no agent profiles consumed for the metric scan). |
| `src/cli/daemon.ts` | scout-scanner switch case | calls `runScoutScannerSweep({ scan: async () => [] }, ...)` — production no-op until TCC-REFACTOR-METRICS adapter lands; emits `{ kind: "swept", proposed, duplicates, scanned_slices }`. |
| `tests/integration/daemon-scout-scanner.test.ts` | 5 new integration tests | (a) sweep persists fresh `PROPOSED` RefactorBacklogItem + ledger `external_observation` row; second pass dedups by fingerprint (no new rows). (b) STOPPED gate suppresses sweep — proves prelude reuse. (c) per-role lockdir excludes sibling scout-scanner. (d) daemon CLI no-op scan branch end-to-end (`scanned_slices=1`, `proposed=0`). (e) default-cadence `--once` smoke. |

## Tests
- 721 passing (was 716) — 5 new daemon-scout-scanner integration tests
- typecheck clean
- build clean

```
Test Files  85 passed (85)
     Tests  721 passed (721)
```

## Conformance refs
- **KAC-REFACTOR-BACKLOG** — `docs/contracts/knowledge-contract.md`. Daemon role implements the *정기 scan* surface that the contract requires; reuses `scoutScan` so the existing 6-state lifecycle (PROPOSED → CURATED → SCHEDULED → DONE/DROPPED/SUPERSEDED) and idempotency (fingerprint dedup over `(scope, code_location, suggested_refactor, rationale)`) are preserved.
- **KAC-SLICE-TELEMETRY** — `in_progress_slices` partition pin: scout-scanner uses the same state set (PENDING/READY/BUILDING/REVIEWING/INTEGRATING) so the scanned scope matches what the manifest inject already exposes.
- **RGC-DAEMON-STARTUP** — per-role lockdir (`log/daemon-scout-scanner.pid.lock`) excludes sibling daemons (test (c) covers).
- **RGC-SIGNALS / Inv #4 / #8** — scout-scanner routes through `runDaemonPrelude` so PAUSED noop / STOPPED graceful-exit identical to phase-7b/7c roles (test (b) covers).
- **RGC-LEDGER** `external_observation` — `scoutScan` already emits one ledger row per PROPOSED, idempotency_key keyed on `(kind=refactor_proposed, proposal_id, from_state=<genesis>, to_state=PROPOSED)`. The daemon adds no new ledger semantics.
- **Plan §검증 G1-3** — *스캔 간격 동안 RefactorBacklog 객체 신규 row 검사*. Test (a) drives this end-to-end (in-process sweep) and test (d) covers the daemon CLI path; both assert the persisted RefactorBacklogItem set.

## Notes
- The production metric-collection adapter (TCC-REFACTOR-METRICS) is **out of scope** for this phase per planning constraints. The daemon hard-wires `scan: async () => []` so the role runs idempotently with zero RefactorBacklog mutations until the adapter lands; tests inject a concrete scan to assert the lifecycle end-to-end.
- scout-scanner uses no `lease` and no `LLM runner`. RefactorBacklog writes are append-only (per-proposal-id `writeAtomic`), and the per-role lockdir prevents two scout-scanner processes from racing. Slice files are read-only here.
- The existing inline call path in `outer-turn.ts` (`aggregateValidationEvidence` for outer Validation) is **not modified** — daemon role is a separate entry point that only adds periodic coverage between Validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)