### PR TITLE
feat(l3): prompt persistence + attempt slot 0700/0600 (L-3-1, L-3-7)

### DIFF
--- a/src/adapters/llm-runner/common/diagnostics.ts
+++ b/src/adapters/llm-runner/common/diagnostics.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, rename, writeFile } from "node:fs/promises";
+import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -24,16 +24,24 @@ function safe(part: string): string {
   return part.replace(/[^A-Za-z0-9_.-]/g, "_");
 }
 
+// L-3-7: attempt directory is forced to 0700 — mkdir's `mode` only applies
+// to newly created paths, so we follow up with chmod to also tighten any
+// pre-existing dir (e.g. created by a prior run with a looser umask).
+// Only the diag dir itself is touched; parents are left alone.
 async function ensureDir(dir: string): Promise<void> {
-  await mkdir(dir, { recursive: true });
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  await chmod(dir, 0o700);
 }
 
+// L-3-7: attempt files are written with 0600. POSIX rename preserves the
+// inode (and therefore the mode) so the final target file inherits 0600
+// from the temp file.
 async function atomicWrite(target: string, body: string): Promise<void> {
   // Same-directory mktemp + rename. If the target dir is on a single
   // filesystem (the default for os.tmpdir() on macOS/Linux), rename is
   // atomic. Cross-mount setups need operator review (verification step).
   const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tmp, body, { encoding: "utf8" });
+  await writeFile(tmp, body, { encoding: "utf8", mode: 0o600 });
   await rename(tmp, target);
 }
 
@@ -72,6 +80,13 @@ export async function openEnvelopeSlot(
 }
 
 export interface AttemptSlots {
+  /**
+   * Composed prompt slot — body is the exact stdin handed to the adapter,
+   * redacted at the write boundary. Persisted before adapter invocation so
+   * a 4-part layout violation (or any later failure) still leaves the
+   * offending prompt on disk for replay (L-3-1).
+   */
+  prompt: DiagnosticsSlot;
   /** stdout file slot (raw adapter stdout, redacted at write boundary). */
   stdout: DiagnosticsSlot;
   /** stderr file slot (redacted at write boundary). */
@@ -83,10 +98,10 @@ export interface AttemptSlots {
 }
 
 /**
- * Open the four per-attempt files for a single adapter invocation.
- * All four share the same attempt suffix so they correlate 1-to-1 in the
- * diagnostics directory. Used by the executor to keep stdout, stderr,
- * envelope, and metadata distinct (planning §3 phase-prod-2).
+ * Open the five per-attempt files for a single adapter invocation.
+ * All five share the same attempt suffix so they correlate 1-to-1 in the
+ * diagnostics directory. Used by the executor to keep prompt, stdout,
+ * stderr, envelope, and metadata distinct (planning §3 phase-prod-2 + L-3-1).
  */
 export async function openAttemptSlots(
   key: DiagnosticsKey,
@@ -95,6 +110,7 @@ export async function openAttemptSlots(
   await ensureDir(dir);
   const base = `${safe(key.sessionId)}-${key.turnIndex}-${safe(key.idempotencyKey)}-${attemptSuffix()}`;
   return {
+    prompt: makeSlot(join(dir, `${base}.prompt`)),
     stdout: makeSlot(join(dir, `${base}.stdout`)),
     stderr: makeSlot(join(dir, `${base}.stderr`)),
     envelope: makeSlot(join(dir, `${base}.envelope`)),

--- a/src/adapters/llm-runner/common/diagnostics.ts
+++ b/src/adapters/llm-runner/common/diagnostics.ts
@@ -40,7 +40,10 @@ async function atomicWrite(target: string, body: string): Promise<void> {
   // Same-directory mktemp + rename. If the target dir is on a single
   // filesystem (the default for os.tmpdir() on macOS/Linux), rename is
   // atomic. Cross-mount setups need operator review (verification step).
-  const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+  // The randomUUID suffix avoids tmp-file collisions when multiple
+  // concurrent writes within the same process land on the same target in
+  // the same millisecond (PR #91 qwen review).
+  const tmp = `${target}.${process.pid}.${Date.now()}.${randomUUID().slice(0, 8)}.tmp`;
   await writeFile(tmp, body, { encoding: "utf8", mode: 0o600 });
   await rename(tmp, target);
 }

--- a/src/ports/llm-runner-executor.ts
+++ b/src/ports/llm-runner-executor.ts
@@ -17,20 +17,29 @@ import { classifyExit, classifyTransportReason } from "./llm-runner.js";
 // even on preflight failure or unexpected throw. Adapter primitives never
 // see the contract refs directly; this function resolves them into stdin.
 //
-// Per attempt, four files are written under LLM_TEAM_RUNNER_DIAG_DIR:
+// Per attempt, five files are written under LLM_TEAM_RUNNER_DIAG_DIR:
+//   - <base>.prompt       (composed stdin handed to the adapter, redacted;
+//                          written before assertFourPartLayout so layout
+//                          violations still leave the offending body on disk
+//                          — L-3-1)
 //   - <base>.stdout       (raw stdout, redacted at write boundary)
 //   - <base>.stderr       (raw stderr, redacted at write boundary; this is
 //                          the path returned as `diagnosticsRef`)
 //   - <base>.envelope     (extracted envelope JSON, or empty)
 //   - <base>.metadata.json
 //
-// Even on preflight failure all four files are written (with empty bodies)
-// so cycle bundles always reference a complete attempt directory.
+// Even on preflight failure all five files are written (with empty bodies
+// for slots that were never reached) so cycle bundles always reference a
+// complete attempt directory.
 export async function runInvoke(
   input: LlmRunnerInput,
   adapter: LlmRunnerAdapter,
 ): Promise<LlmRunnerResult> {
   const slots = await openAttemptSlots(input);
+  // Tracks whether the prompt body was already written by the success path
+  // before reaching `finish`. When false, finish writes an empty prompt file
+  // so the slot is never missing.
+  let promptWritten = false;
 
   const finish = async (
     exitStatus: ExitStatus,
@@ -60,6 +69,9 @@ export async function runInvoke(
     const envSources: NodeJS.ProcessEnv[] = bodies.spawnEnv
       ? [process.env, bodies.spawnEnv]
       : [process.env];
+    if (!promptWritten) {
+      await writeRedacted(slots.prompt, "", envSources);
+    }
     await writeRedacted(slots.stdout, bodies.stdout ?? "", envSources);
     await writeRedacted(slots.stderr, bodies.stderr ?? "", envSources);
     await writeRedacted(slots.envelope, bodies.envelope ?? "", envSources);
@@ -93,6 +105,14 @@ export async function runInvoke(
         reason: "compose_stdin_failed",
       });
     }
+
+    // L-3-1: persist the composed prompt before any further validation so
+    // a 4-part layout violation (or later adapter failure) still leaves the
+    // offending body on disk for replay. spawnEnv is unknown here — fall
+    // back to process.env for redaction; adapter envOverride secrets are
+    // unlikely to appear in the prompt body.
+    await writeRedacted(slots.prompt, stdin, [process.env]);
+    promptWritten = true;
 
     try {
       assertFourPartLayout(stdin);

--- a/tests/adapters/diagnostics.test.ts
+++ b/tests/adapters/diagnostics.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  type DiagnosticsKey,
+  openAttemptSlots,
+} from "../../src/adapters/llm-runner/common/diagnostics.js";
+
+let workDir: string;
+let diagDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "diag-perm-test-"));
+  diagDir = join(workDir, "diag");
+  process.env.LLM_TEAM_RUNNER_DIAG_DIR = diagDir;
+});
+
+const sampleKey: DiagnosticsKey = {
+  sessionId: "s-1",
+  turnIndex: 1,
+  idempotencyKey: "k-1",
+};
+
+function modeBits(path: string): number {
+  return statSync(path).mode & 0o777;
+}
+
+describe("diagnostics — AttemptSlots prompt slot (L-3-1)", () => {
+  it("openAttemptSlots returns a 5th `prompt` slot alongside stdout/stderr/envelope/metadata", async () => {
+    const slots = await openAttemptSlots(sampleKey);
+    expect(slots.prompt).toBeDefined();
+    expect(slots.prompt.path).toMatch(/\.prompt$/);
+  });
+
+  it("all five slots share the same attempt base prefix", async () => {
+    const slots = await openAttemptSlots(sampleKey);
+    const base = slots.prompt.path.replace(/\.prompt$/, "");
+    expect(slots.stdout.path).toBe(`${base}.stdout`);
+    expect(slots.stderr.path).toBe(`${base}.stderr`);
+    expect(slots.envelope.path).toBe(`${base}.envelope`);
+    expect(slots.metadata.path).toBe(`${base}.metadata.json`);
+  });
+
+  it("prompt slot writes a body that is readable from disk", async () => {
+    const slots = await openAttemptSlots(sampleKey);
+    await slots.prompt.write("hello prompt body");
+    expect(modeBits(slots.prompt.path)).toBe(0o600);
+  });
+});
+
+describe("diagnostics — directory and file permissions (L-3-7)", () => {
+  it("openAttemptSlots creates the diag dir with mode 0700", async () => {
+    await openAttemptSlots(sampleKey);
+    expect(modeBits(diagDir)).toBe(0o700);
+  });
+
+  it("openAttemptSlots forces 0700 on a pre-existing dir created with looser mode", async () => {
+    mkdirSync(diagDir, { recursive: true, mode: 0o755 });
+    expect(modeBits(diagDir)).toBe(0o755);
+    await openAttemptSlots(sampleKey);
+    expect(modeBits(diagDir)).toBe(0o700);
+  });
+
+  it("all attempt files (prompt/stdout/stderr/envelope/metadata) are written with mode 0600", async () => {
+    const slots = await openAttemptSlots(sampleKey);
+    await slots.prompt.write("prompt body");
+    await slots.stdout.write("stdout body");
+    await slots.stderr.write("stderr body");
+    await slots.envelope.write('{"ok":true}');
+    await slots.metadata.write('{"meta":1}');
+    expect(modeBits(slots.prompt.path)).toBe(0o600);
+    expect(modeBits(slots.stdout.path)).toBe(0o600);
+    expect(modeBits(slots.stderr.path)).toBe(0o600);
+    expect(modeBits(slots.envelope.path)).toBe(0o600);
+    expect(modeBits(slots.metadata.path)).toBe(0o600);
+  });
+
+  it("re-writing an existing slot keeps the file at mode 0600 (atomic rename preserves perms)", async () => {
+    const slots = await openAttemptSlots(sampleKey);
+    await slots.stdout.write("first body");
+    await slots.stdout.write("second body");
+    expect(modeBits(slots.stdout.path)).toBe(0o600);
+  });
+});
+
+describe("diagnostics — does not chmod paths above the diag dir", () => {
+  it("leaves the parent of diagDir untouched", async () => {
+    const parentMode = modeBits(workDir);
+    await openAttemptSlots(sampleKey);
+    expect(modeBits(workDir)).toBe(parentMode);
+  });
+});

--- a/tests/adapters/diagnostics.test.ts
+++ b/tests/adapters/diagnostics.test.ts
@@ -91,3 +91,25 @@ describe("diagnostics — does not chmod paths above the diag dir", () => {
     expect(modeBits(workDir)).toBe(parentMode);
   });
 });
+
+describe("diagnostics — atomicWrite tmp file collision (PR #91 qwen review)", () => {
+  it("concurrent writes to distinct slots do not collide on the tmp filename", async () => {
+    // Drive 8 parallel writes against 8 distinct slots in the same dir.
+    // Without a uuid suffix on the tmp file, two writes hitting the same
+    // millisecond inside the same pid would race on rename.
+    const slotsArr = await Promise.all(
+      Array.from({ length: 8 }, (_, i) =>
+        openAttemptSlots({
+          ...sampleKey,
+          idempotencyKey: `concurrent-${i}`,
+        }),
+      ),
+    );
+    await Promise.all(
+      slotsArr.map((s, i) => s.stdout.write(`body-${i}`)),
+    );
+    for (let i = 0; i < slotsArr.length; i++) {
+      expect(modeBits(slotsArr[i].stdout.path)).toBe(0o600);
+    }
+  });
+});

--- a/tests/ports/executor.test.ts
+++ b/tests/ports/executor.test.ts
@@ -273,6 +273,87 @@ describe("runInvoke", () => {
     expect(meta.reason).toBe("agent_cwd_missing");
   });
 
+  it("on success persists the composed prompt to <base>.prompt for replay", async () => {
+    const adapter = new StubAdapter(() => ({
+      rawCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: '```json\n{"x":1}\n```\n',
+      stderr: "",
+    }));
+    const r = await runInvoke(makeInput(), adapter);
+    expect(r.exitStatus).toBe("ok");
+    const promptPath = r.envelopeRef.replace(/\.envelope$/, ".prompt");
+    expect(existsSync(promptPath)).toBe(true);
+    const promptBody = readFileSync(promptPath, "utf8");
+    // adapter.lastInput.stdin is the canonical composed prompt the adapter saw.
+    expect(promptBody).toBe(adapter.lastInput!.stdin);
+  });
+
+  it("4-part layout violation still persists the offending prompt body", async () => {
+    const badPrompt = join(workDir, "bad.md");
+    const badBody = "no frontmatter here\n# Context\n";
+    writeFileSync(badPrompt, badBody, "utf8");
+    const adapter = new StubAdapter(() => {
+      throw new Error("should not be called");
+    });
+    const r = await runInvoke(makeInput({ promptRef: badPrompt }), adapter);
+    expect(r.exitStatus).toBe("transport_error");
+    const promptPath = r.envelopeRef.replace(/\.envelope$/, ".prompt");
+    expect(existsSync(promptPath)).toBe(true);
+    expect(readFileSync(promptPath, "utf8")).toBe(badBody);
+  });
+
+  it("composeStdin failure still emits an empty prompt slot file", async () => {
+    const noContextPrompt = join(workDir, "no-context.md");
+    writeFileSync(
+      noContextPrompt,
+      `---\nsession_id: s\n---\n\n# Instruction\n\n# Output Schema\n`,
+      "utf8",
+    );
+    const ctxRef = join(workDir, "ctx-missing-anchor.md");
+    writeFileSync(ctxRef, "ctx body", "utf8");
+    const adapter = new StubAdapter(() => {
+      throw new Error("should not be called");
+    });
+    const r = await runInvoke(
+      makeInput({ promptRef: noContextPrompt, sessionContextRef: ctxRef }),
+      adapter,
+    );
+    expect(r.exitStatus).toBe("transport_error");
+    const promptPath = r.envelopeRef.replace(/\.envelope$/, ".prompt");
+    expect(existsSync(promptPath)).toBe(true);
+    expect(readFileSync(promptPath, "utf8")).toBe("");
+  });
+
+  it("agentCwd missing leaves an empty prompt slot file", async () => {
+    const adapter = new StubAdapter(() => {
+      throw new Error("should not be called");
+    });
+    const r = await runInvoke(
+      makeInput({ agentCwd: join(workDir, "no-such-dir") }),
+      adapter,
+    );
+    expect(r.exitStatus).toBe("adapter_unavailable");
+    const promptPath = r.envelopeRef.replace(/\.envelope$/, ".prompt");
+    expect(existsSync(promptPath)).toBe(true);
+    expect(readFileSync(promptPath, "utf8")).toBe("");
+  });
+
+  it("executor unexpected throw leaves an empty prompt slot file", async () => {
+    const adapter = new StubAdapter(() => {
+      throw new Error("boom");
+    });
+    const r = await runInvoke(makeInput(), adapter);
+    expect(r.exitStatus).toBe("transport_error");
+    const promptPath = r.envelopeRef.replace(/\.envelope$/, ".prompt");
+    expect(existsSync(promptPath)).toBe(true);
+    // Adapter throw happens *after* prompt was already written, so the body is
+    // the composed stdin (not empty). The contract is only that the file exists.
+    const body = readFileSync(promptPath, "utf8");
+    expect(body.length).toBeGreaterThan(0);
+  });
+
   it("captures transport_error reason='rate_limit' in metadata", async () => {
     const adapter = new StubAdapter(() => ({
       rawCode: 1,


### PR DESCRIPTION
## Summary

Closes `pre-e2e-checklist.md` §L-3-1 (prompt 파일 영속화) and §L-3-7 (0700/0600 권한). Adds a 5th attempt slot (`<base>.prompt`) and tightens diag dir/file permissions. Adapter code (claude-code, codex-cli, spawn) unchanged — all changes live in the executor + diagnostics layer.

## Motivation

Production e2e debugging/reproducibility. Previously `runInvoke` held the composed prompt in memory only; if `assertFourPartLayout` failed (or the adapter exited non-zero), the prompt body that triggered the failure was unrecoverable. Simultaneously the diag dir/files inherited default umask (0o755 / 0o644), so `<base>.stdout` etc. were a credential-leak surface on multi-user hosts. Both gaps are closed in one cycle since the new `.prompt` file would otherwise widen the existing exposure.

## Changes

- `diagnostics.ts`
  - `AttemptSlots` gains `prompt: DiagnosticsSlot`
  - `ensureDir` → `mkdir { mode: 0o700 }` + explicit `chmod 0o700` (forces tighten on pre-existing dirs)
  - `atomicWrite` → `writeFile { mode: 0o600 }` (POSIX rename preserves inode mode)
- `llm-runner-executor.ts`
  - `composeStdin` → `writeRedacted(slots.prompt, …)` → `assertFourPartLayout` (prompt persisted *before* validation)
  - `promptWritten` flag so `finish` writes an empty prompt on preflight failure paths only (never overwrites the success-path body)
  - Doc comment updated to describe 5 slots
- Adapter code (`claude-code.ts`, `codex-cli.ts`, `spawn.ts`, `envelope-extract.ts`, `redact.ts`, `prompt-relay.ts`) — **0 changes**

## Tests

- `tests/adapters/diagnostics.test.ts` (new) — 8 cases
  - 5th slot present, all five share base prefix
  - dir 0o700 on new and pre-existing (looser) dirs
  - all five files 0o600 after write
  - re-write keeps mode (atomic rename invariant)
  - parent of diag dir untouched
- `tests/ports/executor.test.ts` — +5 cases
  - on success: `<base>.prompt` body == adapter.lastInput.stdin
  - 4-part violation: prompt body == offending body
  - composeStdin failure: empty prompt file
  - agentCwd missing: empty prompt file
  - executor unexpected throw: prompt file exists (body non-empty since adapter throw happens *after* prompt write)

## Test plan

- [x] `npm run typecheck` — 0 error
- [x] `npm run build` — clean
- [x] `npm test` — 879 passing | 4 skipped (baseline 866 → +13 new)
- [x] Adapter source files unchanged (verified via git diff)
- [x] Manual smoke: `LLM_TEAM_RUNNER_DIAG_DIR=/tmp/l3-test` 1회 호출 시 5 slot 모두 생성 + 권한 0700/0600

## Out of scope (별도 cycle)

- §L-3-2 codex `-o` flag + envelope file-based extraction
- §L-3-5 cycle bundle integration (Phase 10b)
- prompt redaction against adapter `envOverride` secrets (currently uses `process.env` only at prompt-write time since `spawnEnv` is unknown pre-call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)