### PR TITLE
feat(phase-prod-3): live provider healthcheck — Stage 2 + Stage 3 1-shot smoke

### DIFF
--- a/docs/operations/healthcheck.md
+++ b/docs/operations/healthcheck.md
@@ -1,0 +1,89 @@
+# Healthcheck CLI
+
+`tsx src/cli/healthcheck.ts` validates the local environment before any
+production target run. Three stages, increasing in cost:
+
+| Stage | Cost          | Command                    |
+| ----- | ------------- | -------------------------- |
+| 1     | none (~5 s)   | `npm run healthcheck:stage1` |
+| 2     | none (HTTP)   | `npm run healthcheck:stage2` |
+| 3     | live LLM      | `LLM_TEAM_LIVE_HEALTHCHECK=1 npm run healthcheck:stage3` |
+
+## Stage 2 — non-LLM live preflight
+
+- **qwen ping** — HTTP `${LLM_TEAM_QWEN_BASE_URL}/ping` (fallback `/models`).
+  Empty URL → SKIP. 200=PASS, 401/403=FAIL(auth), 429=PASS-w/-warning,
+  5xx=FAIL(upstream).
+- **GitHub `rate_limit`** — `gh api rate_limit`. `remaining < ${LLM_TEAM_GH_RATE_LIMIT_WARN_AT|100}`
+  ⇒ PASS w/ low-budget warning; `remaining == 0` ⇒ FAIL.
+
+Per-probe timeout: 5 s.
+
+## Stage 3 — live 1-shot smoke (opt-in only)
+
+Stage 3 is **always SKIP unless** `LLM_TEAM_LIVE_HEALTHCHECK=1`. This is a
+hard gate — the CLI exits 0 with no live calls otherwise. Cost is bounded
+by two USD caps and a per-day ndjson ledger.
+
+| Env                                  | Default | Purpose                          |
+| ------------------------------------ | ------- | -------------------------------- |
+| `LLM_TEAM_LIVE_HEALTHCHECK`          | (unset) | `"1"` opts into live probes      |
+| `LLM_TEAM_LIVE_COST_CAP_USD`         | `0.10`  | per-run cap                      |
+| `LLM_TEAM_LIVE_DAILY_COST_CAP_USD`   | `1.00`  | daily cap (ledger-aggregated)    |
+| `LLM_TEAM_HEALTHCHECK_RUN_DIR`       | (auto)  | RUN_DIR override                 |
+| `LLM_TEAM_HEALTHCHECK_COST_LEDGER`   | (auto)  | ledger path override             |
+| `LLM_TEAM_QWEN_BASE_URL`             | (unset) | qwen Stage-2 ping (also gates    |
+|                                      |         | codex-qwen smoke)                |
+| `LLM_TEAM_CLAUDE_MODEL`              | (none)  | claude `--model` value           |
+| `LLM_TEAM_CODEX_QWEN_PROFILE`        | `qwen`  | codex `--profile` value          |
+
+### Probes
+
+1. **claude 1-shot** — `claude -p --output-format text [--model <m>]`,
+   prompt via stdin, 60 s timeout.
+2. **codex default 1-shot** — `codex exec --ephemeral --skip-git-repo-check
+   --cd <RUN_DIR> --color never <prompt>`. **stdin is `</dev/null`** —
+   never piped.
+3. **codex qwen 1-shot** — same + `--profile qwen`. Auto-SKIP if Stage 2
+   qwen ping was not PASS.
+
+### RUN_DIR layout
+
+```
+<RUN_DIR>/
+  claude-attempt1.{stdout,stderr,exit,md}
+  codex-default-attempt1.{stdout,stderr,exit,md}
+  codex-qwen-attempt1.{stdout,stderr,exit,md}
+  verified-auth-model.json
+  healthcheck-failure.md     # only if any FAIL
+```
+
+Default RUN_DIR: `~/.llm-team/healthcheck/<utc-timestamp>/` (mode `0700`).
+Never auto-deleted — failures stay on disk for post-mortem.
+
+### Cost ledger
+
+Default path: `~/.llm-team/healthcheck-cost-ledger.ndjson`. One JSON line
+per successful spawn:
+
+```json
+{"ts":"2026-05-09T10:00:00.000Z","kind":"claude.smoke","estimated_usd":0.005,"run_dir":"/.../healthcheck/2026-05-09..."}
+```
+
+Daily cap is computed by summing `estimated_usd` of all entries whose
+`ts` falls within the current UTC day. Cap-exceeded probes SKIP (not
+FAIL) — the operator decides whether to lift the cap.
+
+### Operator workflow
+
+```
+LLM_TEAM_LIVE_HEALTHCHECK=1 \
+  LLM_TEAM_QWEN_BASE_URL=https://… \
+  npm run healthcheck:stage3
+```
+
+Exit 0 ⇒ all live surfaces verified. Inspect
+`<RUN_DIR>/verified-auth-model.json` for the per-CLI status snapshot.
+
+CI MUST NOT set `LLM_TEAM_LIVE_HEALTHCHECK=1` unless an explicit budget
+gate is in place. The default branch protection runs only Stages 1 and 2.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "healthcheck": "tsx src/cli/healthcheck.ts",
-    "healthcheck:stage1": "tsx src/cli/healthcheck.ts --stage 1"
+    "healthcheck:stage1": "tsx src/cli/healthcheck.ts --stage 1",
+    "healthcheck:stage2": "tsx src/cli/healthcheck.ts --stage 2",
+    "healthcheck:stage3": "tsx src/cli/healthcheck.ts --stage 3"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/src/cli/healthcheck-cost-ledger.ts
+++ b/src/cli/healthcheck-cost-ledger.ts
@@ -1,0 +1,144 @@
+/**
+ * Phase prod-3 — Stage 3 cost ledger.
+ *
+ * Stage 3 of the healthcheck CLI may issue live LLM calls when the operator
+ * opts in via `LLM_TEAM_LIVE_HEALTHCHECK=1`. Two USD caps gate cost:
+ *
+ *   1. per-run cap  — `LLM_TEAM_LIVE_COST_CAP_USD`        (default 0.10)
+ *   2. daily   cap  — `LLM_TEAM_LIVE_DAILY_COST_CAP_USD`  (default 1.00)
+ *
+ * Each successful live call appends one line to a ndjson ledger. The ledger
+ * lives outside the trunk working tree so `git status` never surfaces it.
+ *
+ * Default path:
+ *   `${LLM_TEAM_HEALTHCHECK_COST_LEDGER}` if set, otherwise
+ *   `${workdir}/healthcheck/cost-ledger.ndjson` if `workdir` provided,
+ *   otherwise `~/.llm-team/healthcheck-cost-ledger.ndjson`.
+ */
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { CostLedgerEntry } from "./healthcheck-schema.js";
+
+export const DEFAULT_PER_RUN_CAP_USD = 0.1;
+export const DEFAULT_DAILY_CAP_USD = 1.0;
+
+export interface CostLedgerPathOpts {
+  /** Operator-supplied workdir (e.g. RUN_DIR parent). */
+  workdir?: string;
+  /** Process env (used to honor `LLM_TEAM_HEALTHCHECK_COST_LEDGER`). */
+  env?: NodeJS.ProcessEnv;
+  /** Override `os.homedir()` for tests. */
+  home?: string;
+}
+
+export function resolveCostLedgerPath(opts: CostLedgerPathOpts = {}): string {
+  const env = opts.env ?? process.env;
+  const explicit = env.LLM_TEAM_HEALTHCHECK_COST_LEDGER;
+  if (explicit && explicit.length > 0) return resolve(explicit);
+  if (opts.workdir) {
+    return resolve(opts.workdir, "healthcheck", "cost-ledger.ndjson");
+  }
+  const home = opts.home ?? homedir();
+  return resolve(home, ".llm-team", "healthcheck-cost-ledger.ndjson");
+}
+
+export interface ParsedCaps {
+  perRunUsd: number;
+  dailyUsd: number;
+}
+
+export function readCapsFromEnv(env: NodeJS.ProcessEnv): ParsedCaps {
+  const parse = (raw: string | undefined, fallback: number): number => {
+    if (!raw) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : fallback;
+  };
+  return {
+    perRunUsd: parse(env.LLM_TEAM_LIVE_COST_CAP_USD, DEFAULT_PER_RUN_CAP_USD),
+    dailyUsd: parse(env.LLM_TEAM_LIVE_DAILY_COST_CAP_USD, DEFAULT_DAILY_CAP_USD),
+  };
+}
+
+/** Reads the ledger and sums entries whose `ts` falls within [day, day+24h). */
+export function readDailyTotalUsd(
+  ledgerPath: string,
+  now: Date,
+  readFile: (p: string) => string = (p) => readFileSync(p, "utf8"),
+): number {
+  let raw: string;
+  try {
+    raw = readFile(ledgerPath);
+  } catch {
+    return 0;
+  }
+  const dayStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  ).getTime();
+  const dayEnd = dayStart + 24 * 60 * 60 * 1000;
+  let total = 0;
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const r = CostLedgerEntry.safeParse(parsed);
+    if (!r.success) continue;
+    const ts = Date.parse(r.data.ts);
+    if (Number.isNaN(ts)) continue;
+    if (ts >= dayStart && ts < dayEnd) total += r.data.estimated_usd;
+  }
+  return total;
+}
+
+export interface CapCheckInput {
+  estimatedUsd: number;
+  perRunUsd: number;
+  dailyUsd: number;
+  dailyTotalUsd: number;
+}
+
+export type CapCheckResult =
+  | { ok: true }
+  | { ok: false; reason: "per_run" | "daily"; detail: string };
+
+export function checkCaps(input: CapCheckInput): CapCheckResult {
+  if (input.estimatedUsd > input.perRunUsd) {
+    return {
+      ok: false,
+      reason: "per_run",
+      detail: `estimated $${input.estimatedUsd.toFixed(4)} > per-run cap $${input.perRunUsd.toFixed(2)}`,
+    };
+  }
+  if (input.dailyTotalUsd + input.estimatedUsd > input.dailyUsd) {
+    return {
+      ok: false,
+      reason: "daily",
+      detail: `daily $${input.dailyTotalUsd.toFixed(4)} + $${input.estimatedUsd.toFixed(4)} > daily cap $${input.dailyUsd.toFixed(2)}`,
+    };
+  }
+  return { ok: true };
+}
+
+export interface AppendLedgerDeps {
+  appendFile?: (path: string, line: string) => void;
+}
+
+export function appendLedger(
+  ledgerPath: string,
+  entry: CostLedgerEntry,
+  deps: AppendLedgerDeps = {},
+): void {
+  CostLedgerEntry.parse(entry);
+  const append =
+    deps.appendFile ??
+    ((p: string, line: string) => {
+      mkdirSync(dirname(p), { recursive: true });
+      appendFileSync(p, line, { encoding: "utf8" });
+    });
+  append(ledgerPath, `${JSON.stringify(entry)}\n`);
+}

--- a/src/cli/healthcheck-cost-ledger.ts
+++ b/src/cli/healthcheck-cost-ledger.ts
@@ -100,6 +100,14 @@ export interface CapCheckInput {
   perRunUsd: number;
   dailyUsd: number;
   dailyTotalUsd: number;
+  /**
+   * Cumulative USD already spent in the current run (sum of estimated_usd of
+   * probes that already PASSed in this invocation). Defaults to 0 for
+   * backward compatibility, but Stage 3's loop MUST track and pass this so
+   * that several individually-cheap probes cannot collectively exceed the
+   * per-run cap.
+   */
+  runTotalUsd?: number;
 }
 
 export type CapCheckResult =
@@ -107,11 +115,12 @@ export type CapCheckResult =
   | { ok: false; reason: "per_run" | "daily"; detail: string };
 
 export function checkCaps(input: CapCheckInput): CapCheckResult {
-  if (input.estimatedUsd > input.perRunUsd) {
+  const runTotal = input.runTotalUsd ?? 0;
+  if (runTotal + input.estimatedUsd > input.perRunUsd) {
     return {
       ok: false,
       reason: "per_run",
-      detail: `estimated $${input.estimatedUsd.toFixed(4)} > per-run cap $${input.perRunUsd.toFixed(2)}`,
+      detail: `run $${runTotal.toFixed(4)} + $${input.estimatedUsd.toFixed(4)} > per-run cap $${input.perRunUsd.toFixed(2)}`,
     };
   }
   if (input.dailyTotalUsd + input.estimatedUsd > input.dailyUsd) {

--- a/src/cli/healthcheck-schema.ts
+++ b/src/cli/healthcheck-schema.ts
@@ -69,3 +69,55 @@ export const HealthcheckResult = z
   })
   .strict();
 export type HealthcheckResult = z.infer<typeof HealthcheckResult>;
+
+/**
+ * Phase prod-3 — Live Provider Healthcheck additions.
+ *
+ * Stage 3 may invoke real LLM CLIs (claude / codex) when opted in via
+ * `LLM_TEAM_LIVE_HEALTHCHECK=1`. Each live invocation appends a single line
+ * to a ndjson cost ledger so subsequent runs can enforce a daily cap.
+ *
+ * The ledger lives outside the trunk working tree (default
+ * `~/.llm-team/healthcheck-cost-ledger.ndjson`) so `git status` never
+ * surfaces it.
+ */
+export const CostLedgerEntry = z
+  .object({
+    /** ISO timestamp of the live call. */
+    ts: z.string().min(1),
+    /** Stable kind discriminator (e.g. `claude.smoke`, `codex.default.smoke`). */
+    kind: z.string().min(1),
+    /** Estimated USD cost charged against the cap. */
+    estimated_usd: z.number().min(0),
+    /** Optional run directory path (for traceability). */
+    run_dir: z.string().optional(),
+  })
+  .strict();
+export type CostLedgerEntry = z.infer<typeof CostLedgerEntry>;
+
+/**
+ * `verified-auth-model.json` — written after Stage 3 completes.
+ *
+ * `status` records the live-probe outcome per surface; `cli_version` and
+ * `model` are best-effort strings extracted from CLI output.
+ */
+export const VerifiedAuthSurface = z
+  .object({
+    status: z.enum(["PASS", "FAIL", "SKIP"]),
+    cli_version: z.string().optional(),
+    model: z.string().optional(),
+    detail: z.string().optional(),
+  })
+  .strict();
+export type VerifiedAuthSurface = z.infer<typeof VerifiedAuthSurface>;
+
+export const VerifiedAuthModel = z
+  .object({
+    generatedAt: z.string().min(1),
+    claude: VerifiedAuthSurface,
+    codex: VerifiedAuthSurface,
+    codex_qwen: VerifiedAuthSurface,
+    gh: VerifiedAuthSurface,
+  })
+  .strict();
+export type VerifiedAuthModel = z.infer<typeof VerifiedAuthModel>;

--- a/src/cli/healthcheck-stage2.ts
+++ b/src/cli/healthcheck-stage2.ts
@@ -1,0 +1,232 @@
+/**
+ * Phase prod-3 — Stage 2 live-network preflight.
+ *
+ * Stage 2 issues low-cost HTTP probes that are not LLM completions:
+ *
+ *   - qwen endpoint  ping  (`<base>/ping`, fallback `/models`).
+ *       URL from `LLM_TEAM_QWEN_BASE_URL`. Empty → SKIP.
+ *       200=PASS, 401=FAIL(auth), 429=PASS-with-warning, 5xx=FAIL(upstream),
+ *       other non-2xx=FAIL.
+ *
+ *   - GitHub `rate_limit` — fetched via the host `gh api rate_limit`.
+ *       remaining < `LLM_TEAM_GH_RATE_LIMIT_WARN_AT` (default 100) → WARN
+ *       (PASS w/ warning detail). remaining == 0 → FAIL.
+ *
+ * Stage 2 has a 5s per-probe timeout (matching Stage 1 fail-fast budget).
+ */
+import type { SpawnSyncOptions } from "node:child_process";
+import type { HealthcheckItem } from "./healthcheck-schema.js";
+
+export type Stage2Fetch = (
+  url: string,
+  init?: { signal?: AbortSignal; method?: string; headers?: Record<string, string> },
+) => Promise<{ status: number; text: () => Promise<string> }>;
+
+export type Stage2RunCmd = (
+  cmd: string,
+  args: readonly string[],
+  options?: SpawnSyncOptions,
+) => { status: number | null; stdout: string; stderr: string };
+
+export interface Stage2Opts {
+  env: NodeJS.ProcessEnv;
+  fetch?: Stage2Fetch;
+  run: Stage2RunCmd;
+  /** Timeout per probe in ms. Defaults to 5_000. */
+  timeoutMs?: number;
+  /** Override now() for deterministic tests. */
+  now?: () => Date;
+}
+
+export interface Stage2Outcome {
+  items: HealthcheckItem[];
+  /** Whether qwen ping resolved as PASS (used by Stage 3 qwen-smoke gating). */
+  qwenPassed: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_GH_WARN_AT = 100;
+
+async function fetchWithTimeout(
+  doFetch: Stage2Fetch,
+  url: string,
+  timeoutMs: number,
+): Promise<{ status: number; text: string } | { error: string }> {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const r = await doFetch(url, { signal: ac.signal });
+    const text = await r.text().catch(() => "");
+    return { status: r.status, text };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function probeQwen(opts: Stage2Opts): Promise<HealthcheckItem & { ok: boolean }> {
+  const base = (opts.env.LLM_TEAM_QWEN_BASE_URL ?? "").trim();
+  if (base.length === 0) {
+    return {
+      id: "M-2-qwen.ping",
+      status: "SKIP",
+      detail: "LLM_TEAM_QWEN_BASE_URL not set; skipping qwen ping",
+      anchor: "M-2-qwen",
+      ok: false,
+    };
+  }
+  if (!opts.fetch) {
+    return {
+      id: "M-2-qwen.ping",
+      status: "SKIP",
+      detail: "fetch not available; skipping qwen ping",
+      anchor: "M-2-qwen",
+      ok: false,
+    };
+  }
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const url = base.replace(/\/+$/, "") + "/ping";
+  let r = await fetchWithTimeout(opts.fetch, url, timeoutMs);
+  // If /ping is unreachable in a non-network way (404), try /models fallback.
+  if ("status" in r && r.status === 404) {
+    const fallbackUrl = base.replace(/\/+$/, "") + "/models";
+    r = await fetchWithTimeout(opts.fetch, fallbackUrl, timeoutMs);
+  }
+  if ("error" in r) {
+    return {
+      id: "M-2-qwen.ping",
+      status: "FAIL",
+      detail: `qwen ping network error: ${r.error.slice(0, 160)}`,
+      anchor: "M-2-qwen",
+      ok: false,
+    };
+  }
+  if (r.status >= 200 && r.status < 300) {
+    return {
+      id: "M-2-qwen.ping",
+      status: "PASS",
+      detail: `qwen ping ${r.status} ok`,
+      anchor: "M-2-qwen",
+      ok: true,
+    };
+  }
+  if (r.status === 401 || r.status === 403) {
+    return {
+      id: "M-2-qwen.ping",
+      status: "FAIL",
+      detail: `qwen ping ${r.status} auth (check API key)`,
+      anchor: "M-2-qwen",
+      ok: false,
+    };
+  }
+  if (r.status === 429) {
+    return {
+      id: "M-2-qwen.ping",
+      status: "PASS",
+      detail: `qwen ping ${r.status} rate-limited (treated as reachable)`,
+      anchor: "M-2-qwen",
+      ok: true,
+    };
+  }
+  if (r.status >= 500 && r.status < 600) {
+    return {
+      id: "M-2-qwen.ping",
+      status: "FAIL",
+      detail: `qwen ping ${r.status} upstream`,
+      anchor: "M-2-qwen",
+      ok: false,
+    };
+  }
+  return {
+    id: "M-2-qwen.ping",
+    status: "FAIL",
+    detail: `qwen ping unexpected status ${r.status}`,
+    anchor: "M-2-qwen",
+    ok: false,
+  };
+}
+
+interface GhRateLimitJson {
+  rate?: { remaining?: number; limit?: number; reset?: number };
+  resources?: { core?: { remaining?: number; limit?: number; reset?: number } };
+}
+
+function parseGhRateLimit(stdout: string): {
+  remaining: number;
+  limit: number;
+} | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  const j = parsed as GhRateLimitJson;
+  const core = j.resources?.core ?? j.rate;
+  if (!core || typeof core.remaining !== "number") return null;
+  return {
+    remaining: core.remaining,
+    limit: typeof core.limit === "number" ? core.limit : 0,
+  };
+}
+
+function probeGhRateLimit(opts: Stage2Opts): HealthcheckItem {
+  const warnAt = (() => {
+    const raw = opts.env.LLM_TEAM_GH_RATE_LIMIT_WARN_AT;
+    const n = raw ? Number(raw) : NaN;
+    return Number.isFinite(n) && n >= 0 ? n : DEFAULT_GH_WARN_AT;
+  })();
+  const r = opts.run("gh", ["api", "rate_limit"], {
+    encoding: "utf8",
+    timeout: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+  if (r.status !== 0) {
+    return {
+      id: "M-2-gh.rate-limit",
+      status: "FAIL",
+      detail: `gh api rate_limit failed: ${(r.stderr || r.stdout).trim().slice(0, 160)}`,
+      anchor: "M-2-gh",
+    };
+  }
+  const parsed = parseGhRateLimit(r.stdout);
+  if (!parsed) {
+    return {
+      id: "M-2-gh.rate-limit",
+      status: "FAIL",
+      detail: "gh api rate_limit: unparsable response",
+      anchor: "M-2-gh",
+    };
+  }
+  if (parsed.remaining === 0) {
+    return {
+      id: "M-2-gh.rate-limit",
+      status: "FAIL",
+      detail: `gh rate limit exhausted (0/${parsed.limit})`,
+      anchor: "M-2-gh",
+    };
+  }
+  if (parsed.remaining < warnAt) {
+    return {
+      id: "M-2-gh.rate-limit",
+      status: "PASS",
+      detail: `gh rate limit low: ${parsed.remaining}/${parsed.limit} (warn < ${warnAt})`,
+      anchor: "M-2-gh",
+    };
+  }
+  return {
+    id: "M-2-gh.rate-limit",
+    status: "PASS",
+    detail: `gh rate limit ${parsed.remaining}/${parsed.limit}`,
+    anchor: "M-2-gh",
+  };
+}
+
+export async function runStage2(opts: Stage2Opts): Promise<Stage2Outcome> {
+  const items: HealthcheckItem[] = [];
+  const qwen = await probeQwen(opts);
+  const { ok, ...qwenItem } = qwen;
+  items.push(qwenItem);
+  items.push(probeGhRateLimit(opts));
+  return { items, qwenPassed: ok };
+}

--- a/src/cli/healthcheck-stage3.ts
+++ b/src/cli/healthcheck-stage3.ts
@@ -1,0 +1,470 @@
+/**
+ * Phase prod-3 — Stage 3 live 1-shot smoke.
+ *
+ * Stage 3 issues real LLM completions when the operator opts in via
+ * `LLM_TEAM_LIVE_HEALTHCHECK=1`. Every probe is a single, short prompt
+ * (tens of tokens) wrapped by per-run + daily USD caps.
+ *
+ * Probes:
+ *   - claude         1-shot:  `claude -p --output-format text --model <m>`
+ *   - codex (default) 1-shot: `codex exec --skip-git-repo-check --cd <RUN_DIR>
+ *                              --color never <prompt-positional>`
+ *   - codex (qwen)    1-shot: same + `--profile qwen`
+ *
+ * Invariants enforced (also asserted by `tests/cli/healthcheck-stage3.test.ts`):
+ *
+ *   1. `LLM_TEAM_LIVE_HEALTHCHECK !== "1"` ⇒ every probe SKIP, exit 0,
+ *      cost ledger untouched.
+ *   2. codex argv contains `--ephemeral`, `--skip-git-repo-check`, and the
+ *      RUN_DIR via `--cd`. stdin is `</dev/null` (no pipe) so the codex
+ *      positional prompt cannot be confused with a piped stdin payload.
+ *   3. cost-cap exceeded ⇒ probe SKIP (NOT a FAIL — the operator decides
+ *      whether to lift the cap).
+ *   4. qwen Stage 2 ping SKIP/FAIL ⇒ codex-qwen probe auto-SKIP.
+ *   5. Every attempt writes `<probe>.stdout`, `.stderr`, `.exit`, `.md`
+ *      under `<RUN_DIR>/` regardless of outcome (rollback evidence).
+ *   6. On any FAIL, `<RUN_DIR>/healthcheck-failure.md` is generated.
+ *   7. After the run, `<RUN_DIR>/verified-auth-model.json` records the
+ *      live-probe surfaces.
+ *
+ * RUN_DIR resolution (in order):
+ *   - explicit `LLM_TEAM_HEALTHCHECK_RUN_DIR`
+ *   - `<workdir>/healthcheck/<timestamp>/` (workdir from env or `~/.llm-team`)
+ *   Created mode 0700; never deleted on failure.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import {
+  appendLedger,
+  checkCaps,
+  readCapsFromEnv,
+  readDailyTotalUsd,
+  resolveCostLedgerPath,
+} from "./healthcheck-cost-ledger.js";
+import {
+  type CostLedgerEntry,
+  type HealthcheckItem,
+  type VerifiedAuthModel,
+  type VerifiedAuthSurface,
+} from "./healthcheck-schema.js";
+
+export type Stage3SpawnResult = {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  /** Whether the spawn reported `signal === 'SIGTERM'` (timeout). */
+  timedOut?: boolean;
+};
+
+export interface Stage3SpawnInput {
+  cmd: string;
+  args: readonly string[];
+  /** Prompt text to send via stdin (claude). codex passes prompt as positional. */
+  stdin: string | null;
+  cwd: string;
+  timeoutMs: number;
+  /** Whether spawn must connect stdin to /dev/null (codex). */
+  stdinFromDevNull: boolean;
+}
+
+/**
+ * Spawn implementation injected by the CLI. Tests pass a recording mock so
+ * the real claude/codex binaries are never executed. The implementation MUST
+ * honor `stdinFromDevNull: true` by attaching `</dev/null` (i.e. pass
+ * `stdio: ['ignore', ...]`).
+ */
+export type Stage3Spawn = (input: Stage3SpawnInput) => Promise<Stage3SpawnResult>;
+
+export interface Stage3Deps {
+  env: NodeJS.ProcessEnv;
+  spawn: Stage3Spawn;
+  /** Stage 2 qwen-ping outcome (gates codex-qwen). */
+  qwenPassed: boolean;
+  /** Override now() for deterministic tests. */
+  now?: () => Date;
+  /** Override cost ledger reader (default: read from disk). */
+  readLedger?: (path: string) => string;
+  /** Override cost ledger appender (default: appendFileSync). */
+  appendLedger?: (path: string, line: string) => void;
+  /** Override fs.mkdirSync (tests). */
+  mkdir?: (path: string, opts: { recursive: true; mode?: number }) => void;
+  /** Override fs.writeFileSync (tests). */
+  writeFile?: (path: string, content: string) => void;
+  /** Override homedir() (tests). */
+  home?: string;
+  /** Optional explicit workdir (e.g. `--out` parent). */
+  workdir?: string;
+}
+
+export interface Stage3Outcome {
+  items: HealthcheckItem[];
+  /** Resolved RUN_DIR (always populated even when probes SKIP). */
+  runDir: string;
+  /** Path to verified-auth-model.json (if written). */
+  verifiedAuthModelPath?: string;
+  /** Path to healthcheck-failure.md (if any FAIL occurred). */
+  failureMdPath?: string;
+}
+
+const SMOKE_PROMPT_DEFAULT =
+  "Reply with exactly two words: ok ready.\n";
+const PER_PROBE_TIMEOUT_MS = 60_000;
+
+function ts(now: Date): string {
+  return now.toISOString().replace(/[:.]/g, "-");
+}
+
+function resolveRunDir(deps: Stage3Deps, now: Date): string {
+  const env = deps.env;
+  if (env.LLM_TEAM_HEALTHCHECK_RUN_DIR && env.LLM_TEAM_HEALTHCHECK_RUN_DIR.length > 0) {
+    return resolve(env.LLM_TEAM_HEALTHCHECK_RUN_DIR);
+  }
+  const root = deps.workdir
+    ? deps.workdir
+    : resolve(deps.home ?? homedir(), ".llm-team");
+  return resolve(root, "healthcheck", ts(now));
+}
+
+function ensureRunDir(
+  runDir: string,
+  deps: Stage3Deps,
+): void {
+  const mkdir =
+    deps.mkdir ?? ((p, o) => mkdirSync(p, { recursive: o.recursive, mode: o.mode }));
+  mkdir(runDir, { recursive: true, mode: 0o700 });
+}
+
+function writeArtifactSet(
+  runDir: string,
+  probeId: string,
+  result: Stage3SpawnResult,
+  promptText: string,
+  deps: Stage3Deps,
+): void {
+  const writeFile =
+    deps.writeFile ?? ((p, c) => writeFileSync(p, c, { encoding: "utf8" }));
+  writeFile(resolve(runDir, `${probeId}.stdout`), result.stdout);
+  writeFile(resolve(runDir, `${probeId}.stderr`), result.stderr);
+  writeFile(
+    resolve(runDir, `${probeId}.exit`),
+    `${result.status ?? "null"}\n`,
+  );
+  writeFile(
+    resolve(runDir, `${probeId}.md`),
+    [
+      `# ${probeId}`,
+      "",
+      "## prompt",
+      "",
+      "```",
+      promptText.trimEnd(),
+      "```",
+      "",
+      "## exit",
+      "",
+      `\`${result.status ?? "null"}\`${result.timedOut ? " (timed out)" : ""}`,
+      "",
+      "## stdout",
+      "",
+      "```",
+      result.stdout.trimEnd(),
+      "```",
+      "",
+      "## stderr",
+      "",
+      "```",
+      result.stderr.trimEnd(),
+      "```",
+      "",
+    ].join("\n"),
+  );
+}
+
+interface ProbeSpec {
+  id: string;
+  anchor: string;
+  kind: string;
+  estimatedUsd: number;
+  /** Build the spawn input for this probe. */
+  build(runDir: string, prompt: string): Stage3SpawnInput;
+  /** Whether this probe is gated SKIP by external state (qwen). */
+  gate?: { skip: boolean; reason: string };
+}
+
+function buildClaudeArgv(env: NodeJS.ProcessEnv): { cmd: string; args: string[] } {
+  const cmd = env.LLM_TEAM_CLAUDE_BIN || "claude";
+  const args = ["-p", "--output-format", "text"];
+  const model = env.LLM_TEAM_CLAUDE_MODEL;
+  if (model) args.push("--model", model);
+  return { cmd, args };
+}
+
+function buildCodexArgv(
+  env: NodeJS.ProcessEnv,
+  runDir: string,
+  prompt: string,
+  profile: string | null,
+): { cmd: string; args: string[] } {
+  const cmd = env.LLM_TEAM_CODEX_BIN || "codex";
+  const args = [
+    "exec",
+    "--ephemeral",
+    "--skip-git-repo-check",
+    "--cd",
+    runDir,
+    "--color",
+    "never",
+  ];
+  if (profile) args.push("--profile", profile);
+  args.push(prompt);
+  return { cmd, args };
+}
+
+function probeStatus(result: Stage3SpawnResult): "PASS" | "FAIL" {
+  return result.status === 0 && !result.timedOut ? "PASS" : "FAIL";
+}
+
+function summarizeFailure(
+  probeId: string,
+  result: Stage3SpawnResult,
+): string {
+  if (result.timedOut) return "timed out (60s)";
+  if (result.status === null) return "spawn aborted (no status)";
+  return `exit ${result.status}: ${(result.stderr || result.stdout).trim().slice(0, 200)}`;
+}
+
+function makeSurface(
+  status: VerifiedAuthSurface["status"],
+  detail?: string,
+  cliVersion?: string,
+  model?: string,
+): VerifiedAuthSurface {
+  const s: VerifiedAuthSurface = { status };
+  if (detail !== undefined) s.detail = detail;
+  if (cliVersion !== undefined) s.cli_version = cliVersion;
+  if (model !== undefined) s.model = model;
+  return s;
+}
+
+export async function runStage3(deps: Stage3Deps): Promise<Stage3Outcome> {
+  const now = (deps.now ?? (() => new Date()))();
+  const runDir = resolveRunDir(deps, now);
+  ensureRunDir(runDir, deps);
+
+  const env = deps.env;
+  const items: HealthcheckItem[] = [];
+  const optedIn = env.LLM_TEAM_LIVE_HEALTHCHECK === "1";
+
+  // Surface result accumulator (verified-auth-model.json).
+  const surfaces: Record<string, VerifiedAuthSurface> = {
+    claude: makeSurface("SKIP", "stage 3 not run"),
+    codex: makeSurface("SKIP", "stage 3 not run"),
+    codex_qwen: makeSurface("SKIP", "stage 3 not run"),
+    gh: makeSurface("SKIP", "verified by stage 2"),
+  };
+
+  if (!optedIn) {
+    items.push({
+      id: "M-3-opt-in",
+      status: "SKIP",
+      detail:
+        "LLM_TEAM_LIVE_HEALTHCHECK not set to '1'; all live probes skipped (no cost incurred)",
+      anchor: "M-3-0",
+    });
+    const verifiedPath = writeVerifiedAuthModel(runDir, surfaces, now, deps);
+    return { items, runDir, verifiedAuthModelPath: verifiedPath };
+  }
+
+  // Cost caps.
+  const caps = readCapsFromEnv(env);
+  const ledgerPath = resolveCostLedgerPath({ env, workdir: deps.workdir, home: deps.home });
+  let dailyTotal = 0;
+  if (deps.readLedger) {
+    dailyTotal = readDailyTotalUsd(ledgerPath, now, deps.readLedger);
+  } else {
+    dailyTotal = readDailyTotalUsd(ledgerPath, now);
+  }
+
+  const prompt = SMOKE_PROMPT_DEFAULT;
+
+  const probes: ProbeSpec[] = [
+    {
+      id: "claude-attempt1",
+      anchor: "M-3-claude",
+      kind: "claude.smoke",
+      estimatedUsd: 0.005,
+      build(_runDir, p) {
+        const { cmd, args } = buildClaudeArgv(env);
+        return {
+          cmd,
+          args,
+          stdin: p,
+          cwd: runDir,
+          timeoutMs: PER_PROBE_TIMEOUT_MS,
+          stdinFromDevNull: false,
+        };
+      },
+    },
+    {
+      id: "codex-default-attempt1",
+      anchor: "M-3-codex",
+      kind: "codex.default.smoke",
+      estimatedUsd: 0.005,
+      build(rd, p) {
+        const { cmd, args } = buildCodexArgv(env, rd, p, null);
+        return {
+          cmd,
+          args,
+          stdin: null,
+          cwd: rd,
+          timeoutMs: PER_PROBE_TIMEOUT_MS,
+          stdinFromDevNull: true,
+        };
+      },
+    },
+    {
+      id: "codex-qwen-attempt1",
+      anchor: "M-3-codex-qwen",
+      kind: "codex.qwen.smoke",
+      estimatedUsd: 0.005,
+      gate: deps.qwenPassed
+        ? undefined
+        : { skip: true, reason: "qwen Stage 2 ping not PASS; codex-qwen smoke skipped" },
+      build(rd, p) {
+        const profile = env.LLM_TEAM_CODEX_QWEN_PROFILE || "qwen";
+        const { cmd, args } = buildCodexArgv(env, rd, p, profile);
+        return {
+          cmd,
+          args,
+          stdin: null,
+          cwd: rd,
+          timeoutMs: PER_PROBE_TIMEOUT_MS,
+          stdinFromDevNull: true,
+        };
+      },
+    },
+  ];
+
+  for (const probe of probes) {
+    if (probe.gate?.skip) {
+      items.push({
+        id: probe.id,
+        status: "SKIP",
+        detail: probe.gate.reason,
+        anchor: probe.anchor,
+      });
+      surfaces[surfaceKeyFor(probe.kind)] = makeSurface("SKIP", probe.gate.reason);
+      continue;
+    }
+    const cap = checkCaps({
+      estimatedUsd: probe.estimatedUsd,
+      perRunUsd: caps.perRunUsd,
+      dailyUsd: caps.dailyUsd,
+      dailyTotalUsd: dailyTotal,
+    });
+    if (!cap.ok) {
+      items.push({
+        id: probe.id,
+        status: "SKIP",
+        detail: `cost cap (${cap.reason}): ${cap.detail}`,
+        anchor: probe.anchor,
+      });
+      surfaces[surfaceKeyFor(probe.kind)] = makeSurface("SKIP", cap.detail);
+      continue;
+    }
+    const input = probe.build(runDir, prompt);
+    const result = await deps.spawn(input);
+    writeArtifactSet(runDir, probe.id, result, prompt, deps);
+
+    const status = probeStatus(result);
+    items.push({
+      id: probe.id,
+      status,
+      detail:
+        status === "PASS"
+          ? `argv: ${input.cmd} ${input.args.join(" ")}`
+          : summarizeFailure(probe.id, result),
+      anchor: probe.anchor,
+    });
+    surfaces[surfaceKeyFor(probe.kind)] = makeSurface(
+      status,
+      status === "PASS" ? "live 1-shot ok" : summarizeFailure(probe.id, result),
+    );
+
+    // Append ledger AFTER spawn (only if we actually spawned).
+    const entry: CostLedgerEntry = {
+      ts: now.toISOString(),
+      kind: probe.kind,
+      estimated_usd: probe.estimatedUsd,
+      run_dir: runDir,
+    };
+    appendLedger(ledgerPath, entry, { appendFile: deps.appendLedger });
+    dailyTotal += probe.estimatedUsd;
+  }
+
+  // failure markdown (if any FAIL).
+  let failureMdPath: string | undefined;
+  if (items.some((it) => it.status === "FAIL")) {
+    failureMdPath = writeFailureMd(runDir, items, deps);
+  }
+
+  const verifiedAuthModelPath = writeVerifiedAuthModel(runDir, surfaces, now, deps);
+  return { items, runDir, verifiedAuthModelPath, failureMdPath };
+}
+
+function surfaceKeyFor(kind: string): string {
+  if (kind === "claude.smoke") return "claude";
+  if (kind === "codex.qwen.smoke") return "codex_qwen";
+  return "codex";
+}
+
+function writeVerifiedAuthModel(
+  runDir: string,
+  surfaces: Record<string, VerifiedAuthSurface>,
+  now: Date,
+  deps: Stage3Deps,
+): string {
+  const writeFile =
+    deps.writeFile ?? ((p, c) => writeFileSync(p, c, { encoding: "utf8" }));
+  const path = resolve(runDir, "verified-auth-model.json");
+  const value: VerifiedAuthModel = {
+    generatedAt: now.toISOString(),
+    claude: surfaces.claude!,
+    codex: surfaces.codex!,
+    codex_qwen: surfaces.codex_qwen!,
+    gh: surfaces.gh!,
+  };
+  writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+function writeFailureMd(
+  runDir: string,
+  items: HealthcheckItem[],
+  deps: Stage3Deps,
+): string {
+  const writeFile =
+    deps.writeFile ?? ((p, c) => writeFileSync(p, c, { encoding: "utf8" }));
+  const path = resolve(runDir, "healthcheck-failure.md");
+  const failed = items.filter((it) => it.status === "FAIL");
+  const lines: string[] = [
+    "# healthcheck stage 3 — FAILURE",
+    "",
+    `Failed items (${failed.length}):`,
+    "",
+  ];
+  for (const it of failed) {
+    lines.push(`- **${it.id}** (${it.anchor}): ${it.detail}`);
+    lines.push(`  - artifacts: \`${it.id}.stdout\` / \`${it.id}.stderr\` / \`${it.id}.exit\` / \`${it.id}.md\``);
+  }
+  lines.push("");
+  lines.push("## next steps");
+  lines.push("");
+  lines.push("1. Inspect the per-probe `<probe>.stderr` for the upstream error.");
+  lines.push("2. Re-authenticate the failing CLI (`claude /login`, `codex auth login`).");
+  lines.push("3. Re-run with `LLM_TEAM_LIVE_HEALTHCHECK=1 npm run healthcheck:stage3`.");
+  lines.push("");
+  writeFile(path, lines.join("\n"));
+  return path;
+}

--- a/src/cli/healthcheck-stage3.ts
+++ b/src/cli/healthcheck-stage3.ts
@@ -35,6 +35,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
+import { redactSecrets } from "../adapters/llm-runner/common/redact.js";
 import {
   appendLedger,
   checkCaps,
@@ -144,8 +145,13 @@ function writeArtifactSet(
 ): void {
   const writeFile =
     deps.writeFile ?? ((p, c) => writeFileSync(p, c, { encoding: "utf8" }));
-  writeFile(resolve(runDir, `${probeId}.stdout`), result.stdout);
-  writeFile(resolve(runDir, `${probeId}.stderr`), result.stderr);
+  // Sink-boundary redaction (phase-prod-2 pattern). Provider CLIs may emit
+  // tokens or `Bearer` headers in stderr on auth errors; scrub before any
+  // RUN_DIR file is written.
+  const stdout = redactSecrets(result.stdout, deps.env);
+  const stderr = redactSecrets(result.stderr, deps.env);
+  writeFile(resolve(runDir, `${probeId}.stdout`), stdout);
+  writeFile(resolve(runDir, `${probeId}.stderr`), stderr);
   writeFile(
     resolve(runDir, `${probeId}.exit`),
     `${result.status ?? "null"}\n`,
@@ -168,13 +174,13 @@ function writeArtifactSet(
       "## stdout",
       "",
       "```",
-      result.stdout.trimEnd(),
+      stdout.trimEnd(),
       "```",
       "",
       "## stderr",
       "",
       "```",
-      result.stderr.trimEnd(),
+      stderr.trimEnd(),
       "```",
       "",
     ].join("\n"),
@@ -193,11 +199,18 @@ interface ProbeSpec {
 }
 
 function buildClaudeArgv(env: NodeJS.ProcessEnv): { cmd: string; args: string[] } {
-  const cmd = env.LLM_TEAM_CLAUDE_BIN || "claude";
-  const args = ["-p", "--output-format", "text"];
+  // Mirror ClaudeCodeAdapter.buildArgv: support multi-token launchers
+  // (e.g. `npx claude`) by splitting on whitespace and passing the tail as
+  // leading argv. Without this, `LLM_TEAM_CLAUDE_BIN="npx claude"` would
+  // ENOENT because spawn would look for an executable literally named
+  // "npx claude".
+  const tokens = (env.LLM_TEAM_CLAUDE_BIN || "claude").split(/\s+/).filter(Boolean);
+  const cmd = tokens[0] ?? "claude";
+  const baseArgs = tokens.slice(1);
+  const flags: string[] = ["-p", "--output-format", "text"];
   const model = env.LLM_TEAM_CLAUDE_MODEL;
-  if (model) args.push("--model", model);
-  return { cmd, args };
+  if (model) flags.push("--model", model);
+  return { cmd, args: [...baseArgs, ...flags] };
 }
 
 function buildCodexArgv(
@@ -228,10 +241,15 @@ function probeStatus(result: Stage3SpawnResult): "PASS" | "FAIL" {
 function summarizeFailure(
   probeId: string,
   result: Stage3SpawnResult,
+  env: NodeJS.ProcessEnv,
 ): string {
   if (result.timedOut) return "timed out (60s)";
   if (result.status === null) return "spawn aborted (no status)";
-  return `exit ${result.status}: ${(result.stderr || result.stdout).trim().slice(0, 200)}`;
+  // Sink-boundary redaction: detail is persisted into result.items (and
+  // ultimately healthcheck-failure.md). Apply the same scrubbing as the
+  // RUN_DIR artifacts so neither path leaks tokens.
+  const raw = (result.stderr || result.stdout).trim().slice(0, 200);
+  return `exit ${result.status}: ${redactSecrets(raw, env)}`;
 }
 
 function makeSurface(
@@ -285,6 +303,9 @@ export async function runStage3(deps: Stage3Deps): Promise<Stage3Outcome> {
   } else {
     dailyTotal = readDailyTotalUsd(ledgerPath, now);
   }
+  // Per-run accumulator — same pattern as dailyTotal but reset every
+  // invocation. Increments only after a probe PASSes (matches ledger append).
+  let runTotal = 0;
 
   const prompt = SMOKE_PROMPT_DEFAULT;
 
@@ -362,6 +383,7 @@ export async function runStage3(deps: Stage3Deps): Promise<Stage3Outcome> {
       perRunUsd: caps.perRunUsd,
       dailyUsd: caps.dailyUsd,
       dailyTotalUsd: dailyTotal,
+      runTotalUsd: runTotal,
     });
     if (!cap.ok) {
       items.push({
@@ -384,12 +406,12 @@ export async function runStage3(deps: Stage3Deps): Promise<Stage3Outcome> {
       detail:
         status === "PASS"
           ? `argv: ${input.cmd} ${input.args.join(" ")}`
-          : summarizeFailure(probe.id, result),
+          : summarizeFailure(probe.id, result, env),
       anchor: probe.anchor,
     });
     surfaces[surfaceKeyFor(probe.kind)] = makeSurface(
       status,
-      status === "PASS" ? "live 1-shot ok" : summarizeFailure(probe.id, result),
+      status === "PASS" ? "live 1-shot ok" : summarizeFailure(probe.id, result, env),
     );
 
     // Append ledger AFTER spawn (only if we actually spawned).
@@ -401,6 +423,7 @@ export async function runStage3(deps: Stage3Deps): Promise<Stage3Outcome> {
     };
     appendLedger(ledgerPath, entry, { appendFile: deps.appendLedger });
     dailyTotal += probe.estimatedUsd;
+    runTotal += probe.estimatedUsd;
   }
 
   // failure markdown (if any FAIL).

--- a/src/cli/healthcheck.ts
+++ b/src/cli/healthcheck.ts
@@ -461,6 +461,31 @@ export async function runHealthcheck(
   }
 
   if (args.stage === 3) {
+    // Default-SKIP gate: without `LLM_TEAM_LIVE_HEALTHCHECK=1`, stage 3 must
+    // not spawn anything AND must not run stage 2's network probes (qwen
+    // ping, gh rate_limit). Return a SKIP-only result so an unauthenticated
+    // host on a CI runner cannot accidentally fail this stage.
+    if (env.LLM_TEAM_LIVE_HEALTHCHECK !== "1") {
+      const skipItem: HealthcheckItem = {
+        id: "M-3-opt-in",
+        status: "SKIP",
+        detail:
+          "LLM_TEAM_LIVE_HEALTHCHECK not set to '1'; stage 3 (and its stage-2 prerequisites) skipped (no spawn, no network)",
+        anchor: "M-3-0",
+      };
+      const result: HealthcheckResult = {
+        stage: 3,
+        items: [skipItem],
+        passed: true,
+        generatedAt,
+        auth_models: {
+          claude: "UNKNOWN_UNTIL_STAGE3",
+          codex: "UNKNOWN_UNTIL_STAGE3",
+          gh: env.GH_TOKEN && env.GH_TOKEN.length > 0 ? "env_token" : "unknown",
+        },
+      };
+      return HealthcheckResult.parse(result);
+    }
     // Stage 3 needs the qwen ping outcome to gate codex-qwen smoke. Run
     // stage 2 first as a prerequisite (its own probes also surface in the
     // stage-3 result so an operator sees the full picture).

--- a/src/cli/healthcheck.ts
+++ b/src/cli/healthcheck.ts
@@ -23,7 +23,7 @@
  *   tsx src/cli/healthcheck.ts --stage 1 [--target <path>] [--out <dir>]
  *     [--json]
  */
-import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import { spawn as nodeSpawn, spawnSync, type SpawnSyncOptions } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
@@ -33,6 +33,12 @@ import {
   type HealthcheckItem,
   type HealthcheckStage,
 } from "./healthcheck-schema.js";
+import { runStage2, type Stage2Fetch } from "./healthcheck-stage2.js";
+import {
+  runStage3,
+  type Stage3Spawn,
+  type Stage3SpawnInput,
+} from "./healthcheck-stage3.js";
 
 export type RunCmd = (
   cmd: string,
@@ -65,6 +71,26 @@ export interface HealthcheckEnv {
   env?: NodeJS.ProcessEnv;
   cwd?: string;
   now?: () => Date;
+  /** Stage 2 — HTTP probe (qwen ping). Defaults to global `fetch`. */
+  fetch?: Stage2Fetch;
+  /** Stage 3 — child spawn (mocked in tests). Defaults to a real spawn that
+   * honors `stdinFromDevNull` for codex invocations. */
+  stage3Spawn?: Stage3Spawn;
+  /** Stage 3 — workdir override for RUN_DIR / cost ledger (tests). */
+  stage3Workdir?: string;
+  /** Stage 3 — homedir override (tests). */
+  stage3Home?: string;
+  /** Stage 3 — readLedger override (tests). */
+  stage3ReadLedger?: (path: string) => string;
+  /** Stage 3 — appendLedger override (tests). */
+  stage3AppendLedger?: (path: string, line: string) => void;
+  /** Stage 3 — mkdir override (tests). */
+  stage3Mkdir?: (
+    path: string,
+    opts: { recursive: true; mode?: number },
+  ) => void;
+  /** Stage 3 — writeFile override (tests). */
+  stage3WriteFile?: (path: string, content: string) => void;
 }
 
 export function parseArgs(argv: readonly string[]): HealthcheckArgs {
@@ -401,36 +427,82 @@ export function runStage1(opts: {
   return { items, auth_models };
 }
 
-export function runHealthcheck(
+export async function runHealthcheck(
   args: HealthcheckArgs,
   envCfg: HealthcheckEnv = {},
-): HealthcheckResult {
+): Promise<HealthcheckResult> {
   const run = envCfg.run ?? defaultRunCmd;
   const env = envCfg.env ?? process.env;
   const cwd = envCfg.cwd ?? process.cwd();
   const now = envCfg.now ?? (() => new Date());
   const generatedAt = now().toISOString();
 
-  if (args.stage === 2 || args.stage === 3) {
-    const placeholder: HealthcheckResult = {
-      stage: args.stage,
-      items: [
-        {
-          id: `M-${args.stage}-placeholder`,
-          status: "SKIP",
-          detail: `stage ${args.stage} is implemented in phase-prod-3`,
-          anchor: `M-${args.stage}-0`,
-        },
-      ],
-      passed: true,
+  if (args.stage === 2) {
+    const out = await runStage2({
+      env,
+      run,
+      fetch: envCfg.fetch ?? (typeof fetch !== "undefined" ? defaultFetch : undefined),
+      now,
+    });
+    const passed = out.items.every((it) => it.status !== "FAIL");
+    const result: HealthcheckResult = {
+      stage: 2,
+      items: out.items,
+      passed,
       generatedAt,
+      // stage 2 does not re-classify CLI auth models; preserve neutral state.
       auth_models: {
         claude: "UNKNOWN_UNTIL_STAGE3",
         codex: "UNKNOWN_UNTIL_STAGE3",
-        gh: "unknown",
+        gh: env.GH_TOKEN && env.GH_TOKEN.length > 0 ? "env_token" : "unknown",
       },
     };
-    return HealthcheckResult.parse(placeholder);
+    return HealthcheckResult.parse(result);
+  }
+
+  if (args.stage === 3) {
+    // Stage 3 needs the qwen ping outcome to gate codex-qwen smoke. Run
+    // stage 2 first as a prerequisite (its own probes also surface in the
+    // stage-3 result so an operator sees the full picture).
+    const s2 = await runStage2({
+      env,
+      run,
+      fetch: envCfg.fetch ?? (typeof fetch !== "undefined" ? defaultFetch : undefined),
+      now,
+    });
+    const s3 = await runStage3({
+      env,
+      spawn: envCfg.stage3Spawn ?? defaultStage3Spawn,
+      qwenPassed: s2.qwenPassed,
+      now,
+      readLedger: envCfg.stage3ReadLedger,
+      appendLedger: envCfg.stage3AppendLedger,
+      mkdir: envCfg.stage3Mkdir,
+      writeFile: envCfg.stage3WriteFile,
+      home: envCfg.stage3Home,
+      workdir: envCfg.stage3Workdir,
+    });
+    const items = [...s2.items, ...s3.items];
+    const passed = items.every((it) => it.status !== "FAIL");
+    const surface = (id: string): AuthModel => {
+      const it = s3.items.find((x) => x.anchor === id);
+      if (!it) return "UNKNOWN_UNTIL_STAGE3";
+      if (it.status === "PASS") return "interactive_only";
+      if (it.status === "FAIL") return "unknown";
+      return "UNKNOWN_UNTIL_STAGE3";
+    };
+    const result: HealthcheckResult = {
+      stage: 3,
+      items,
+      passed,
+      generatedAt,
+      auth_models: {
+        claude: surface("M-3-claude"),
+        codex: surface("M-3-codex"),
+        gh: env.GH_TOKEN && env.GH_TOKEN.length > 0 ? "env_token" : "unknown",
+      },
+    };
+    return HealthcheckResult.parse(result);
   }
 
   const { items, auth_models } = runStage1({
@@ -448,6 +520,60 @@ export function runHealthcheck(
   };
   return HealthcheckResult.parse(result);
 }
+
+/**
+ * Default Stage 2 fetch — uses the Node 20+ global `fetch`.
+ */
+const defaultFetch: Stage2Fetch = (url, init) =>
+  // eslint-disable-next-line no-undef
+  fetch(url, init).then((r) => ({
+    status: r.status,
+    text: () => r.text(),
+  }));
+
+/**
+ * Default Stage 3 spawn — wraps `child_process.spawn` and honors
+ * `stdinFromDevNull` (codex contract).
+ */
+const defaultStage3Spawn: Stage3Spawn = (input: Stage3SpawnInput) =>
+  new Promise((resolveSpawn) => {
+    const stdinSpec = input.stdinFromDevNull ? "ignore" : "pipe";
+    const child = nodeSpawn(input.cmd, [...input.args], {
+      cwd: input.cwd,
+      stdio: [stdinSpec, "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const t = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, input.timeoutMs);
+    child.stdout?.on("data", (d) => {
+      stdout += d.toString("utf8");
+    });
+    child.stderr?.on("data", (d) => {
+      stderr += d.toString("utf8");
+    });
+    if (!input.stdinFromDevNull && input.stdin != null && child.stdin) {
+      child.stdin.end(input.stdin, "utf8");
+    } else if (!input.stdinFromDevNull && child.stdin) {
+      child.stdin.end();
+    }
+    child.on("close", (code) => {
+      clearTimeout(t);
+      resolveSpawn({ status: code, stdout, stderr, timedOut });
+    });
+    child.on("error", (err) => {
+      clearTimeout(t);
+      resolveSpawn({
+        status: null,
+        stdout,
+        stderr: stderr + `\nspawn error: ${err.message}`,
+        timedOut,
+      });
+    });
+  });
 
 function writeOutFile(
   result: HealthcheckResult,
@@ -478,7 +604,7 @@ export async function main(
 ): Promise<number> {
   const stdout = deps.stdout ?? ((s: string) => process.stdout.write(s));
   const args = parseArgs(argv);
-  const result = runHealthcheck(args, deps);
+  const result = await runHealthcheck(args, deps);
   if (!deps.skipOutFile) writeOutFile(result, args, deps.cwd ?? process.cwd());
   if (args.json) {
     stdout(`${JSON.stringify(result)}\n`);

--- a/tests/cli/healthcheck-stage2.test.ts
+++ b/tests/cli/healthcheck-stage2.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import {
+  runStage2,
+  type Stage2Fetch,
+  type Stage2RunCmd,
+} from "../../src/cli/healthcheck-stage2.js";
+
+function mockFetch(
+  table: Record<string, { status: number; body?: string; throws?: string }>,
+): Stage2Fetch {
+  return async (url) => {
+    const hit = table[url];
+    if (!hit) throw new Error(`no mock for ${url}`);
+    if (hit.throws) throw new Error(hit.throws);
+    return {
+      status: hit.status,
+      text: async () => hit.body ?? "",
+    };
+  };
+}
+
+function ghRateLimitRun(
+  table: Record<string, { status: number; stdout?: string; stderr?: string }>,
+): Stage2RunCmd {
+  return (cmd, args) => {
+    const key = `${cmd} ${args.join(" ")}`;
+    const hit = table[key];
+    if (!hit) return { status: 127, stdout: "", stderr: `no mock: ${key}` };
+    return { status: hit.status, stdout: hit.stdout ?? "", stderr: hit.stderr ?? "" };
+  };
+}
+
+const GH_OK = {
+  "gh api rate_limit": {
+    status: 0,
+    stdout: JSON.stringify({
+      resources: { core: { remaining: 4500, limit: 5000, reset: 0 } },
+    }),
+  },
+};
+
+describe("healthcheck stage 2 — qwen ping", () => {
+  it("SKIPs when LLM_TEAM_QWEN_BASE_URL is not set", async () => {
+    const out = await runStage2({
+      env: {},
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({}),
+    });
+    const qwen = out.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("SKIP");
+    expect(out.qwenPassed).toBe(false);
+  });
+
+  it("classifies HTTP 200 as PASS and sets qwenPassed=true", async () => {
+    const out = await runStage2({
+      env: { LLM_TEAM_QWEN_BASE_URL: "https://q.example.com/v1" },
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({
+        "https://q.example.com/v1/ping": { status: 200, body: "ok" },
+      }),
+    });
+    const qwen = out.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("PASS");
+    expect(out.qwenPassed).toBe(true);
+  });
+
+  it("classifies HTTP 401 as FAIL(auth)", async () => {
+    const out = await runStage2({
+      env: { LLM_TEAM_QWEN_BASE_URL: "https://q.example.com" },
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({
+        "https://q.example.com/ping": { status: 401, body: "unauthorized" },
+      }),
+    });
+    const qwen = out.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("FAIL");
+    expect(qwen?.detail).toContain("auth");
+    expect(out.qwenPassed).toBe(false);
+  });
+
+  it("classifies HTTP 429 as PASS-with-warning (qwenPassed=true)", async () => {
+    const out = await runStage2({
+      env: { LLM_TEAM_QWEN_BASE_URL: "https://q.example.com" },
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({
+        "https://q.example.com/ping": { status: 429 },
+      }),
+    });
+    const qwen = out.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("PASS");
+    expect(qwen?.detail).toContain("rate-limited");
+    expect(out.qwenPassed).toBe(true);
+  });
+
+  it("classifies HTTP 5xx as FAIL(upstream)", async () => {
+    const out = await runStage2({
+      env: { LLM_TEAM_QWEN_BASE_URL: "https://q.example.com" },
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({
+        "https://q.example.com/ping": { status: 503 },
+      }),
+    });
+    const qwen = out.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("FAIL");
+    expect(qwen?.detail).toContain("upstream");
+  });
+
+  it("falls back to /models when /ping returns 404", async () => {
+    const out = await runStage2({
+      env: { LLM_TEAM_QWEN_BASE_URL: "https://q.example.com" },
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({
+        "https://q.example.com/ping": { status: 404 },
+        "https://q.example.com/models": { status: 200, body: "[]" },
+      }),
+    });
+    const qwen = out.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("PASS");
+  });
+
+  it("network error becomes FAIL", async () => {
+    const out = await runStage2({
+      env: { LLM_TEAM_QWEN_BASE_URL: "https://q.example.com" },
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({
+        "https://q.example.com/ping": { status: 0, throws: "ECONNREFUSED" },
+      }),
+    });
+    const qwen = out.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("FAIL");
+    expect(qwen?.detail).toContain("network error");
+  });
+});
+
+describe("healthcheck stage 2 — gh rate_limit", () => {
+  it("PASSes when remaining is comfortably above the warn cap", async () => {
+    const out = await runStage2({
+      env: {},
+      run: ghRateLimitRun(GH_OK),
+      fetch: mockFetch({}),
+    });
+    const gh = out.items.find((i) => i.id === "M-2-gh.rate-limit");
+    expect(gh?.status).toBe("PASS");
+    expect(gh?.detail).toContain("4500/5000");
+  });
+
+  it("PASSes with warning when remaining < cap (default 100)", async () => {
+    const out = await runStage2({
+      env: {},
+      run: ghRateLimitRun({
+        "gh api rate_limit": {
+          status: 0,
+          stdout: JSON.stringify({
+            resources: { core: { remaining: 50, limit: 5000 } },
+          }),
+        },
+      }),
+      fetch: mockFetch({}),
+    });
+    const gh = out.items.find((i) => i.id === "M-2-gh.rate-limit");
+    expect(gh?.status).toBe("PASS");
+    expect(gh?.detail).toContain("low");
+  });
+
+  it("FAILs when remaining == 0", async () => {
+    const out = await runStage2({
+      env: {},
+      run: ghRateLimitRun({
+        "gh api rate_limit": {
+          status: 0,
+          stdout: JSON.stringify({
+            resources: { core: { remaining: 0, limit: 5000 } },
+          }),
+        },
+      }),
+      fetch: mockFetch({}),
+    });
+    const gh = out.items.find((i) => i.id === "M-2-gh.rate-limit");
+    expect(gh?.status).toBe("FAIL");
+    expect(gh?.detail).toContain("exhausted");
+  });
+
+  it("FAILs when gh exits non-zero", async () => {
+    const out = await runStage2({
+      env: {},
+      run: ghRateLimitRun({
+        "gh api rate_limit": { status: 1, stderr: "auth required" },
+      }),
+      fetch: mockFetch({}),
+    });
+    const gh = out.items.find((i) => i.id === "M-2-gh.rate-limit");
+    expect(gh?.status).toBe("FAIL");
+  });
+
+  it("FAILs when response is not JSON", async () => {
+    const out = await runStage2({
+      env: {},
+      run: ghRateLimitRun({
+        "gh api rate_limit": { status: 0, stdout: "<html>..." },
+      }),
+      fetch: mockFetch({}),
+    });
+    const gh = out.items.find((i) => i.id === "M-2-gh.rate-limit");
+    expect(gh?.status).toBe("FAIL");
+    expect(gh?.detail).toContain("unparsable");
+  });
+
+  it("honors LLM_TEAM_GH_RATE_LIMIT_WARN_AT override", async () => {
+    const out = await runStage2({
+      env: { LLM_TEAM_GH_RATE_LIMIT_WARN_AT: "1000" },
+      run: ghRateLimitRun({
+        "gh api rate_limit": {
+          status: 0,
+          stdout: JSON.stringify({
+            resources: { core: { remaining: 500, limit: 5000 } },
+          }),
+        },
+      }),
+      fetch: mockFetch({}),
+    });
+    const gh = out.items.find((i) => i.id === "M-2-gh.rate-limit");
+    expect(gh?.detail).toContain("low");
+  });
+});

--- a/tests/cli/healthcheck-stage3.test.ts
+++ b/tests/cli/healthcheck-stage3.test.ts
@@ -352,3 +352,143 @@ describe("healthcheck stage 3 — verified-auth-model.json", () => {
     expect(json.codex_qwen.status).toBe("SKIP");
   });
 });
+
+describe("healthcheck stage 3 — per-run cost cap accumulator (P1-B)", () => {
+  it("cap=$0.010 with 3 probes × $0.005 ⇒ first two PASS, third SKIP (per_run)", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: {
+        LLM_TEAM_LIVE_HEALTHCHECK: "1",
+        LLM_TEAM_LIVE_COST_CAP_USD: "0.010",
+      },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "ok", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    // Two probes spawned, third gated by cumulative per-run cap.
+    expect(recorded.inputs).toHaveLength(2);
+    const passes = out.items.filter((i) => i.status === "PASS");
+    expect(passes).toHaveLength(2);
+    const skips = out.items.filter((i) => i.status === "SKIP");
+    expect(skips).toHaveLength(1);
+    expect(skips[0]?.detail).toContain("per_run");
+    // Ledger reflects only the two PASSes.
+    const ledger = fs.appended.get(
+      "/tmp/home/.llm-team/healthcheck-cost-ledger.ndjson",
+    );
+    expect(ledger!.trim().split("\n")).toHaveLength(2);
+  });
+});
+
+describe("healthcheck stage 3 — redactSecrets at sink boundary (P1-C)", () => {
+  it("redacts ghp_… token from stdout/stderr/.md and detail before persisting", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const leak = "auth failed: ghp_ABCDEFGHIJKLMNOPQRST123456 invalid";
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({
+        status: 1,
+        stdout: `prefix ${leak} suffix`,
+        stderr: leak,
+      })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const stdoutFile = [...fs.files.entries()].find(([k]) =>
+      k.endsWith("claude-attempt1.stdout"),
+    );
+    const stderrFile = [...fs.files.entries()].find(([k]) =>
+      k.endsWith("claude-attempt1.stderr"),
+    );
+    const mdFile = [...fs.files.entries()].find(([k]) =>
+      k.endsWith("claude-attempt1.md"),
+    );
+    expect(stdoutFile?.[1]).not.toContain("ghp_ABCDEFGHIJKLMNOPQRST123456");
+    expect(stdoutFile?.[1]).toContain("[REDACTED]");
+    expect(stderrFile?.[1]).not.toContain("ghp_ABCDEFGHIJKLMNOPQRST123456");
+    expect(stderrFile?.[1]).toContain("[REDACTED]");
+    expect(mdFile?.[1]).not.toContain("ghp_ABCDEFGHIJKLMNOPQRST123456");
+    // detail (in items + failure md) is also scrubbed.
+    const failItem = out.items.find((i) => i.id === "claude-attempt1");
+    expect(failItem?.detail).not.toContain("ghp_ABCDEFGHIJKLMNOPQRST123456");
+    expect(failItem?.detail).toContain("[REDACTED]");
+    const failureMd = fs.files.get(out.failureMdPath!);
+    expect(failureMd).not.toContain("ghp_ABCDEFGHIJKLMNOPQRST123456");
+  });
+
+  it("redacts secret-suspected env values that leak into stderr", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const secret = "supersecret-xyz-123";
+    await runStage3({
+      env: {
+        LLM_TEAM_LIVE_HEALTHCHECK: "1",
+        ANTHROPIC_API_KEY: secret,
+      },
+      spawn: recordingSpawn(recorded, () => ({
+        status: 1,
+        stdout: "",
+        stderr: `boom: leaked ${secret}`,
+      })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const stderrFile = [...fs.files.entries()].find(([k]) =>
+      k.endsWith("claude-attempt1.stderr"),
+    );
+    expect(stderrFile?.[1]).not.toContain(secret);
+    expect(stderrFile?.[1]).toContain("[REDACTED]");
+  });
+});
+
+describe("healthcheck stage 3 — LLM_TEAM_CLAUDE_BIN multi-token (P1-D)", () => {
+  it('LLM_TEAM_CLAUDE_BIN="npx claude" splits into cmd="npx" + leading args ["claude", ...]', async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    await runStage3({
+      env: {
+        LLM_TEAM_LIVE_HEALTHCHECK: "1",
+        LLM_TEAM_CLAUDE_BIN: "npx claude",
+      },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const claude = recorded.inputs.find((i) => i.cmd === "npx");
+    expect(claude).toBeDefined();
+    expect(claude!.cmd).toBe("npx");
+    expect(claude!.args[0]).toBe("claude");
+    expect(claude!.args.slice(1, 4)).toEqual(["-p", "--output-format", "text"]);
+    // The literal "npx claude" must NOT appear as a single argv token.
+    expect(recorded.inputs.find((i) => i.cmd === "npx claude")).toBeUndefined();
+  });
+
+  it("collapses repeated whitespace in LLM_TEAM_CLAUDE_BIN", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    await runStage3({
+      env: {
+        LLM_TEAM_LIVE_HEALTHCHECK: "1",
+        LLM_TEAM_CLAUDE_BIN: "  npx   claude  ",
+      },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const claude = recorded.inputs.find((i) => i.cmd === "npx");
+    expect(claude).toBeDefined();
+    expect(claude!.args[0]).toBe("claude");
+  });
+});

--- a/tests/cli/healthcheck-stage3.test.ts
+++ b/tests/cli/healthcheck-stage3.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from "vitest";
+import {
+  runStage3,
+  type Stage3Spawn,
+  type Stage3SpawnInput,
+  type Stage3SpawnResult,
+} from "../../src/cli/healthcheck-stage3.js";
+
+interface InMemoryFs {
+  files: Map<string, string>;
+  appended: Map<string, string>;
+  mkdirCalls: { path: string; mode?: number }[];
+}
+
+function newFs(): InMemoryFs {
+  return { files: new Map(), appended: new Map(), mkdirCalls: [] };
+}
+
+function makeFsDeps(fs: InMemoryFs) {
+  return {
+    mkdir: (path: string, opts: { recursive: true; mode?: number }) => {
+      fs.mkdirCalls.push({ path, mode: opts.mode });
+    },
+    writeFile: (path: string, content: string) => {
+      fs.files.set(path, content);
+    },
+    appendLedger: (path: string, line: string) => {
+      const prev = fs.appended.get(path) ?? "";
+      fs.appended.set(path, prev + line);
+    },
+    readLedger: (path: string) => fs.appended.get(path) ?? "",
+  };
+}
+
+interface RecordedSpawn {
+  inputs: Stage3SpawnInput[];
+}
+
+function recordingSpawn(
+  recorded: RecordedSpawn,
+  result: (input: Stage3SpawnInput) => Stage3SpawnResult,
+): Stage3Spawn {
+  return async (input) => {
+    recorded.inputs.push(input);
+    return result(input);
+  };
+}
+
+const NOW = () => new Date("2026-05-09T10:00:00.000Z");
+
+describe("healthcheck stage 3 — opt-in gate", () => {
+  it("default (no LLM_TEAM_LIVE_HEALTHCHECK): all probes SKIP, no spawn, no ledger writes", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: {},
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "ok", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(recorded.inputs).toHaveLength(0);
+    expect(out.items.every((i) => i.status === "SKIP")).toBe(true);
+    expect(out.items[0]?.id).toBe("M-3-opt-in");
+    expect(fs.appended.size).toBe(0);
+    // verified-auth-model.json should still be written for traceability.
+    const verified = [...fs.files.keys()].find((k) => k.endsWith("verified-auth-model.json"));
+    expect(verified).toBeDefined();
+  });
+
+  it("LLM_TEAM_LIVE_HEALTHCHECK=1 + qwenPassed=true: all three probes spawn", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "ok", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(recorded.inputs).toHaveLength(3);
+    expect(out.items.filter((i) => i.status === "PASS")).toHaveLength(3);
+  });
+});
+
+describe("healthcheck stage 3 — codex argv invariants", () => {
+  it("codex argv contains --ephemeral, --skip-git-repo-check, --cd <RUN_DIR>, and stdinFromDevNull=true", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "ok", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const codex = recorded.inputs.find((i) => i.cmd === "codex" && !i.args.includes("--profile"));
+    const codexQwen = recorded.inputs.find((i) => i.args.includes("--profile"));
+    expect(codex).toBeDefined();
+    expect(codexQwen).toBeDefined();
+    for (const c of [codex!, codexQwen!]) {
+      expect(c.args).toContain("--ephemeral");
+      expect(c.args).toContain("--skip-git-repo-check");
+      expect(c.args).toContain("--color");
+      expect(c.args).toContain("never");
+      expect(c.args).toContain("--cd");
+      // RUN_DIR must immediately follow --cd.
+      const cdIdx = c.args.indexOf("--cd");
+      expect(c.args[cdIdx + 1]).toBe(c.cwd);
+      // stdin MUST be wired to /dev/null (never the prompt pipe).
+      expect(c.stdinFromDevNull).toBe(true);
+      expect(c.stdin).toBe(null);
+    }
+    // codex-qwen explicitly carries --profile <name>.
+    const profIdx = codexQwen!.args.indexOf("--profile");
+    expect(typeof codexQwen!.args[profIdx + 1]).toBe("string");
+  });
+
+  it("claude argv uses -p --output-format text and feeds prompt via stdin", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1", LLM_TEAM_CLAUDE_MODEL: "claude-3-5-haiku" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "ok", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const claude = recorded.inputs.find((i) => i.cmd === "claude");
+    expect(claude).toBeDefined();
+    expect(claude!.args.slice(0, 3)).toEqual(["-p", "--output-format", "text"]);
+    expect(claude!.args).toContain("--model");
+    expect(claude!.args[claude!.args.indexOf("--model") + 1]).toBe("claude-3-5-haiku");
+    expect(claude!.stdin).toBeTypeOf("string");
+    expect(claude!.stdinFromDevNull).toBe(false);
+    expect(claude!.timeoutMs).toBe(60_000);
+  });
+});
+
+describe("healthcheck stage 3 — RUN_DIR artifacts", () => {
+  it("each spawn writes 4 files (.stdout/.stderr/.exit/.md) to RUN_DIR", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({
+        status: 0,
+        stdout: "two words",
+        stderr: "",
+      })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    for (const probeId of ["claude-attempt1", "codex-default-attempt1", "codex-qwen-attempt1"]) {
+      for (const ext of [".stdout", ".stderr", ".exit", ".md"]) {
+        const found = [...fs.files.keys()].find(
+          (k) => k.endsWith(`${probeId}${ext}`),
+        );
+        expect(found, `${probeId}${ext} missing`).toBeDefined();
+      }
+    }
+    // verified-auth-model.json written exactly once.
+    expect(
+      [...fs.files.keys()].filter((k) => k.endsWith("verified-auth-model.json")),
+    ).toHaveLength(1);
+    expect(out.runDir).toContain("/tmp/home/.llm-team/healthcheck/");
+  });
+
+  it("RUN_DIR is created with mode 0700", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(fs.mkdirCalls[0]?.mode).toBe(0o700);
+  });
+
+  it("LLM_TEAM_HEALTHCHECK_RUN_DIR env overrides default RUN_DIR", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: {
+        LLM_TEAM_LIVE_HEALTHCHECK: "1",
+        LLM_TEAM_HEALTHCHECK_RUN_DIR: "/tmp/custom/run-dir",
+      },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(out.runDir).toBe("/tmp/custom/run-dir");
+  });
+});
+
+describe("healthcheck stage 3 — qwen Stage 2 gating", () => {
+  it("qwenPassed=false skips codex-qwen probe (claude + codex still run)", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: false,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(recorded.inputs).toHaveLength(2);
+    const qwen = out.items.find((i) => i.id === "codex-qwen-attempt1");
+    expect(qwen?.status).toBe("SKIP");
+    expect(qwen?.detail).toContain("qwen");
+  });
+});
+
+describe("healthcheck stage 3 — cost cap", () => {
+  it("daily cap exceeded ⇒ probe SKIP (not FAIL)", async () => {
+    const fs = newFs();
+    // Pre-seed the ledger so daily total already at $0.999 (just below $1.00).
+    // The first 0.005 spawn will push us over.
+    fs.appended.set(
+      "/tmp/home/.llm-team/healthcheck-cost-ledger.ndjson",
+      JSON.stringify({
+        ts: "2026-05-09T05:00:00.000Z",
+        kind: "claude.smoke",
+        estimated_usd: 0.999,
+      }) + "\n",
+    );
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(recorded.inputs).toHaveLength(0);
+    expect(out.items.filter((i) => i.status === "SKIP").length).toBeGreaterThanOrEqual(3);
+    const sample = out.items.find((i) => i.id === "claude-attempt1");
+    expect(sample?.detail).toContain("cost cap");
+  });
+
+  it("per-run cap below estimated cost ⇒ SKIP", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1", LLM_TEAM_LIVE_COST_CAP_USD: "0.001" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(recorded.inputs).toHaveLength(0);
+    const sample = out.items.find((i) => i.id === "claude-attempt1");
+    expect(sample?.status).toBe("SKIP");
+    expect(sample?.detail).toContain("per_run");
+  });
+
+  it("successful spawn appends a ledger entry", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const ledger = fs.appended.get(
+      "/tmp/home/.llm-team/healthcheck-cost-ledger.ndjson",
+    );
+    expect(ledger).toBeDefined();
+    const lines = ledger!.trim().split("\n");
+    expect(lines).toHaveLength(3);
+    for (const l of lines) {
+      const p = JSON.parse(l);
+      expect(p.estimated_usd).toBeGreaterThan(0);
+      expect(p.kind).toMatch(/^(claude|codex)\./);
+    }
+  });
+});
+
+describe("healthcheck stage 3 — failure markdown", () => {
+  it("any FAIL produces healthcheck-failure.md in RUN_DIR", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, (input) => ({
+        status: input.cmd === "claude" ? 1 : 0,
+        stdout: "",
+        stderr: input.cmd === "claude" ? "auth failed" : "",
+      })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(out.failureMdPath).toBeDefined();
+    const md = fs.files.get(out.failureMdPath!);
+    expect(md).toContain("FAILURE");
+    expect(md).toContain("claude-attempt1");
+  });
+
+  it("all PASS does not produce healthcheck-failure.md", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, () => ({ status: 0, stdout: "", stderr: "" })),
+      qwenPassed: true,
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    expect(out.failureMdPath).toBeUndefined();
+  });
+});
+
+describe("healthcheck stage 3 — verified-auth-model.json", () => {
+  it("records PASS/FAIL/SKIP per surface", async () => {
+    const fs = newFs();
+    const recorded: RecordedSpawn = { inputs: [] };
+    const out = await runStage3({
+      env: { LLM_TEAM_LIVE_HEALTHCHECK: "1" },
+      spawn: recordingSpawn(recorded, (input) => ({
+        status: input.cmd === "claude" ? 0 : 2,
+        stdout: "",
+        stderr: input.cmd === "claude" ? "" : "boom",
+      })),
+      qwenPassed: false, // qwen probe → SKIP
+      now: NOW,
+      home: "/tmp/home",
+      ...makeFsDeps(fs),
+    });
+    const json = JSON.parse(fs.files.get(out.verifiedAuthModelPath!)!);
+    expect(json.claude.status).toBe("PASS");
+    expect(json.codex.status).toBe("FAIL");
+    expect(json.codex_qwen.status).toBe("SKIP");
+  });
+});

--- a/tests/cli/healthcheck.test.ts
+++ b/tests/cli/healthcheck.test.ts
@@ -76,8 +76,8 @@ describe("healthcheck parseArgs", () => {
 });
 
 describe("healthcheck runHealthcheck", () => {
-  it("all-pass mock yields passed=true and conforms to Zod schema", () => {
-    const result = runHealthcheck(
+  it("all-pass mock yields passed=true and conforms to Zod schema", async () => {
+    const result = await runHealthcheck(
       { stage: 1, json: false },
       {
         run: mockRun(ALL_PASS_TABLE),
@@ -99,10 +99,10 @@ describe("healthcheck runHealthcheck", () => {
     expect(result.auth_models.gh).toBe("env_token");
   });
 
-  it("missing required binary yields FAIL and passed=false", () => {
+  it("missing required binary yields FAIL and passed=false", async () => {
     const table = { ...ALL_PASS_TABLE };
     table["command -v claude"] = { status: 1 };
-    const result = runHealthcheck(
+    const result = await runHealthcheck(
       { stage: 1, json: false },
       {
         run: mockRun(table),
@@ -117,10 +117,10 @@ describe("healthcheck runHealthcheck", () => {
     expect(m11?.detail).toContain("claude");
   });
 
-  it("git < 2.5 yields FAIL on M-1-2", () => {
+  it("git < 2.5 yields FAIL on M-1-2", async () => {
     const table = { ...ALL_PASS_TABLE };
     table["git --version"] = { status: 0, stdout: "git version 2.4.0\n" };
-    const result = runHealthcheck(
+    const result = await runHealthcheck(
       { stage: 1, json: false },
       {
         run: mockRun(table),
@@ -134,8 +134,8 @@ describe("healthcheck runHealthcheck", () => {
     expect(m12?.status).toBe("FAIL");
   });
 
-  it("typecheck/build are always SKIP in stage 1 (out of fail-fast budget)", () => {
-    const result = runHealthcheck(
+  it("typecheck/build are always SKIP in stage 1 (out of fail-fast budget)", async () => {
+    const result = await runHealthcheck(
       { stage: 1, json: false },
       {
         run: mockRun(ALL_PASS_TABLE),
@@ -148,19 +148,34 @@ describe("healthcheck runHealthcheck", () => {
     expect(result.items.find((i) => i.id === "M-1-6.build")?.status).toBe("SKIP");
   });
 
-  it("stage 2 returns the phase-prod-3 placeholder", () => {
-    const result = runHealthcheck(
+  it("stage 2 with no qwen URL skips qwen ping (no longer the phase-prod-3 placeholder)", async () => {
+    const table: Record<string, { status: number; stdout?: string; stderr?: string }> = {
+      "gh api rate_limit": {
+        status: 0,
+        stdout: JSON.stringify({
+          resources: { core: { remaining: 4000, limit: 5000 } },
+        }),
+      },
+    };
+    const result = await runHealthcheck(
       { stage: 2, json: false },
-      { run: mockRun({}), env: {}, cwd: process.cwd(), now: () => new Date(0) },
+      {
+        run: mockRun(table),
+        env: {},
+        cwd: process.cwd(),
+        now: () => new Date("2026-05-09T00:00:00.000Z"),
+      },
     );
     expect(result.stage).toBe(2);
-    expect(result.passed).toBe(true);
-    expect(result.items[0]?.detail).toContain("phase-prod-3");
+    const qwen = result.items.find((i) => i.id === "M-2-qwen.ping");
+    expect(qwen?.status).toBe("SKIP");
+    const gh = result.items.find((i) => i.id === "M-2-gh.rate-limit");
+    expect(gh?.status).toBe("PASS");
     expect(result.auth_models.claude).toBe("UNKNOWN_UNTIL_STAGE3");
   });
 
-  it("auth model detection: gh env_token and claude env_token via ANTHROPIC_API_KEY", () => {
-    const result = runHealthcheck(
+  it("auth model detection: gh env_token and claude env_token via ANTHROPIC_API_KEY", async () => {
+    const result = await runHealthcheck(
       { stage: 1, json: false },
       {
         run: mockRun(ALL_PASS_TABLE),
@@ -175,8 +190,8 @@ describe("healthcheck runHealthcheck", () => {
     expect(result.auth_models.codex).toBe("interactive_only");
   });
 
-  it("gh keychain detection when no GH_TOKEN", () => {
-    const result = runHealthcheck(
+  it("gh keychain detection when no GH_TOKEN", async () => {
+    const result = await runHealthcheck(
       { stage: 1, json: false },
       {
         run: mockRun(ALL_PASS_TABLE),
@@ -188,7 +203,7 @@ describe("healthcheck runHealthcheck", () => {
     expect(result.auth_models.gh).toBe("keychain");
   });
 
-  it("caches `gh auth status` and `<bin> --help` (one spawn per probe)", () => {
+  it("caches `gh auth status` and `<bin> --help` (one spawn per probe)", async () => {
     const calls: string[] = [];
     const countingRun: RunCmd = (cmd, args) => {
       const key = `${cmd} ${args.join(" ")}`.trim();
@@ -197,7 +212,7 @@ describe("healthcheck runHealthcheck", () => {
       if (hit) return { status: hit.status, stdout: hit.stdout ?? "", stderr: hit.stderr ?? "" };
       return { status: 127, stdout: "", stderr: `mock: no entry for ${key}` };
     };
-    runHealthcheck(
+    await runHealthcheck(
       { stage: 1, json: false },
       {
         run: countingRun,

--- a/tests/cli/healthcheck.test.ts
+++ b/tests/cli/healthcheck.test.ts
@@ -278,6 +278,39 @@ describe("healthcheck main() integration", () => {
     ).rejects.toThrow(/unknown flag/);
   });
 
+  it("stage 3 default-SKIP gate (P1-A): no LLM_TEAM_LIVE_HEALTHCHECK ⇒ stage 2 fetch NOT called, stage 3 spawn NOT called, exit 0", async () => {
+    const fetchCalls: string[] = [];
+    const spawnCalls: { cmd: string }[] = [];
+    const result = await runHealthcheck(
+      { stage: 3, json: false },
+      {
+        // run is irrelevant here — neither stage 2 nor stage 3 should call it.
+        run: mockRun({}),
+        env: {}, // explicitly NOT setting LLM_TEAM_LIVE_HEALTHCHECK.
+        cwd: process.cwd(),
+        now: () => new Date("2026-05-09T00:00:00.000Z"),
+        fetch: async (url: string) => {
+          fetchCalls.push(url);
+          return { status: 200, text: async () => "" };
+        },
+        stage3Spawn: async (input) => {
+          spawnCalls.push({ cmd: input.cmd });
+          return { status: 0, stdout: "", stderr: "" };
+        },
+      },
+    );
+    // Default-SKIP invariant: nothing spawned, nothing fetched.
+    expect(spawnCalls).toHaveLength(0);
+    expect(fetchCalls).toHaveLength(0);
+    expect(result.stage).toBe(3);
+    expect(result.passed).toBe(true);
+    // The single SKIP item explains why.
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.status).toBe("SKIP");
+    expect(result.items[0]?.id).toBe("M-3-opt-in");
+    expect(result.items[0]?.detail).toContain("LLM_TEAM_LIVE_HEALTHCHECK");
+  });
+
   it("non-json mode emits human-readable lines and exits 0 on all-pass", async () => {
     let captured = "";
     const code = await main(["--stage", "1"], {

--- a/tests/fixtures/healthcheck/smoke-prompt.md
+++ b/tests/fixtures/healthcheck/smoke-prompt.md
@@ -1,0 +1,1 @@
+Reply with exactly two words: ok ready.


### PR DESCRIPTION
## Summary
- Stage 2 (qwen ping + GitHub rate_limit) and Stage 3 (claude/codex/codex-qwen 1-shot smoke).
- opt-in via `LLM_TEAM_LIVE_HEALTHCHECK=1`; default SKIP, no cost, exit 0.
- cost cap (per-run + daily) with ndjson cost ledger (default `~/.llm-team/healthcheck-cost-ledger.ndjson`).
- codex smoke enforces `--ephemeral --skip-git-repo-check --cd <RUN_DIR>` and `</dev/null` stdin.

## 구현
- `src/cli/healthcheck-stage2.ts` — qwen `/ping` (`/models` fallback): 200=PASS, 401/403=FAIL(auth), 429=PASS-w/-warning, 5xx=FAIL(upstream); `gh api rate_limit` warn-at cap (default 100), `remaining==0`=FAIL.
- `src/cli/healthcheck-stage3.ts` — opt-in gate, per-probe 60 s timeout, RUN_DIR 4-tuple artifacts (`.stdout`/`.stderr`/`.exit`/`.md`), `verified-auth-model.json`, `healthcheck-failure.md` on any FAIL. qwen Stage-2 not-PASS ⇒ codex-qwen auto-SKIP.
- `src/cli/healthcheck-cost-ledger.ts` — ndjson append, UTC daily aggregation, per-run + daily cap check. Cap exceeded ⇒ probe SKIP (not FAIL).
- `src/cli/healthcheck-schema.ts` — `CostLedgerEntry`, `VerifiedAuthSurface`, `VerifiedAuthModel`.
- `src/cli/healthcheck.ts` — wires Stage 2/3 (replaces phase-prod-1 placeholder), default `Stage3Spawn` honors `stdinFromDevNull` (codex contract).
- `package.json` — `healthcheck:stage2`, `healthcheck:stage3` (no new deps).
- `docs/operations/healthcheck.md`, `tests/fixtures/healthcheck/smoke-prompt.md`.

## 테스트 (mock 기반, no real LLM calls)
| File | Cases |
|---|---|
| `tests/cli/healthcheck-stage2.test.ts` | 13 — ping classification, fallback, rate_limit cap |
| `tests/cli/healthcheck-stage3.test.ts` | 14 — opt-in, codex argv invariants, RUN_DIR 4-tuple, qwen gating, cost cap (per-run + daily), failure md, verified-auth-model |
| `tests/cli/healthcheck.test.ts` | updated — placeholder removed, async runHealthcheck |

- `npm test` → **819 passing** (was 792; +27)
- `npm run typecheck` → 0 errors
- `npm run build` → 0 errors

## Gate (planning §6)
- [x] opt-in 강제 (default SKIP, exit 0, ledger untouched)
- [x] codex argv test asserts `--ephemeral` + `--skip-git-repo-check` + `--cd <RUN_DIR>` + `stdinFromDevNull=true` (`stdin === null`)
- [x] cost cap (per-run + daily) → SKIP classification
- [x] RUN_DIR 4-tuple per attempt + 0700 mkdir mode
- [x] qwen Stage-2 SKIP/FAIL ⇒ codex-qwen auto-SKIP
- [ ] **DEFERRED-TO-HUMAN**: `LLM_TEAM_LIVE_HEALTHCHECK=1 npm run healthcheck:stage3` 0 exit
      — requires real LLM calls + claude/codex auth + USD budget. Verify manually in operator environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)