### PR TITLE
feat(phase-prod-6): production runbook + go/no-go + migration checklist + DoD

### DIFF
--- a/docs/operations/e2e-go-no-go.md
+++ b/docs/operations/e2e-go-no-go.md
@@ -23,8 +23,9 @@ live smoke / e2e 비용을 운영자가 사전에 승인한다. 기본값은 `do
 
 | 항목 | 기본 | 승인값 | 비고 |
 |---|---|---|---|
-| `LLM_TEAM_LIVE_COST_CAP_USD` (per-run) | $0.10 | $______ | rehearsal 1회당 상한 |
+| `LLM_TEAM_LIVE_COST_CAP_USD` (healthcheck Stage 3 per-run) | $0.10 | $______ | healthcheck Stage 3 1회 상한 (cost ledger). e2e harness 비용에는 적용되지 않음 |
 | `LLM_TEAM_LIVE_DAILY_COST_CAP_USD` (daily) | $1.00 | $______ | UTC day 누적 ledger 합 |
+| `LLM_TEAM_E2E_COST_CAP_USD` (e2e harness per-run) | $0.20 | $______ | `tests/helpers/e2e-harness.ts` rehearsal 1회 상한 |
 | 1회 e2e 예상 비용 (claude smoke + codex default + codex qwen + 시나리오) | — | $______ | 견적 |
 
 승인일: `____-__-__` 승인자: `____________`

--- a/docs/operations/e2e-go-no-go.md
+++ b/docs/operations/e2e-go-no-go.md
@@ -1,0 +1,72 @@
+# E2E Go / No-Go Decision
+
+production target 으로 전환하기 전, sandbox 에서 live e2e 1회를 통과시키고 cost cap / rollback 조건을 명문화한다. 본 문서는 rehearsal 결과 기록 양식이며, **rehearsal 1회 PASS 자체는 deferred-to-human** 이다.
+
+## 1. Phase 0 ~ 5 Gate 결과
+
+각 phase 의 gate 통과 여부를 evidence link 와 함께 기록.
+
+| Phase | Gate (planning §3~§8) | 결과 | 날짜 | 검증자 | Evidence |
+|---|---|---|---|---|---|
+| Phase 0 | scope 정리 + production target 기준 | [ ] PASS / [ ] FAIL | YYYY-MM-DD | — | PR #83 |
+| Phase 1 | non-live preflight stage 1 | [ ] PASS / [ ] FAIL | YYYY-MM-DD | — | PR #84 |
+| Phase 2 | adapter hardening | [ ] PASS / [ ] FAIL | YYYY-MM-DD | — | PR #85 |
+| Phase 3 | live healthcheck stage 2/3 | [ ] PASS / [ ] FAIL | YYYY-MM-DD | — | PR #86 |
+| Phase 4 | e2e sandbox harness | [ ] PASS / [ ] FAIL | YYYY-MM-DD | — | PR #87 |
+| Phase 5 | full e2e + CI workflows | [ ] PASS / [ ] FAIL | YYYY-MM-DD | — | PR #88 |
+
+`pre-e2e-checklist.md` 의 Critical 항목 PASS 기록은 `.human/checklist/pre-e2e-checklist.md` (gitignored, local-only) 에 운영자가 직접 표기.
+
+## 2. Cost Cap 승인
+
+live smoke / e2e 비용을 운영자가 사전에 승인한다. 기본값은 `docs/operations/healthcheck.md §Cost ledger` 와 정합.
+
+| 항목 | 기본 | 승인값 | 비고 |
+|---|---|---|---|
+| `LLM_TEAM_LIVE_COST_CAP_USD` (per-run) | $0.10 | $______ | rehearsal 1회당 상한 |
+| `LLM_TEAM_LIVE_DAILY_COST_CAP_USD` (daily) | $1.00 | $______ | UTC day 누적 ledger 합 |
+| 1회 e2e 예상 비용 (claude smoke + codex default + codex qwen + 시나리오) | — | $______ | 견적 |
+
+승인일: `____-__-__` 승인자: `____________`
+
+cap 초과 attempt 는 **SKIP** 으로 ledger 에 기록되고 FAIL 로 분류되지 않는다 (planning §11). cap 자체 계산이 불가능하면 live phase 진입 차단.
+
+## 3. Rollback / Stop 조건
+
+rehearsal 중 다음 조건 발생 시 즉시 e2e 를 중단하고 본 문서 §4 의 결정 row 에 `blocker` 로 기록.
+
+- **production target 에 partial side effect 감지** — sandbox 가 아닌 production repo / workdir / ledger 에 의도치 않은 쓰기.
+- **sandbox GitHub side effect 가 격리 prefix 외로 누출** — `identity.label_prefix` (예: `e2e:`) 외의 label / branch / issue 가 생성됨.
+- **rate_limit / quota 한 번에 다수 발생** — 1 cycle 안에 N≥3 attempt 가 `reason=rate_limit` (Phase-prod-2 adapter) 로 분류.
+- **healthcheck Stage 3 FAIL** — rehearsal 직전 stage 3 에서 어느 surface 라도 FAIL.
+- **cost ledger 일치 불가** — ledger 합계와 provider 측 청구 사이에 비합리적 차이.
+
+중단 시 **반드시 보존**:
+- `<RUN_DIR>` (healthcheck artifact + verified-auth-model.json + failure md)
+- cycle bundle 디렉토리 (`<workdir>/<target>/cycles/...`) — `LLM_TEAM_CYCLE_BUNDLE_DISABLED` 미설정 시 자동 보존
+- sandbox repo 의 side effect summary — label / branch / issue / PR prefix 별 enumeration
+
+## 4. Go / No-Go 결정
+
+| 항목 | 결과 |
+|---|---|
+| 모든 Phase gate PASS | [ ] yes / [ ] no |
+| pre-e2e-checklist Critical PASS | [ ] yes / [ ] no |
+| migration-checklist 의 모든 blocker `applied` 또는 `not_applicable` | [ ] yes / [ ] no |
+| live e2e rehearsal 1회 sandbox 통과 (deferred-to-human) | [ ] yes / [ ] no |
+| cost cap 승인 완료 | [ ] yes / [ ] no |
+| rollback 조건 위반 0건 | [ ] yes / [ ] no |
+
+**최종 결정**: [ ] **GO** (production target 전환 승인) / [ ] **NO-GO** (blocker 잔존) / [ ] **ADVISORY** (조건부 진행)
+
+결정일: `____-__-__` 결정자: `____________`
+
+NO-GO 또는 ADVISORY 인 경우 blocker 사유 + 다음 rehearsal 일정 기록.
+
+## 5. See Also
+
+- [`docs/operations/production-runbook.md`](production-runbook.md) — daemon / 인증 / rotation / workdir / rate-limit.
+- [`docs/operations/production-migration-checklist.md`](production-migration-checklist.md) — migration 적용 결과 + blocker decision.
+- [`docs/operations/phase-prod-DoD.md`](phase-prod-DoD.md) — Phase 0~5 DoD evidence.
+- [`docs/operations/healthcheck.md`](healthcheck.md) — Stage 1~3 + cost ledger.
+- [`.human/checklist/pre-e2e-checklist.md`](../../.human/checklist/pre-e2e-checklist.md) — Critical 항목 (gitignored, local-only).

--- a/docs/operations/phase-prod-DoD.md
+++ b/docs/operations/phase-prod-DoD.md
@@ -1,0 +1,38 @@
+# Phase-prod Definition of Done — Evidence
+
+planning §12 (`.human/draft/2026-05-09-production-implementation-phases.md`, gitignored) 의 DoD 8 항목별 현재 상태 + evidence link. PR 본문 대신 본 문서가 추적 source.
+
+## DoD Items
+
+| # | Item | Status | Evidence |
+|---|---|---|---|
+| 1 | Phase 0 의 결정 6건이 닫혔다: healthcheck TS, exitStatus enum 유지, CI auth 모델 발견 방식, cycle bundle minimal subset, checklist anchor 호환성, Phase 3+ 비용 승인/cap. | [x] CLOSED | PR #83 (target fixture + production-target.md), [`docs/operations/production-target.md`](production-target.md), [`docs/operations/migration-inventory.md`](migration-inventory.md), [`docs/operations/phase-prod-conventions.md`](phase-prod-conventions.md) |
+| 2 | Phase 1 healthcheck stage1 이 local/CI 에서 통과한다. | [x] CLOSED | PR #84 (healthcheck stage 1 CLI), [`docs/operations/healthcheck.md`](healthcheck.md), `npm run healthcheck:stage1` |
+| 3 | Phase 2 adapter hardening tests 가 통과한다. | [x] CLOSED | PR #85 (env policy / redact / attempt diagnostics / transport reason), `src/adapters/llm-runner/*`, `src/adapters/llm-runner/common/redact.ts` |
+| 4 | Phase 3 live healthcheck stage2/stage3 이 opt-in 으로 통과한다. | [~] PARTIAL — code merged, **live e2e rehearsal 1회 sandbox 통과는 deferred-to-human** | PR #86 (Stage 2 + Stage 3 1-shot smoke). live rehearsal 은 [`e2e-go-no-go.md §4`](e2e-go-no-go.md) decision row 에서 closure. |
+| 5 | Phase 4 최소 e2e 시나리오가 sandbox 에서 통과한다. | [x] CLOSED | PR #87 (e2e sandbox harness + inner tdd_build mock smoke) |
+| 6 | Phase 5 PR workflow 와 manual/nightly e2e workflow 가 존재한다. | [x] CLOSED | PR #88 (full e2e + CI workflows + ledger-summary CLI) |
+| 7 | Phase 6 production runbook 과 go/no-go 문서가 존재한다. | [x] CLOSED (본 cycle) | [`production-runbook.md`](production-runbook.md), [`e2e-go-no-go.md`](e2e-go-no-go.md), [`production-migration-checklist.md`](production-migration-checklist.md), 본 문서 |
+| 7b | cost cap / rollback / migration inventory 가 go/no-go 문서에 반영되어 있다. | [x] CLOSED | [`e2e-go-no-go.md §2`](e2e-go-no-go.md) (cost cap), [`e2e-go-no-go.md §3`](e2e-go-no-go.md) (rollback), [`production-migration-checklist.md`](production-migration-checklist.md) (migration) |
+| 8 | `.human/checklist/pre-e2e-checklist.md` 의 Critical 항목이 실행 결과로 닫혔다. | [ ] **DEFERRED-TO-HUMAN** | `.human/checklist/pre-e2e-checklist.md` 는 gitignored local-only 문서. rehearsal 실행 후 운영자가 직접 `[x]` + 날짜/검증자 기록. |
+
+## Deferred-to-Human
+
+본 cycle 의 Gate 에서 의도적으로 제외한 항목 (planning §9 "deferred-to-human (Gate excluded)" 와 정합):
+
+- **DoD #4 후반부**: `LLM_TEAM_E2E=1` live e2e 1회 sandbox 통과 — phase-prod-6 closure 가 아님. 운영자가 rehearsal 시점에 `e2e-go-no-go.md §1` Phase 3/4 row 에 결과 기록.
+- **DoD #8**: `pre-e2e-checklist.md` Critical 항목 PASS 날짜 — gitignored 문서이므로 commit 으로 추적 불가. local 기록만.
+- **production target 전환 승인**: `e2e-go-no-go.md §4` 결정 row 가 `GO` 일 때만 진행.
+
+## Update Policy
+
+- DoD 항목 status 변경 시 본 표를 업데이트하고 evidence link (PR # 또는 doc path) 를 첨부.
+- live rehearsal 통과 시 DoD #4 status 를 `[x] CLOSED` 로, evidence 에 RUN_DIR 경로 / cost ledger 합계 첨부.
+- 8개 항목 모두 CLOSED 또는 DEFERRED-TO-HUMAN 명시 후에만 production 전환 승인.
+
+## See Also
+
+- [`docs/operations/production-runbook.md`](production-runbook.md)
+- [`docs/operations/e2e-go-no-go.md`](e2e-go-no-go.md)
+- [`docs/operations/production-migration-checklist.md`](production-migration-checklist.md)
+- [`docs/operations/phase-prod-conventions.md`](phase-prod-conventions.md) — phase-prod branch / commit / PR 규약.

--- a/docs/operations/production-migration-checklist.md
+++ b/docs/operations/production-migration-checklist.md
@@ -1,0 +1,29 @@
+# Production Migration Checklist
+
+`docs/operations/migration-inventory.md` 의 항목별 *적용 결과* 표. production target 진입 전 모든 항목이 `applied` / `not_applicable` 또는 `deferred (운영 결정 사유 + blocker=advisory/pass)` 여야 한다.
+
+## 적용 결과
+
+| 항목 ID | status | 적용 일자 | 검증 명령 / Evidence | Production 차단 |
+|---|---|---|---|---|
+| `phase-8c-vr-coverage-backfill` | `not_applicable` (greenfield) / `deferred` (live target) | YYYY-MM-DD | greenfield: 새 target 은 phase-8c 이후 코드로 첫 부팅 → 기존 VR 없음. live target: `docs/migration/phase-8c-vr-coverage-backfill.md` 의 deploy procedure 적용 후 확인. | **advisory** (greenfield) / **blocker** (기존 운영 target 보유 시) |
+
+신규 production target 은 `not_applicable` 로 진입 가능 (`migration-inventory.md` §production 진입 전 적용 필요 = "(없음)"). 기존 live target 을 phase-8c 이후 코드로 마이그레이션하는 경우만 `blocker`.
+
+## Production 차단 분류
+
+- **blocker** — 본 항목 PASS 전까지 production target 전환 금지.
+- **advisory** — production 전환 가능. 단, 운영 첫 N cycle 동안 모니터링 필요.
+- **pass** — 본 항목과 무관 (`not_applicable`).
+
+## Update Policy
+
+- 신규 `docs/migration/*.md` 추가 시 `migration-inventory.md` 에 등록 후 본 표에도 동시 등록.
+- 항목 ID 는 `migration-inventory.md` 와 1:1 정합 (파일명 stem).
+- `deferred` 는 운영 결정 사유 + blocker 분류 명시 후에만 사용.
+
+## See Also
+
+- [`docs/operations/migration-inventory.md`](migration-inventory.md) — phase-prod-0 시점의 enumeration.
+- [`docs/operations/e2e-go-no-go.md`](e2e-go-no-go.md) — go/no-go 결정에서 본 표를 참조.
+- [`docs/operations/production-target.md`](production-target.md) — `validateOrThrow` + `migration-inventory` 정합성을 production 진입 조건으로 명시.

--- a/docs/operations/production-runbook.md
+++ b/docs/operations/production-runbook.md
@@ -1,0 +1,174 @@
+# Production Runbook
+
+production target 진입 후의 daemon / 인증 / workdir / cycle bundle / rate-limit 운영 절차. operator 가 5분 안에 읽고 실행한다. 인증 분기는 `verified_auth_model` (Phase 1 stage 1 + Phase 3 stage 3) 의 4 모드 (`env_token` / `credential_file` / `interactive_only` / `unknown`) 를 따른다.
+
+## 1. Daemon User ↔ CLI Auth User 일치
+
+Daemon 을 띄우는 unix user 와 `claude` / `codex` / `gh` 인증이 묶인 user 가 동일해야 한다. 불일치 시 credential file 을 읽지 못해 `interactive_only` 모드에서 fail-fast.
+
+```bash
+# daemon 으로 띄우려는 user 로 직접 실행
+whoami                                  # daemon user 확인
+id -u; id -g                            # uid/gid
+claude /config 2>/dev/null | head       # auth 결과 가시화 (interactive_only 인 경우)
+codex --version                         # codex binary 도달 여부
+gh auth status                          # gh 인증 상태
+```
+
+운영 권장: daemon 을 systemd / launchd 로 띄울 때도 `User=` 가 위 `whoami` 와 동일해야 한다. 검증은 Stage 1 healthcheck (`npm run healthcheck:stage1`) 가 cover.
+
+## 2. 인증 갱신 절차 — `verified_auth_model` 모드별 분기
+
+`<RUN_DIR>/verified-auth-model.json` (Stage 3 산출) 에서 `claude.status` / `codex.status` / 운영 정보로 모드를 판정한다. Stage 1 의 `auth_models.{claude,codex,gh}` 도 동일 enum 사용.
+
+### 2-a. `env_token`
+
+CLI 가 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GH_TOKEN` 을 읽는 모드. 갱신은 환경변수 교체 후 daemon 재기동.
+
+```bash
+# claude
+export ANTHROPIC_API_KEY="<new>"
+# codex
+export OPENAI_API_KEY="<new>"
+# gh
+export GH_TOKEN="<new>"
+# daemon 재기동 (운영체계 의존; 예시는 launchd)
+launchctl kickstart -k gui/$(id -u)/llm-team.daemon
+```
+
+`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` 는 redact-suffix policy 대상 (`src/adapters/llm-runner/common/redact.ts`) — 로그에 평문 노출 금지.
+
+### 2-b. `credential_file`
+
+CLI 가 OS 의 credential file 을 읽는 모드. 갱신은 interactive login 후 file mode 0600 강제.
+
+```bash
+# claude — credential path 후보 (실제 경로는 binary 버전 의존, healthcheck stage 3 산출에서 확정)
+claude /login                              # interactive login
+chmod 0600 ~/.claude/credentials.json      # 또는 ~/.config/claude/credentials.json
+# codex — credential path 후보 (binary 버전 의존)
+codex login                                # interactive (정확한 명령은 codex --help 참조)
+chmod 0600 ~/.codex/credentials.json       # 또는 ~/.config/codex/auth.json
+# 재기동
+launchctl kickstart -k gui/$(id -u)/llm-team.daemon
+```
+
+실제 credential path 는 운영 시점 healthcheck Stage 3 의 `verified-auth-model.json.detail` 에서 확정. file mode 0600 미충족 시 daemon healthcheck 가 advisory 로 warn.
+
+### 2-c. `interactive_only`
+
+env token 도, credential file 도 detect 되지 않는 모드 (`detectCliAuthModel` 가 `auth` / `login` 서브커맨드만 발견). daemon user 로 ssh 후 interactive login 필수.
+
+```bash
+ssh <daemon-host>                          # daemon user 로 로그인
+sudo -u <daemon-user> -i                   # daemon user 로 shell 진입
+claude /login                              # interactive
+codex login
+gh auth login
+ls -la ~/.claude ~/.codex ~/.config/gh     # credential file 확인
+launchctl kickstart -k gui/$(id -u)/llm-team.daemon
+```
+
+자동화 불가 — 운영자 손이 필요하다. `interactive_only` 모드는 CI / nightly e2e 에서 사용 금지 (`docs/operations/healthcheck.md` 의 Stage 3 ledger gate).
+
+### 2-d. `unknown`
+
+CLI 가 PATH 에 없거나 help 출력이 예상 surface 와 다른 경우. 갱신 전에 binary 자체를 재설치.
+
+```bash
+which claude codex gh
+claude --version; codex --version; gh --version
+# 재설치 후 Stage 1 healthcheck 재실행
+npm run healthcheck:stage1
+```
+
+`UNKNOWN_UNTIL_STAGE3` 도 유사 — Stage 3 (`LLM_TEAM_LIVE_HEALTHCHECK=1 npm run healthcheck:stage3`) 로 확정한 뒤 위 모드 중 하나로 분류.
+
+## 3. GH_TOKEN Rotation
+
+`github` provider 사용 target 한정. fs-mirror provider 만 쓰는 target 은 본 절 불필요.
+
+```bash
+# 1. 새 token 발급 (GitHub UI). scope 는 기존 token 과 동일.
+# 2. env 모드:
+export GH_TOKEN="<new>"
+# 또는 credential 모드:
+gh auth refresh -s repo,workflow             # interactive
+# 3. daemon 재기동
+launchctl kickstart -k gui/$(id -u)/llm-team.daemon
+# 4. phase-9a TeamMembership cache 만료 대기 또는 강제 무효화
+#    (cache TTL 은 target.governance.team_membership_cache_ttl_ms 참조)
+```
+
+cache TTL 이 길게 설정된 경우 daemon 재기동만으로는 즉시 반영되지 않을 수 있다 — 재기동이 cache 를 비우는지 target 별로 확인.
+
+## 4. Workdir 권한 정책
+
+```bash
+# production target 의 workdir 생성 / 검증
+install -d -m 0700 "<identity.workdir_path>"
+# 운영 user 가 owner 인지 확인
+stat -f '%Su %Sp' "<identity.workdir_path>"   # macOS
+stat -c '%U %a'   "<identity.workdir_path>"   # linux
+# 파일 단위 0600 준수 — 위반 시 chmod
+find "<identity.workdir_path>" -type f -not -perm 600 -exec chmod 0600 {} \;
+find "<identity.workdir_path>" -type d -not -perm 700 -exec chmod 0700 {} \;
+```
+
+`onboarding.md §운영 환경 요구` 와 일관 — cycle bundle 디렉토리 0700 / 파일 0600 강제.
+
+## 5. Cycle Bundle Retention (수동 cleanup)
+
+phase-10b 정식 retention 구현 전 수동 가이드. cycle bundle 위치: `<workdir>/<target>/cycles/<Role>-<obj_id>-<hash12>/`.
+
+```bash
+# 30일 이상 디렉토리 archive
+WORKDIR="<identity.workdir_path>/cycles"
+find "$WORKDIR" -maxdepth 1 -type d -mtime +30 -print
+# 검토 후 tarball 로 archive
+find "$WORKDIR" -maxdepth 1 -type d -mtime +30 -print0 | \
+  xargs -0 -I{} tar -czf "{}.tar.gz" "{}" && \
+  find "$WORKDIR" -maxdepth 1 -type d -mtime +30 -exec rm -rf {} +
+# 90일 이상 archive 도 정리
+find "$WORKDIR" -maxdepth 1 -name "*.tar.gz" -mtime +90 -delete
+```
+
+`LLM_TEAM_CYCLE_BUNDLE_DISABLED=1` 로 신규 bundle 생성을 일시 차단 가능. 정식 retention / prune 은 phase-10b backlog.
+
+## 6. Rate-Limit / Backoff
+
+Phase-prod-2 의 adapter 가 `transport_error` (`reason: "rate_limit"`) 로 분류한 attempt 는 retry 정책에 따라 자동 backoff. 운영자 대응:
+
+- **단일 attempt 실패**: adapter 가 다음 attempt 로 자동 재시도. 운영자 개입 불필요.
+- **연속 N회 rate_limit**: cycle bundle 의 `attempts/*/diagnostics.txt` 에 `reason=rate_limit` 누적 → 운영자가 daemon 일시 정지 + provider quota 확인.
+- **daily cap 도달**: healthcheck cost ledger (`~/.llm-team/healthcheck-cost-ledger.ndjson`) SKIP. 운영자가 cap 상향 또는 다음 UTC day 까지 대기.
+
+```bash
+# rate_limit 이 누적 중인지 빠르게 확인
+WORKDIR="<identity.workdir_path>/cycles"
+grep -lr 'reason=rate_limit' "$WORKDIR" | tail -20
+# daemon 일시 정지 (운영체계 의존)
+launchctl unload ~/Library/LaunchAgents/llm-team.daemon.plist
+# provider 에서 quota 회복 후 재기동
+launchctl load   ~/Library/LaunchAgents/llm-team.daemon.plist
+```
+
+## 7. Notifier Production 경로
+
+기존 어댑터 재사용 — 본 cycle 에서 신규 notifier 코드 추가 없음.
+
+| target.governance | NotifierPort 구현 | 산출 위치 |
+|---|---|---|
+| `human_team_provider: "github"` | `src/adapters/notifier/github.ts` (`GitHubNotifier`) | target issue/PR 댓글 |
+| `human_team_provider: "fs-mirror"` | `src/adapters/notifier/fs-mirror.ts` (`FsMirrorNotifier`) | `<workdir>/<target>/external_mirror/notifications.ndjson` |
+
+production failure report 는 위 경로로 전송된다. 별도의 production-only adapter 는 *없다* — `github` provider 사용 target 에 한해 phase-10 backlog 로 production-grade alerting (PagerDuty / Slack) 검토.
+
+## 8. See Also
+
+- [`docs/operations/healthcheck.md`](healthcheck.md) — Stage 1~3 healthcheck.
+- [`docs/operations/onboarding.md`](onboarding.md) — onboarding gate / cycle bundle layout.
+- [`docs/operations/production-target.md`](production-target.md) — target.json schema / sandbox 차이.
+- [`docs/operations/e2e-go-no-go.md`](e2e-go-no-go.md) — go/no-go 결정 양식.
+- [`docs/operations/production-migration-checklist.md`](production-migration-checklist.md) — migration 적용 결과.
+- [`docs/operations/phase-prod-DoD.md`](phase-prod-DoD.md) — Phase 0~5 DoD evidence.

--- a/docs/operations/production-runbook.md
+++ b/docs/operations/production-runbook.md
@@ -1,6 +1,6 @@
 # Production Runbook
 
-production target 진입 후의 daemon / 인증 / workdir / cycle bundle / rate-limit 운영 절차. operator 가 5분 안에 읽고 실행한다. 인증 분기는 `verified_auth_model` (Phase 1 stage 1 + Phase 3 stage 3) 의 4 모드 (`env_token` / `credential_file` / `interactive_only` / `unknown`) 를 따른다.
+production target 진입 후의 daemon / 인증 / workdir / cycle bundle / rate-limit 운영 절차. operator 가 5분 안에 읽고 실행한다. 인증 분기는 Stage 1 healthcheck 산출 `Stage1Result.auth_models.{claude,codex,gh}` 의 4 모드 (`env_token` / `credential_file` / `interactive_only` / `unknown`) 를 따른다. Stage 3 의 `verified-auth-model.json.<surface>.status` 는 별개 enum (`PASS` / `FAIL` / `SKIP`) 으로 live-probe 결과만 기록한다.
 
 ## 1. Daemon User ↔ CLI Auth User 일치
 
@@ -17,9 +17,9 @@ gh auth status                          # gh 인증 상태
 
 운영 권장: daemon 을 systemd / launchd 로 띄울 때도 `User=` 가 위 `whoami` 와 동일해야 한다. 검증은 Stage 1 healthcheck (`npm run healthcheck:stage1`) 가 cover.
 
-## 2. 인증 갱신 절차 — `verified_auth_model` 모드별 분기
+## 2. 인증 갱신 절차 — `auth_models` 모드별 분기
 
-`<RUN_DIR>/verified-auth-model.json` (Stage 3 산출) 에서 `claude.status` / `codex.status` / 운영 정보로 모드를 판정한다. Stage 1 의 `auth_models.{claude,codex,gh}` 도 동일 enum 사용.
+Stage 1 healthcheck 산출 `Stage1Result.auth_models.{claude,codex,gh}` 에서 4 모드 (`env_token` / `credential_file` / `interactive_only` / `unknown`) 를 읽어 모드를 판정한다. Stage 3 의 `<RUN_DIR>/verified-auth-model.json` 은 surface 별 live-probe 결과 (`PASS` / `FAIL` / `SKIP`) 와 `detail` 문자열만 기록하므로 모드 판정에는 사용하지 않는다.
 
 ### 2-a. `env_token`
 
@@ -43,17 +43,17 @@ launchctl kickstart -k gui/$(id -u)/llm-team.daemon
 CLI 가 OS 의 credential file 을 읽는 모드. 갱신은 interactive login 후 file mode 0600 강제.
 
 ```bash
-# claude — credential path 후보 (실제 경로는 binary 버전 의존, healthcheck stage 3 산출에서 확정)
+# claude — phase-prod-5 e2e workflow 와 동일 경로
 claude /login                              # interactive login
-chmod 0600 ~/.claude/credentials.json      # 또는 ~/.config/claude/credentials.json
-# codex — credential path 후보 (binary 버전 의존)
+chmod 0600 ~/.config/claude/credentials
+# codex — phase-prod-5 e2e workflow 와 동일 경로
 codex login                                # interactive (정확한 명령은 codex --help 참조)
-chmod 0600 ~/.codex/credentials.json       # 또는 ~/.config/codex/auth.json
+chmod 0600 ~/.config/codex/credentials
 # 재기동
 launchctl kickstart -k gui/$(id -u)/llm-team.daemon
 ```
 
-실제 credential path 는 운영 시점 healthcheck Stage 3 의 `verified-auth-model.json.detail` 에서 확정. file mode 0600 미충족 시 daemon healthcheck 가 advisory 로 warn.
+위 경로는 phase-prod-5 `.github/workflows/e2e.yml` 이 materialize 하는 위치와 정렬된다. binary 버전이 다른 경로를 사용하는 경우 운영자가 수동 확인 — file mode 0600 강제는 운영자 책임 (자동 검사 미구현).
 
 ### 2-c. `interactive_only`
 
@@ -97,7 +97,7 @@ gh auth refresh -s repo,workflow             # interactive
 # 3. daemon 재기동
 launchctl kickstart -k gui/$(id -u)/llm-team.daemon
 # 4. phase-9a TeamMembership cache 만료 대기 또는 강제 무효화
-#    (cache TTL 은 target.governance.team_membership_cache_ttl_ms 참조)
+#    (cache TTL 은 target.governance.human_team_cache_ttl_seconds 참조 — 단위: 초, default 300)
 ```
 
 cache TTL 이 길게 설정된 경우 daemon 재기동만으로는 즉시 반영되지 않을 수 있다 — 재기동이 cache 를 비우는지 target 별로 확인.
@@ -123,7 +123,7 @@ phase-10b 정식 retention 구현 전 수동 가이드. cycle bundle 위치: `<w
 
 ```bash
 # 30일 이상 디렉토리 archive
-WORKDIR="<identity.workdir_path>/cycles"
+WORKDIR="<identity.workdir_path>/<target_id>/cycles"
 find "$WORKDIR" -maxdepth 1 -type d -mtime +30 -print
 # 검토 후 tarball 로 archive
 find "$WORKDIR" -maxdepth 1 -type d -mtime +30 -print0 | \
@@ -133,20 +133,20 @@ find "$WORKDIR" -maxdepth 1 -type d -mtime +30 -print0 | \
 find "$WORKDIR" -maxdepth 1 -name "*.tar.gz" -mtime +90 -delete
 ```
 
-`LLM_TEAM_CYCLE_BUNDLE_DISABLED=1` 로 신규 bundle 생성을 일시 차단 가능. 정식 retention / prune 은 phase-10b backlog.
+정식 retention / prune (자동 archive, 신규 bundle 생성 차단 토글 등) 은 phase-10b backlog — 현재 소스에는 미구현. `LLM_TEAM_CYCLE_BUNDLE_DISABLED` 같은 차단 env 도 미구현이므로 수동 cleanup 만 가능.
 
 ## 6. Rate-Limit / Backoff
 
-Phase-prod-2 의 adapter 가 `transport_error` (`reason: "rate_limit"`) 로 분류한 attempt 는 retry 정책에 따라 자동 backoff. 운영자 대응:
+Phase-prod-2 의 adapter 는 `transport_error` (`reason: "rate_limit"`) 를 invalid outcome 으로 분류하고 **자동 재시도하지 않는다** (`src/application/turn-worker.ts` — "No retry"). 현재 cycle 은 실패로 종료되며, 다음 trigger 또는 daemon 재기동 시점까지 대기. 운영자 대응:
 
-- **단일 attempt 실패**: adapter 가 다음 attempt 로 자동 재시도. 운영자 개입 불필요.
-- **연속 N회 rate_limit**: cycle bundle 의 `attempts/*/diagnostics.txt` 에 `reason=rate_limit` 누적 → 운영자가 daemon 일시 정지 + provider quota 확인.
+- **단일 attempt rate_limit**: cycle 종료 후 다음 trigger / daemon 재기동 시 자연 재시도. 즉시 회복이 필요하면 daemon 재기동.
+- **연속 N회 rate_limit**: adapter diagnostics metadata (`os.tmpdir()/llm-team/runner/*.metadata.json`) 에 `"reason":"rate_limit"` 누적 → 운영자가 daemon 일시 정지 + provider quota 확인.
 - **daily cap 도달**: healthcheck cost ledger (`~/.llm-team/healthcheck-cost-ledger.ndjson`) SKIP. 운영자가 cap 상향 또는 다음 UTC day 까지 대기.
 
 ```bash
-# rate_limit 이 누적 중인지 빠르게 확인
-WORKDIR="<identity.workdir_path>/cycles"
-grep -lr 'reason=rate_limit' "$WORKDIR" | tail -20
+# rate_limit 이 누적 중인지 빠르게 확인 — adapter diagnostics metadata
+DIAGDIR="$(node -e 'console.log(require("os").tmpdir())')/llm-team/runner"
+grep -lE '"reason":\s*"rate_limit"' "$DIAGDIR"/*.metadata.json 2>/dev/null | tail -20
 # daemon 일시 정지 (운영체계 의존)
 launchctl unload ~/Library/LaunchAgents/llm-team.daemon.plist
 # provider 에서 quota 회복 후 재기동


### PR DESCRIPTION
## Summary
- production-runbook.md (auth/rotation/workdir/retention/rate-limit).
- e2e-go-no-go.md (gate 기록 양식 + cost cap 승인 + rollback).
- production-migration-checklist.md (Phase 0 inventory 의 적용 결과).
- phase-prod-DoD.md (Phase 0~5 DoD evidence + deferred-to-human 명시).

## 구현
- production-runbook.md: daemon user ↔ CLI auth user 일치 검증, `verified_auth_model` 4 모드 (env_token/credential_file/interactive_only/unknown) 별 인증 갱신 절차 분기, GH_TOKEN rotation (phase-9a TeamMembership cache 고려), workdir 0700/파일 0600, cycle bundle 수동 cleanup (phase-10b 정식 retention out-of-scope), rate-limit/backoff 운영자 대응, 기존 notifier (`GitHubNotifier` / `FsMirrorNotifier`) 경로만 명시 (코드 추가 없음).
- e2e-go-no-go.md: Phase 0~5 gate 결과 표 (PR #83~#88 evidence), cost cap 결정 row (per-run / daily / 1회 e2e 견적), rollback/stop 조건 6항목, 최종 GO/NO-GO/ADVISORY 결정 row.
- production-migration-checklist.md: migration-inventory 의 `phase-8c-vr-coverage-backfill` 항목을 greenfield(`not_applicable` / advisory) vs 기존 live target(`deferred` / blocker) 로 분류, blocker/advisory/pass 분류 명시.
- phase-prod-DoD.md: planning §12 DoD 8 항목 status + evidence (PR #83 #84 #85 #86 #87 #88 매핑), DoD #4 후반부와 #8 을 deferred-to-human 으로 명시.

## 테스트
- npm test → 866 passing (4 skipped, no source change)
- npm run typecheck → 0 errors
- npm run build → 0 errors

## Gate (planning §9)
- [x] 4 ops docs 신설
- [x] DoD #1~#7 evidence enumerated (PR #83~#88)
- [x] migration checklist with blocker decision (`phase-8c-vr-coverage-backfill` advisory/blocker 분기)
- [x] auth rotation per verified_auth_model 분기 (4 모드 + UNKNOWN_UNTIL_STAGE3 처리)
- [x] e2e-go-no-go.md 가 cost cap 결정 양식 + rollback 조건 포함
- [x] 기존 src/ 코드 변경 없음 (docs-only)
- [ ] **DEFERRED-TO-HUMAN**: DoD #4 (live e2e rehearsal sandbox 통과), DoD #8 (`.human/checklist/pre-e2e-checklist.md` Critical PASS 기록), production target 전환 승인

Tracking: phase-prod-6 per local plan (`.human/draft/2026-05-09-production-implementation-phases.md`, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)