### PR TITLE
feat(phase-prod-0): e2e-sandbox target fixture + production target docs

### DIFF
--- a/docs/operations/migration-inventory.md
+++ b/docs/operations/migration-inventory.md
@@ -1,0 +1,20 @@
+# Migration Inventory
+
+phase-prod-0 시점의 `docs/migration/*.md` enumeration. production target 진입 전 적용 여부를 항목별 기록한다.
+
+| 파일 | status | 근거 |
+|---|---|---|
+| `docs/migration/phase-8c-vr-coverage-backfill.md` | `not_applicable` (greenfield) / `deferred` (live target) | 신규 production target 은 phase 8c 이후 코드로 처음 부팅되므로 pre-8c VR 자체가 없다 → not_applicable. 기존 운영 target 이 있다면 본 문서의 deploy procedure 를 따라 backfill 후 phase 8c 적용. phase-prod-0 의 e2e-sandbox 는 신규 fixture 이므로 not_applicable. |
+
+## production 진입 전 적용 필요
+
+(없음 — phase-prod-0 시점 기준)
+
+## production 진입과 무관 (deferred 가능)
+
+- `phase-8c-vr-coverage-backfill.md` — 기존 live target 에만 영향. phase-prod-* 는 신규 sandbox / production target 만 다루므로 본 cycle 에서는 적용 의무 없음.
+
+## Update policy
+
+- 신규 `docs/migration/*.md` 추가 시 본 표에 동시 등록.
+- production target 진입 전 모든 `applied` 또는 `not_applicable` 상태여야 한다 (`deferred` 는 운영 결정 사유 기록 후 허용).

--- a/docs/operations/phase-prod-conventions.md
+++ b/docs/operations/phase-prod-conventions.md
@@ -1,0 +1,38 @@
+# phase-prod-* Branch / Commit / PR 규약
+
+phase-prod-0 ~ phase-prod-6 의 cycle 단위 브랜치/커밋/PR 명명 규약. phase-pipeline skill 이 본 문서를 cycle bootstrap 시 참조한다.
+
+## Branch
+
+```
+feat/phase-prod-<N>-<short-slug>
+```
+
+- `<N>` — phase-prod 번호 (0 ~ 6).
+- `<short-slug>` — kebab-case 4 단어 이내 (예: `scope-cleanup`, `healthcheck-stage1`).
+
+## Commit prefix
+
+| 종류 | prefix |
+|---|---|
+| feature / 신규 산출물 | `feat(phase-prod-<N>):` |
+| 버그 수정 | `fix(phase-prod-<N>):` |
+| 리팩토링 | `refactor(phase-prod-<N>):` |
+
+본문은 기존 commit (예: `ea4b2e6`) 양식을 따라 `산출:` / `검증:` 섹션 권장.
+
+## PR title
+
+```
+feat(phase-prod-<N>): <one-line summary>
+```
+
+PR body 는 `## Summary` / `## 구현` / `## 테스트` / `## Gate` 섹션 사용. 마지막 줄에 planning 문서 closing 명시:
+
+```
+Closes Phase <N> of `.human/draft/2026-05-09-production-implementation-phases.md`.
+```
+
+## phase-pipeline skill 결합
+
+phase-pipeline skill 은 cycle 시작 시 본 문서의 prefix / branch 패턴을 자동 적용하고, planning 문서 (`.human/draft/2026-05-09-production-implementation-phases.md`) 의 해당 phase 절을 발췌해 phase-implementer 로 위임한다.

--- a/docs/operations/phase-prod-conventions.md
+++ b/docs/operations/phase-prod-conventions.md
@@ -27,12 +27,12 @@ feat/phase-prod-<N>-<short-slug>
 feat(phase-prod-<N>): <one-line summary>
 ```
 
-PR body 는 `## Summary` / `## 구현` / `## 테스트` / `## Gate` 섹션 사용. 마지막 줄에 planning 문서 closing 명시:
+PR body 는 `## Summary` / `## 구현` / `## 테스트` / `## Gate` 섹션 사용. 마지막 줄에 planning 문서 tracking 메타데이터 명시 (GitHub closing syntax 아님 — `.human/` 은 gitignored 로컬 plan 참조용):
 
 ```
-Closes Phase <N> of `.human/draft/2026-05-09-production-implementation-phases.md`.
+Tracking: phase-prod-<N> per local plan (`.human/draft/2026-05-09-production-implementation-phases.md`, gitignored).
 ```
 
 ## phase-pipeline skill 결합
 
-phase-pipeline skill 은 cycle 시작 시 본 문서의 prefix / branch 패턴을 자동 적용하고, planning 문서 (`.human/draft/2026-05-09-production-implementation-phases.md`) 의 해당 phase 절을 발췌해 phase-implementer 로 위임한다.
+본 문서는 phase-pipeline skill 의 자동 pre-flight 탐지 대상이 아니라 **수동 참조용 운영 규약**이다. cycle 시작 시 사용자가 본 문서를 명시적으로 참조하거나, skill 이 git log / 직전 PR 의 prefix 패턴 (`feat(phase-prod-<N>):`) 으로 phase-prod cycle 임을 자동 매칭한다. planning 문서 (`.human/draft/2026-05-09-production-implementation-phases.md`) 의 해당 phase 절은 사용자가 수동으로 발췌해 phase-implementer 로 위임한다.

--- a/docs/operations/production-target.md
+++ b/docs/operations/production-target.md
@@ -1,0 +1,50 @@
+# Production Target Configuration Guide
+
+production target.json 작성 가이드. 본 문서는 `src/config/target-schema.ts` 의 Zod 스키마와 `src/application/config-validator.ts` 의 `validateOrThrow` 가 single source of truth 이다 — 본 문서는 운영 권장값과 sandbox 와의 차이만 기술한다.
+
+## 필수 필드
+
+| 경로 | 권장값 / 제약 |
+|---|---|
+| `identity.target_id` | 운영 식별자 (kebab-case) |
+| `identity.kind` | `external` (LLM-team 자체 운영 시 `self-hosting` — agent_cwd ≠ workdir_path 강제) |
+| `identity.workdir_path` | 영속 store 절대경로 |
+| `identity.agent_cwd` | worktree root. `self-hosting` 시 workdir_path 외부 |
+| `identity.audit_hash_seed` | 1회 발급 후 변경 금지 |
+| `agent_profiles.{atlas,forge,sentinel,scout}.runner` | `claude_code` 또는 `codex_cli` |
+| `governance.human_team` | 운영 팀 식별자 |
+| `governance.control_issue_number` / `contract_change_issue_number` | 서로 다름 |
+| `governance.human_team_provider` | `fs-mirror` (기본) 또는 `github` |
+| `lease.ttl_default_ms` | 60000 ~ 300000 권장. 무한/0 금지 |
+| `dual_track.priority` | `delivery_first` (기본) / `balanced` / `discovery_first` |
+| `context_budget` | (parent_loop, phase_or_purpose) 별 token_hard_cap. omit 시 architecture default 적용 (`CONTEXT_BUDGET_DEFAULTS`) |
+
+## 금지 사항
+
+- `agent_profiles.*.runner = "fake"` — production 차단 (PR #73 P1; `runner-registry.ts:80-86` 가 `allowFake: false` 로 throw).
+- `lease.ttl_*_ms` 의 0 또는 음수 — Zod `.positive()` 거부.
+- `governance.control_issue_number === contract_change_issue_number` — schema refine 거부.
+
+## GitHub side-effect 격리 권장
+
+- 신규 운영 타겟은 `governance.human_team_provider: "fs-mirror"` 로 시작 — 외부 GitHub Teams 호출 0건.
+- 검증 충분 후 `github` 으로 전환. 전환 시점에 `GH_TOKEN` 권한 / rate-limit 확인 (pre-e2e-checklist §M-2-6, §M-3-3).
+- 운영 부작용을 sandbox repo / fork 에 한정하고 싶을 때는 `identity.label_prefix` 로 production label 과 분리.
+
+## sandbox vs production 차이
+
+| 항목 | e2e-sandbox (`tests/fixtures/targets/e2e-sandbox.json`) | production |
+|---|---|---|
+| `target_id` | `e2e-sandbox` | 운영 식별자 (예: `acme-prod`) |
+| `workdir_path` | `/tmp/llm-team-e2e/sandbox/...` (매 run 격리, mkdtempSync 권장) | 영속 디스크 (운영 user 0700) |
+| `human_team_provider` | `fs-mirror` 강제 | `fs-mirror` → `github` 단계 전환 |
+| `label_prefix` | `e2e:` (production label 과 격리) | 운영 prefix 또는 미설정 |
+| `lease.ttl_*` | 짧게 (J-6: stale 회수 빠름) | 운영 부하에 맞춰 조정 |
+| `runner: "fake"` | 금지 | 금지 |
+
+## 검증 절차
+
+1. `validateOrThrow(JSON.parse(...))` 가 throw 없이 반환.
+2. `pre-e2e-checklist.md §G` 체크리스트 통과.
+3. healthcheck Stage 1~2 (`.human/draft/healthcheck-spec.md#M-6`) PASS.
+4. `migration-inventory.md` 의 모든 항목 `applied` 또는 `not_applicable`.

--- a/tests/fixtures/targets/e2e-sandbox.json
+++ b/tests/fixtures/targets/e2e-sandbox.json
@@ -1,0 +1,43 @@
+{
+  "identity": {
+    "target_id": "e2e-sandbox",
+    "kind": "external",
+    "workdir_path": "/tmp/llm-team-e2e/sandbox/workdir",
+    "agent_cwd": "/tmp/llm-team-e2e/sandbox/agent_cwd",
+    "audit_hash_seed": "e2e-sandbox-v1",
+    "label_prefix": "e2e:"
+  },
+  "agent_profiles": {
+    "atlas": { "runner": "claude_code", "model": "claude-opus-4-7" },
+    "forge": { "runner": "claude_code", "model": "claude-opus-4-7" },
+    "sentinel": { "runner": "codex_cli", "profile": "gpt5.5" },
+    "scout": { "runner": "codex_cli", "profile": "qwen" }
+  },
+  "governance": {
+    "human_team": "e2e-sandbox-team",
+    "control_issue_number": 9001,
+    "contract_change_issue_number": 9002,
+    "human_team_provider": "fs-mirror"
+  },
+  "lease": {
+    "ttl_default_ms": 60000,
+    "ttl_by_lease_kind": {
+      "slot_lock": 30000,
+      "slice_lease": 120000,
+      "session_lease": 300000,
+      "turn_lease": 60000
+    }
+  },
+  "dual_track": {
+    "priority": "delivery_first"
+  },
+  "context_budget": {
+    "outer.Discovery": { "token_hard_cap": 256000 },
+    "outer.Specification": { "token_hard_cap": 256000 },
+    "outer.Planning": { "token_hard_cap": 256000 },
+    "outer.Validation": { "token_hard_cap": 256000 },
+    "middle.review": { "token_hard_cap": 192000 },
+    "middle.merge": { "token_hard_cap": 128000 },
+    "inner.tdd_build": { "token_hard_cap": 128000 }
+  }
+}

--- a/tests/fixtures/targets/e2e-sandbox.test.ts
+++ b/tests/fixtures/targets/e2e-sandbox.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { validateOrThrow } from "../../../src/application/config-validator.js";
+
+const FIXTURE_PATH = resolve(__dirname, "e2e-sandbox.json");
+
+describe("e2e-sandbox target fixture", () => {
+  const raw = JSON.parse(readFileSync(FIXTURE_PATH, "utf8"));
+
+  it("parses with validateOrThrow (production validator)", () => {
+    const cfg = validateOrThrow(raw);
+    expect(cfg.identity.target_id).toBe("e2e-sandbox");
+  });
+
+  it("declares all four agent profiles", () => {
+    const cfg = validateOrThrow(raw);
+    expect(cfg.agent_profiles.atlas.runner).toBeDefined();
+    expect(cfg.agent_profiles.forge.runner).toBeDefined();
+    expect(cfg.agent_profiles.sentinel.runner).toBeDefined();
+    expect(cfg.agent_profiles.scout.runner).toBeDefined();
+  });
+
+  it("does not use the test-only `fake` runner on any profile", () => {
+    const cfg = validateOrThrow(raw);
+    for (const profile of [
+      cfg.agent_profiles.atlas,
+      cfg.agent_profiles.forge,
+      cfg.agent_profiles.sentinel,
+      cfg.agent_profiles.scout,
+    ]) {
+      expect(profile.runner).not.toBe("fake");
+    }
+  });
+
+  it("declares production fields required by §G of pre-e2e-checklist", () => {
+    const cfg = validateOrThrow(raw);
+    expect(cfg.identity.workdir_path).toBeTruthy();
+    expect(cfg.identity.audit_hash_seed).toBeTruthy();
+    expect(cfg.governance?.human_team).toBeTruthy();
+    expect(cfg.lease?.ttl_default_ms).toBeGreaterThan(0);
+    expect(Object.keys(cfg.context_budget ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it("isolates GitHub side effects via fs-mirror provider", () => {
+    const cfg = validateOrThrow(raw);
+    expect(cfg.governance?.human_team_provider).toBe("fs-mirror");
+  });
+});


### PR DESCRIPTION
## Summary
- e2e-sandbox target fixture (production shape, no fake runner) with validateOrThrow round-trip test.
- Production target authoring guide + migration inventory + phase-prod-* conventions doc.

## 구현
- `tests/fixtures/targets/e2e-sandbox.json` — 4 agent profiles wired to `claude_code` / `codex_cli` (atlas+forge=claude, sentinel=gpt5.5, scout=qwen). `governance.human_team_provider: fs-mirror` for GitHub-side-effect isolation. Explicit `lease.ttl_*`, `context_budget`, `audit_hash_seed`, `label_prefix: e2e:`.
- `tests/fixtures/targets/e2e-sandbox.test.ts` — 5 cases: `validateOrThrow` parses, all 4 profiles defined, no profile uses `fake`, §G fields populated, `human_team_provider === fs-mirror`.
- `docs/operations/production-target.md` — required fields, prohibitions (no `fake`, no zero TTL, distinct issue numbers), sandbox vs production diff table, validation sequence.
- `docs/operations/migration-inventory.md` — enumeration of `docs/migration/*` with status. Currently 1 entry (phase-8c-vr-coverage-backfill: not_applicable for greenfield, deferred for live targets).
- `docs/operations/phase-prod-conventions.md` — branch (`feat/phase-prod-<N>-<slug>`), commit prefix (`feat(phase-prod-<N>):`), PR title/body conventions for phases 0~6.

The `.human/` side of phase-prod-0 (checklist split into healthcheck-spec / e2e-scenarios / e2e-ci-spec + anchor-map) is reorganized in the local tree only — `.human/` is gitignored (planning artifacts stay out of tracking). This PR carries the tracked deliverables.

## 테스트
- `npm test` → 741 passing (baseline 736 + 5 new fixture tests)
- `npm run typecheck` → 0 errors
- `npm run build` → 0 errors

## Gate (planning §3)
- [x] checklist split + anchor map (local `.human/` tree)
- [x] sandbox target fixture + validateOrThrow 테스트
- [x] migration inventory
- [x] production target 가이드
- [x] phase-prod 규약 문서

Closes Phase 0 of \`.human/draft/2026-05-09-production-implementation-phases.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)