### PR TITLE
fix(phase-prod-1): remove M-1-4 vitest list from Stage 1

### DIFF
--- a/src/cli/healthcheck.ts
+++ b/src/cli/healthcheck.ts
@@ -303,22 +303,10 @@ export function runStage1(opts: {
     anchor: "M-1-3",
   });
 
-  // M-1-4 — vitest list (project tests are runnable). Use --reporter=dot
-  // and `--listFiles` lite-substitute by invoking `vitest list`. Falls back
-  // to a non-zero status as FAIL.
-  const vitestList = run("npx", ["--no-install", "vitest", "list"], {
-    cwd,
-  });
-  items.push({
-    id: "M-1-4.vitest-list",
-    status: vitestList.status === 0 ? "PASS" : "FAIL",
-    detail:
-      vitestList.status === 0
-        ? "vitest list ok"
-        : `vitest list failed: ${(vitestList.stderr || vitestList.stdout).trim().slice(0, 160)}`,
-    anchor: "M-1-4",
-  });
-
+  // M-1-4 — vitest list. Removed from Stage 1 fail-fast: cold `vitest list`
+  // exceeds the 5s budget on this repo (866 tests, deep import graph), which
+  // produced false negatives. The intent ("test infra is alive") is covered
+  // by `npm test` / `npm run typecheck` in the PR build (.github/workflows).
   // M-1-5 — typecheck. Stage 1 is a 5s fail-fast probe and `npm run
   // typecheck` is a multi-second compile, so it is always SKIP here. The
   // PR build (.github/workflows) and `npm run typecheck` cover this gate.

--- a/tests/cli/healthcheck.test.ts
+++ b/tests/cli/healthcheck.test.ts
@@ -34,7 +34,6 @@ const ALL_PASS_TABLE: Record<string, { status: number; stdout?: string; stderr?:
   "command -v gtimeout": { status: 1 },
   "git --version": { status: 0, stdout: "git version 2.43.0\n" },
   "node --version": { status: 0, stdout: "v20.10.0\n" },
-  "npx --no-install vitest list": { status: 0, stdout: "tests/foo.test.ts\n" },
   "gh auth status": { status: 0, stdout: "Logged in (keychain)\n" },
   "gh api user --jq .login": { status: 0, stdout: "octocat\n" },
   "gh auth token": { status: 0, stdout: "ghp_xxx\n" },
@@ -93,7 +92,7 @@ describe("healthcheck runHealthcheck", () => {
     expect(result.items.every((i) => i.status !== "FAIL")).toBe(true);
     // Anchors present.
     expect(result.items.map((i) => i.anchor)).toEqual(
-      expect.arrayContaining(["M-1-1", "M-1-2", "M-1-3", "M-1-4", "M-2-1", "M-2-2", "M-2-3", "M-2-4", "M-2-5"]),
+      expect.arrayContaining(["M-1-1", "M-1-2", "M-1-3", "M-2-1", "M-2-2", "M-2-3", "M-2-4", "M-2-5"]),
     );
     // Auth models populated.
     expect(result.auth_models.gh).toBe("env_token");


### PR DESCRIPTION
## Summary
- Stage 1의 M-1-4 (`npx vitest list`) 제거. 866 tests 의 deep import graph 에서 cold transform 18.8s — Stage 1 의 5sec fail-fast budget 초과로 false negative.
- M-1-4 의 의도("test infra is alive") 는 PR build workflow 의 `npm test` (866 passing) + `npm run typecheck` + `npm run build` 가 더 강하게 커버.

## 변경
- `src/cli/healthcheck.ts:306-320` 제거 (M-1-4 항목 + spawn 호출).
- `tests/cli/healthcheck.test.ts:37` mock entry + line 96 anchor list 정리.

## Verification
- `npm run healthcheck:stage1` → `passed=true`, exit 0, items=11.
- `npm test` → 866 passing | 4 skipped.
- `npm run typecheck` / `npm run build` → 0 errors.

Discovered while closing DoD #2 (`docs/operations/phase-prod-DoD.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)