### PR TITLE
fix(ledger): skip duplicate persistence + cache replay + 30s lock timeout (incident-2)

### DIFF
--- a/src/adapters/store/fs.ts
+++ b/src/adapters/store/fs.ts
@@ -19,7 +19,7 @@ export interface FsStoreOptions {
   workdir: string;
   /** Whether to fsync the parent directory after rename. Default true. */
   fsyncDir?: boolean;
-  /** Max time to wait for cross-process lock acquisition. Default 5000ms. */
+  /** Max time to wait for cross-process lock acquisition. Default 30000ms. */
   lockTimeoutMs?: number;
   /** Lockdir age beyond which the lock is treated as stale. Default 60_000ms. */
   staleLockMs?: number;
@@ -46,7 +46,7 @@ export class FsStore implements StorePort {
   constructor(opts: FsStoreOptions) {
     this.workdir = resolve(opts.workdir);
     this.fsyncDir = opts.fsyncDir ?? true;
-    this.lockTimeoutMs = opts.lockTimeoutMs ?? 5_000;
+    this.lockTimeoutMs = opts.lockTimeoutMs ?? 30_000;
     this.staleLockMs = opts.staleLockMs ?? 60_000;
     this.raceWindowMs = opts.raceWindowMs ?? 1_000;
   }

--- a/src/adapters/store/fs.ts
+++ b/src/adapters/store/fs.ts
@@ -19,7 +19,18 @@ export interface FsStoreOptions {
   workdir: string;
   /** Whether to fsync the parent directory after rename. Default true. */
   fsyncDir?: boolean;
-  /** Max time to wait for cross-process lock acquisition. Default 30000ms. */
+  /**
+   * Max time to wait for cross-process lock acquisition. Default 30000ms.
+   *
+   * Scope (PR #94 P1-B): this single value applies to **every** withFileLock
+   * caller — ledger appendTransition, control-state writes, lease checkout,
+   * human-signal drain, etc. — because they all share `acquireLock` below.
+   * Increasing the default from the historical 5s to 30s (incident-2 fix)
+   * therefore lets *any* of those callers wait up to 30s for a stuck lock.
+   * Per-call overrides are not currently supported; if a future incident
+   * requires a tighter SLO for a specific lock, introduce a per-call timeout
+   * option rather than tuning this global down.
+   */
   lockTimeoutMs?: number;
   /** Lockdir age beyond which the lock is treated as stale. Default 60_000ms. */
   staleLockMs?: number;

--- a/src/application/control-state.ts
+++ b/src/application/control-state.ts
@@ -216,6 +216,21 @@ export type DaemonPreludeOutcome =
   | { action: "stopped"; state: "STOPPED" };
 
 /**
+ * Per-process memo of the last (signal_id, state) tuple a given role emitted
+ * a prelude noop for. Lets a paused daemon's tight loop self-throttle
+ * without round-tripping through the ledger every cycle (incident-2 P0 #5).
+ * A fresh pause signal — i.e. a different signal_id or a state change —
+ * still causes a single emission. Belt-and-suspenders with the ledger's
+ * own duplicate-skip; the row never even reaches appendTransition.
+ */
+const preludeEmitMemo = new Map<string, { signal_id: string; state: ControlState }>();
+
+/** Visible for tests: reset the per-process prelude memo. */
+export function __resetDaemonPreludeMemo(): void {
+  preludeEmitMemo.clear();
+}
+
+/**
  * Daemon pre-pickup gate. Reads the current control state and, when
  * non-RUNNING, emits a `pause_resume` ledger row capturing the noop pickup.
  * The drain itself runs *outside* this helper so callers can supply the
@@ -229,6 +244,21 @@ export async function runDaemonPrelude(
     return { action: "proceed", state: "RUNNING" };
   }
   const action = current.state === "PAUSED" ? "paused" : "stopped";
+  // Self-throttle: skip the appendTransition entirely when this role
+  // already emitted a noop row for the same (signal_id, state) tuple in
+  // this process. The ledger's duplicate path would also skip persistence,
+  // but avoiding the lock+replay round-trip here matters when a paused
+  // daemon polls aggressively.
+  const memo = preludeEmitMemo.get(deps.role);
+  if (
+    memo != null &&
+    memo.signal_id === current.signal_id &&
+    memo.state === current.state
+  ) {
+    return action === "paused"
+      ? { action: "paused", state: "PAUSED" }
+      : { action: "stopped", state: "STOPPED" };
+  }
   // RGC-SIGNALS: emit a noop row so operators see the gate firing. The
   // idempotency key folds together (role, signal_id, state) so a daemon
   // looping while paused does not flood the ledger with duplicates per
@@ -272,6 +302,10 @@ export async function runDaemonPrelude(
     result: "noop",
     result_detail: `paused:role=${deps.role}:signal_id=${current.signal_id}`,
     timestamp: deps.clock.isoNow(),
+  });
+  preludeEmitMemo.set(deps.role, {
+    signal_id: current.signal_id,
+    state: current.state,
   });
   return action === "paused"
     ? { action: "paused", state: "PAUSED" }

--- a/src/application/control-state.ts
+++ b/src/application/control-state.ts
@@ -222,12 +222,29 @@ export type DaemonPreludeOutcome =
  * A fresh pause signal — i.e. a different signal_id or a state change —
  * still causes a single emission. Belt-and-suspenders with the ledger's
  * own duplicate-skip; the row never even reaches appendTransition.
+ *
+ * Sizing: keyed by daemon role label, which is a finite,
+ * daemon-process-local set (turn-worker, dialogue-coordinator, etc.). Map
+ * size is bounded by the daemon role count and never grows with traffic,
+ * so no eviction is required (PR #94 P1-C).
  */
 const preludeEmitMemo = new Map<string, { signal_id: string; state: ControlState }>();
+
+/**
+ * In-flight singleflight registry (PR #94 P0-2). Keyed by role, holds the
+ * Promise of the *first* runDaemonPrelude call that observed a non-RUNNING
+ * gate before its memo entry was committed. Concurrent callers from the
+ * same role (Promise.all etc.) await the same Promise instead of each
+ * racing into appendTransition and emitting redundant noop rows. Entries
+ * are removed once the originating call resolves so a subsequent gate
+ * crossing for a different (signal_id, state) tuple still takes effect.
+ */
+const preludeInflight = new Map<string, Promise<DaemonPreludeOutcome>>();
 
 /** Visible for tests: reset the per-process prelude memo. */
 export function __resetDaemonPreludeMemo(): void {
   preludeEmitMemo.clear();
+  preludeInflight.clear();
 }
 
 /**
@@ -259,6 +276,31 @@ export async function runDaemonPrelude(
       ? { action: "paused", state: "PAUSED" }
       : { action: "stopped", state: "STOPPED" };
   }
+  // PR #94 P0-2 singleflight: if another caller in the same process is
+  // already in the middle of emitting the noop row for this role, await
+  // its result instead of racing into a second appendTransition. Without
+  // this gate, Promise.all-style concurrent invocations would all pass the
+  // memo check above (memo is only written *after* appendTransition
+  // resolves) and each persist a redundant noop row — the ledger's own
+  // duplicate-skip cannot collapse them because result="noop" is excluded
+  // from appliedKeys, so every concurrent row hits the applied path.
+  const inflight = preludeInflight.get(deps.role);
+  if (inflight != null) return inflight;
+  const promise = emitPreludeNoop(deps, current.state, current.signal_id, action);
+  preludeInflight.set(deps.role, promise);
+  try {
+    return await promise;
+  } finally {
+    preludeInflight.delete(deps.role);
+  }
+}
+
+async function emitPreludeNoop(
+  deps: DaemonPreludeDeps,
+  state: "PAUSED" | "STOPPED" | ControlState,
+  signal_id: string,
+  action: "paused" | "stopped",
+): Promise<DaemonPreludeOutcome> {
   // RGC-SIGNALS: emit a noop row so operators see the gate firing. The
   // idempotency key folds together (role, signal_id, state) so a daemon
   // looping while paused does not flood the ledger with duplicates per
@@ -267,8 +309,8 @@ export async function runDaemonPrelude(
     scope: "pause_resume",
     parts: {
       role: deps.role,
-      state: current.state,
-      signal_id: current.signal_id,
+      state,
+      signal_id,
     },
   });
   await deps.ledger.appendTransition({
@@ -277,7 +319,7 @@ export async function runDaemonPrelude(
     object_id: "system",
     object_kind: "system",
     from_state: null,
-    to_state: current.state,
+    to_state: state,
     loop_kind: null,
     phase: null,
     slice_id: null,
@@ -300,12 +342,12 @@ export async function runDaemonPrelude(
     lease_token: null,
     lease_kind: null,
     result: "noop",
-    result_detail: `paused:role=${deps.role}:signal_id=${current.signal_id}`,
+    result_detail: `paused:role=${deps.role}:signal_id=${signal_id}`,
     timestamp: deps.clock.isoNow(),
   });
   preludeEmitMemo.set(deps.role, {
-    signal_id: current.signal_id,
-    state: current.state,
+    signal_id,
+    state: state as ControlState,
   });
   return action === "paused"
     ? { action: "paused", state: "PAUSED" }

--- a/src/application/ledger.ts
+++ b/src/application/ledger.ts
@@ -82,11 +82,17 @@ export class FileLedger implements LedgerAppender {
   /**
    * Per-process cache of the last replay result. Avoids O(n) re-parse per
    * append in steady state. Invalidated when the file's byte length diverges
-   * from `lastReplayedSize` — covers external writers and absent files.
+   * from `lastReplayedSize` OR when the trailing bytes diverge from
+   * `lastReplayedTail` — the tail check closes the same-size content-swap
+   * hole (PR #94 P0-1): an external writer that replaces the ndjson with a
+   * different payload of identical byte length would otherwise hit the cache
+   * and chain the next applied row off a stale `cachedHead`, corrupting the
+   * audit_hash chain. Tail length is bounded so the comparison stays O(1).
    */
   private cachedHead: string | null = null;
   private cachedAppliedKeys: Set<string> | null = null;
   private lastReplayedSize: number | null = null;
+  private lastReplayedTail: string | null = null;
 
   constructor(opts: LedgerAppenderOptions) {
     this.store = opts.store;
@@ -145,6 +151,14 @@ export class FileLedger implements LedgerAppender {
       // appendLine implementation adds a trailing newline iff missing, so
       // size delta is serialized.length + 1.
       this.cachedHead = row.audit_hash;
+      // PR #94 P1-A: `replay.appliedKeys` is the SAME Set instance held by
+      // `cachedAppliedKeys` (replayCached returns the cache reference, not a
+      // clone). Mutating it here is intentional and is safe ONLY because we
+      // are inside the file lock AND the appendLine above has already
+      // succeeded — i.e. the on-disk row exists, so adding its key to the
+      // cache cannot create a state where the cache claims a key is applied
+      // when the file does not yet contain it. Any future refactor that
+      // reorders these lines (mutate before append) must instead clone.
       if (
         row.result === "applied" ||
         row.result === "recovered" ||
@@ -155,6 +169,17 @@ export class FileLedger implements LedgerAppender {
       this.cachedAppliedKeys = replay.appliedKeys;
       if (this.lastReplayedSize != null)
         this.lastReplayedSize += serialized.length + 1;
+      // Re-compute the tail fingerprint from the appended row so the next
+      // replayCached call can short-circuit. The on-disk content is the
+      // prior body + serialized + "\n"; we only need the trailing slice of
+      // that, which we can reconstruct from the fingerprint of the new
+      // row alone when it is longer than the fingerprint window, or by
+      // re-reading otherwise. Cheaper to invalidate and let replayCached
+      // refresh on next call when the row is short.
+      const appendedLine = serialized + "\n";
+      if (Buffer.byteLength(appendedLine, "utf8") >= TAIL_FINGERPRINT_BYTES)
+        this.lastReplayedTail = tailFingerprint(appendedLine);
+      else this.lastReplayedTail = null;
       this.logger?.log({
         level: "info",
         event: "ledger.append",
@@ -183,10 +208,12 @@ export class FileLedger implements LedgerAppender {
   }> {
     const body = await this.store.readText(LEDGER_TRANSITIONS_PATH);
     const currentSize = body == null ? 0 : Buffer.byteLength(body, "utf8");
+    const currentTail = body == null ? "" : tailFingerprint(body);
     if (
       this.cachedHead != null &&
       this.cachedAppliedKeys != null &&
-      this.lastReplayedSize === currentSize
+      this.lastReplayedSize === currentSize &&
+      this.lastReplayedTail === currentTail
     ) {
       return { head: this.cachedHead, appliedKeys: this.cachedAppliedKeys };
     }
@@ -194,6 +221,7 @@ export class FileLedger implements LedgerAppender {
     this.cachedHead = result.head;
     this.cachedAppliedKeys = result.appliedKeys;
     this.lastReplayedSize = currentSize;
+    this.lastReplayedTail = currentTail;
     return result;
   }
 
@@ -274,4 +302,20 @@ function stripHash(
   void _h;
   void _p;
   return rest;
+}
+
+/**
+ * Trailing-byte window used as a content fingerprint alongside the cached
+ * size. 256 bytes comfortably covers a complete ndjson row's audit_hash
+ * (64 hex chars) plus surrounding fields, so any same-size content swap
+ * by a sibling writer will alter the tail and force a re-replay.
+ */
+const TAIL_FINGERPRINT_BYTES = 256;
+
+function tailFingerprint(body: string): string {
+  // Slice on byte boundaries to keep the comparison stable for utf-8
+  // payloads. ndjson rows are ASCII-only in practice (schema enforces it),
+  // so the simpler string slice is sufficient.
+  if (body.length <= TAIL_FINGERPRINT_BYTES) return body;
+  return body.slice(body.length - TAIL_FINGERPRINT_BYTES);
 }

--- a/src/application/ledger.ts
+++ b/src/application/ledger.ts
@@ -56,21 +56,37 @@ export interface LedgerAppenderOptions {
 
 /**
  * Append-only ledger writer that maintains the audit_hash chain and rejects
- * rows whose idempotency_key has already been observed (recording the
- * duplicate as its own ledger row per SOC-IDEMPOTENCY).
+ * rows whose idempotency_key has already been observed.
  *
  * Concurrency model:
  *   - Every appendTransition acquires a store-level lock on
- *     `LEDGER_TRANSITIONS_PATH`. Inside that lock, the file is re-read so the
- *     audit_hash chain head and seenKeys set always reflect on-disk state,
- *     guaranteeing no fork even when multiple processes share one workdir.
+ *     `LEDGER_TRANSITIONS_PATH`. Inside that lock, the chain head and
+ *     appliedKeys set are kept consistent with on-disk state via an
+ *     in-memory cache invalidated when the file's byte length diverges from
+ *     the cached `lastReplayedSize` (e.g. a sibling process appended).
  *   - Replay strict-verifies every row's audit_hash_prev linkage and
  *     re-computes audit_hash; any deviation throws LedgerCorruptError.
+ *
+ * Idempotency policy (incident-2 P0): when an incoming row's idempotency_key
+ * was already applied, the file append is **skipped entirely**. The function
+ * still resolves with a synthesized row (result="duplicate", chained from
+ * the current head) and emits a `ledger.duplicate` log event for
+ * observability, but the audit chain head does not advance — duplicates are
+ * not persisted and therefore cannot affect the next applied row's
+ * `audit_hash_prev`.
  */
 export class FileLedger implements LedgerAppender {
   private readonly store: StorePort;
   private readonly logger?: LoggerPort;
   private readonly auditHashSeed?: string;
+  /**
+   * Per-process cache of the last replay result. Avoids O(n) re-parse per
+   * append in steady state. Invalidated when the file's byte length diverges
+   * from `lastReplayedSize` — covers external writers and absent files.
+   */
+  private cachedHead: string | null = null;
+  private cachedAppliedKeys: Set<string> | null = null;
+  private lastReplayedSize: number | null = null;
 
   constructor(opts: LedgerAppenderOptions) {
     this.store = opts.store;
@@ -80,7 +96,7 @@ export class FileLedger implements LedgerAppender {
 
   async lastAuditHash(): Promise<string> {
     return this.store.withFileLock(LEDGER_TRANSITIONS_PATH, async () => {
-      const replay = await this.replay();
+      const replay = await this.replayCached();
       return replay.head;
     });
   }
@@ -89,32 +105,59 @@ export class FileLedger implements LedgerAppender {
     rowWithoutHash: Omit<LedgerRow, "audit_hash" | "audit_hash_prev">,
   ): Promise<{ row: LedgerRow; result: "applied" | "duplicate" }> {
     return this.store.withFileLock(LEDGER_TRANSITIONS_PATH, async () => {
-      const replay = await this.replay();
+      const replay = await this.replayCached();
       const isDuplicate = replay.appliedKeys.has(rowWithoutHash.idempotency_key);
-      const declaredResult = rowWithoutHash.result;
-      const effectiveResult = isDuplicate ? "duplicate" : declaredResult;
-      const finalRowWithoutHash =
-        effectiveResult === declaredResult
-          ? rowWithoutHash
-          : { ...rowWithoutHash, result: effectiveResult };
       const prev = replay.head;
-      const hash = computeAuditHash(
-        prev,
-        finalRowWithoutHash,
-        this.auditHashSeed,
-      );
+      if (isDuplicate) {
+        // Synthesize a duplicate row representation for the caller without
+        // persisting. Chain head does NOT advance — the next applied row
+        // still chains off the last applied row.
+        const dupRowWithoutHash = { ...rowWithoutHash, result: "duplicate" as const };
+        const dupHash = computeAuditHash(prev, dupRowWithoutHash, this.auditHashSeed);
+        const dupRow: LedgerRow = LedgerRow.parse({
+          ...dupRowWithoutHash,
+          audit_hash_prev: prev,
+          audit_hash: dupHash,
+        });
+        this.logger?.log({
+          level: "info",
+          event: "ledger.duplicate",
+          fields: {
+            transition_id: dupRow.transition_id,
+            object_kind: dupRow.object_kind,
+            object_id: dupRow.object_id,
+            action_kind: dupRow.action_kind,
+            result: dupRow.result,
+            idempotency_key: dupRow.idempotency_key,
+          },
+        });
+        return { row: dupRow, result: "duplicate" };
+      }
+      const hash = computeAuditHash(prev, rowWithoutHash, this.auditHashSeed);
       const row: LedgerRow = LedgerRow.parse({
-        ...finalRowWithoutHash,
+        ...rowWithoutHash,
         audit_hash_prev: prev,
         audit_hash: hash,
       });
-      await this.store.appendLine(
-        LEDGER_TRANSITIONS_PATH,
-        JSON.stringify(row),
-      );
+      const serialized = JSON.stringify(row);
+      await this.store.appendLine(LEDGER_TRANSITIONS_PATH, serialized);
+      // Advance the in-memory cache after a successful applied write. The
+      // appendLine implementation adds a trailing newline iff missing, so
+      // size delta is serialized.length + 1.
+      this.cachedHead = row.audit_hash;
+      if (
+        row.result === "applied" ||
+        row.result === "recovered" ||
+        row.result === "rolled_back" ||
+        row.result === "escalated"
+      )
+        replay.appliedKeys.add(row.idempotency_key);
+      this.cachedAppliedKeys = replay.appliedKeys;
+      if (this.lastReplayedSize != null)
+        this.lastReplayedSize += serialized.length + 1;
       this.logger?.log({
         level: "info",
-        event: isDuplicate ? "ledger.duplicate" : "ledger.append",
+        event: "ledger.append",
         fields: {
           transition_id: row.transition_id,
           object_kind: row.object_kind,
@@ -124,8 +167,38 @@ export class FileLedger implements LedgerAppender {
           idempotency_key: row.idempotency_key,
         },
       });
-      return { row, result: isDuplicate ? "duplicate" : "applied" };
+      return { row, result: "applied" };
     });
+  }
+
+  /**
+   * Returns the cached replay result if the on-disk file size matches the
+   * cached size; otherwise re-reads and re-replays. Cache is per-instance so
+   * separate FileLedger objects (even pointed at the same store) each see a
+   * fresh replay until they prime their cache.
+   */
+  private async replayCached(): Promise<{
+    head: string;
+    appliedKeys: Set<string>;
+  }> {
+    const body = await this.store.readText(LEDGER_TRANSITIONS_PATH);
+    const currentSize = body == null ? 0 : Buffer.byteLength(body, "utf8");
+    if (
+      this.cachedHead != null &&
+      this.cachedAppliedKeys != null &&
+      this.lastReplayedSize === currentSize
+    ) {
+      return { head: this.cachedHead, appliedKeys: this.cachedAppliedKeys };
+    }
+    const result = body == null ? this.emptyReplay() : this.replayBody(body);
+    this.cachedHead = result.head;
+    this.cachedAppliedKeys = result.appliedKeys;
+    this.lastReplayedSize = currentSize;
+    return result;
+  }
+
+  private emptyReplay(): { head: string; appliedKeys: Set<string> } {
+    return { head: AUDIT_HASH_GENESIS, appliedKeys: new Set<string>() };
   }
 
   /**
@@ -133,15 +206,17 @@ export class FileLedger implements LedgerAppender {
    *   - each row passes schema parsing
    *   - audit_hash_prev equals the prior row's audit_hash (genesis for first)
    *   - audit_hash equals the recomputed hash
-   * Throws LedgerCorruptError on any deviation. The seenKeys set tracks rows
-   * with result="applied" (or terminal recovery results) so that retries hit
-   * the duplicate path.
+   * Throws LedgerCorruptError on any deviation. The appliedKeys set tracks
+   * rows with result="applied" (or terminal recovery results) so retries hit
+   * the duplicate path. Note: as of incident-2 P0, duplicate rows are no
+   * longer persisted, so they cannot appear during replay; if a legacy
+   * `result="duplicate"` row is encountered (older ledgers), it advances the
+   * chain head exactly as it did historically but does not re-add to
+   * appliedKeys (the original applied row already did).
    */
-  private async replay(): Promise<{ head: string; appliedKeys: Set<string> }> {
-    const body = await this.store.readText(LEDGER_TRANSITIONS_PATH);
+  private replayBody(body: string): { head: string; appliedKeys: Set<string> } {
     const appliedKeys = new Set<string>();
     let head = AUDIT_HASH_GENESIS;
-    if (body == null) return { head, appliedKeys };
     const lines = body.split("\n");
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];

--- a/tests/adapters/store-fs.test.ts
+++ b/tests/adapters/store-fs.test.ts
@@ -113,6 +113,16 @@ describe("FsStore", () => {
     expect(counter).toBe(20);
   });
 
+  it("incident-2 P0: lockTimeoutMs default is 30000ms", async () => {
+    const s = new FsStore({ workdir });
+    // Read the private field via index access. The constructor stores the
+    // resolved option so any future reorganization that changes the default
+    // away from 30s will break this sanity check.
+    expect((s as unknown as { lockTimeoutMs: number }).lockTimeoutMs).toBe(
+      30_000,
+    );
+  });
+
   it("orphaned lock is reclaimed within raceWindowMs (P2-6)", async () => {
     // Custom store with short raceWindowMs so the test runs quickly. The
     // production default is 1000ms; we use 50ms here to exercise the same

--- a/tests/application/control-state.test.ts
+++ b/tests/application/control-state.test.ts
@@ -12,10 +12,11 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { FsStore } from "../../src/adapters/store/fs.js";
 import {
   CONTROL_STATE_PATH,
+  __resetDaemonPreludeMemo,
   applyControlSignal,
   readControlState,
   runDaemonPrelude,
@@ -255,6 +256,10 @@ describe("applyControlSignal", () => {
 });
 
 describe("runDaemonPrelude", () => {
+  beforeEach(() => {
+    __resetDaemonPreludeMemo();
+  });
+
   it("RUNNING → proceed, no ledger row", async () => {
     const store = new FsStore({ workdir: workdir() });
     const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
@@ -299,7 +304,7 @@ describe("runDaemonPrelude", () => {
     expect(rows[0]?.result_detail).toMatch(/sig-pause/);
   });
 
-  it("PAUSED noop is idempotent across daemon loops (same signal_id)", async () => {
+  it("incident-2 P0 #5: PAUSED loop self-throttles — only one noop row per (role, signal_id, state)", async () => {
     const store = new FsStore({ workdir: workdir() });
     const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
     const ledger = makeLedger(store);
@@ -307,6 +312,34 @@ describe("runDaemonPrelude", () => {
       store,
       clock,
       controlSignal({ signal_id: "sig-pause", signal_type: "pause" }),
+    );
+    for (let i = 0; i < 5; i++) {
+      const out = await runDaemonPrelude({
+        store,
+        clock,
+        ledger,
+        callerId: "test-caller",
+        targetId: "test-target",
+        role: "turn-worker",
+      });
+      expect(out.action).toBe("paused");
+    }
+    const rows = await readLedgerRows(store);
+    // Per-process prelude memo prevents repeat appends for the same
+    // (signal_id, state) tuple. A new pause signal would still produce a
+    // fresh row.
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.result).toBe("noop");
+  });
+
+  it("incident-2 P0 #5: prelude memo re-emits when signal_id changes (resume → re-pause)", async () => {
+    const store = new FsStore({ workdir: workdir() });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = makeLedger(store);
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause-1", signal_type: "pause" }),
     );
     await runDaemonPrelude({
       store,
@@ -316,6 +349,16 @@ describe("runDaemonPrelude", () => {
       targetId: "test-target",
       role: "turn-worker",
     });
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-resume-1", signal_type: "resume" }),
+    );
+    await applyControlSignal(
+      store,
+      clock,
+      controlSignal({ signal_id: "sig-pause-2", signal_type: "pause" }),
+    );
     await runDaemonPrelude({
       store,
       clock,
@@ -325,14 +368,9 @@ describe("runDaemonPrelude", () => {
       role: "turn-worker",
     });
     const rows = await readLedgerRows(store);
-    // Both rows persist as `noop` — the ledger's dedup only folds
-    // applied/recovered/rolled_back/escalated. Operators see one row per
-    // loop they spent paused, but the shared idempotency_key keeps the
-    // audit trail traceable to a single signal.
-    expect(rows.length).toBe(2);
-    expect(rows[0]?.result).toBe("noop");
-    expect(rows[1]?.result).toBe("noop");
-    expect(rows[0]?.idempotency_key).toBe(rows[1]?.idempotency_key);
+    const noopRows = rows.filter((r) => r.result === "noop");
+    expect(noopRows.length).toBe(2);
+    expect(noopRows[0]?.idempotency_key).not.toBe(noopRows[1]?.idempotency_key);
   });
 
   it("a different role with the same paused signal emits its own noop row", async () => {

--- a/tests/application/ledger.test.ts
+++ b/tests/application/ledger.test.ts
@@ -146,7 +146,7 @@ describe("FileLedger", () => {
     expect(r2.row.audit_hash).not.toBe(r1.row.audit_hash);
   });
 
-  it("records a duplicate row per SOC-IDEMPOTENCY when key reappears", async () => {
+  it("incident-2 P0: duplicate idempotency_key is NOT persisted to disk", async () => {
     const store = new MemoryStore();
     const ledger = new FileLedger({ store });
     const r1 = await ledger.appendTransition(baseRow({}));
@@ -158,23 +158,64 @@ describe("FileLedger", () => {
     expect(r2.result).toBe("duplicate");
     expect(r2.row.result).toBe("duplicate");
     expect(r2.row.idempotency_key).toBe(r1.row.idempotency_key);
+    // Synthesized duplicate row's audit_hash_prev still points at the
+    // current head (r1) for caller diagnostics, but the row itself is
+    // never written.
     expect(r2.row.audit_hash_prev).toBe(r1.row.audit_hash);
     const body = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
-    expect(body.split("\n").filter(Boolean).length).toBe(2);
+    expect(body.split("\n").filter(Boolean).length).toBe(1);
   });
 
-  it("subsequent applied rows chain off the duplicate row", async () => {
+  it("incident-2 P0: subsequent applied rows chain off the last APPLIED row, not the duplicate", async () => {
     const store = new MemoryStore();
     const ledger = new FileLedger({ store });
     const r1 = await ledger.appendTransition(baseRow({}));
     const r2 = await ledger.appendTransition(
       baseRow({ transition_id: TX_ID_2 }),
     );
+    expect(r2.result).toBe("duplicate");
     const r3 = await ledger.appendTransition(
       baseRow({ transition_id: TX_ID_3, idempotency_key: "k3" }),
     );
     expect(r3.result).toBe("applied");
-    expect(r3.row.audit_hash_prev).toBe(r2.row.audit_hash);
+    expect(r3.row.audit_hash_prev).toBe(r1.row.audit_hash);
+    // File has exactly r1 + r3 (duplicate r2 was not persisted).
+    const body = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+    expect(body.split("\n").filter(Boolean).length).toBe(2);
+  });
+
+  it("incident-2 P0: 1000 same-key duplicate appends grow the file exactly once (cache smoke)", async () => {
+    const store = new MemoryStore();
+    const ledger = new FileLedger({ store });
+    await ledger.appendTransition(baseRow({}));
+    for (let i = 0; i < 1000; i++) {
+      const out = await ledger.appendTransition(
+        baseRow({ transition_id: TX_ID_2 }),
+      );
+      expect(out.result).toBe("duplicate");
+    }
+    const body = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+    expect(body.split("\n").filter(Boolean).length).toBe(1);
+  });
+
+  it("incident-2 P0: external writer (sibling FileLedger) invalidates the cache on next append", async () => {
+    const store = new MemoryStore();
+    const a = new FileLedger({ store });
+    const b = new FileLedger({ store });
+    // Prime a's cache.
+    const ra = await a.appendTransition(baseRow({}));
+    // b writes through the same store while a still holds a stale cache.
+    const rb = await b.appendTransition(
+      baseRow({ transition_id: TX_ID_2, idempotency_key: "k2" }),
+    );
+    expect(rb.row.audit_hash_prev).toBe(ra.row.audit_hash);
+    // a's next append must observe b's row (file size diverged from
+    // a.lastReplayedSize → forced re-replay).
+    const ra2 = await a.appendTransition(
+      baseRow({ transition_id: TX_ID_3, idempotency_key: "k3" }),
+    );
+    expect(ra2.result).toBe("applied");
+    expect(ra2.row.audit_hash_prev).toBe(rb.row.audit_hash);
   });
 
   it("auditHashSeed alters the chain", async () => {
@@ -196,12 +237,12 @@ describe("FileLedger", () => {
     expect(await ledger2.lastAuditHash()).toBe(r1.row.audit_hash);
     const dup = await ledger2.appendTransition(baseRow({}));
     expect(dup.result).toBe("duplicate");
-    // Duplicate row chains forward — head advances.
-    expect(await ledger2.lastAuditHash()).toBe(dup.row.audit_hash);
+    // incident-2 P0: duplicate is not persisted, head does NOT advance.
+    expect(await ledger2.lastAuditHash()).toBe(r1.row.audit_hash);
     const r3 = await ledger2.appendTransition(
       baseRow({ transition_id: TX_ID_3, idempotency_key: "k3" }),
     );
-    expect(r3.row.audit_hash_prev).toBe(dup.row.audit_hash);
+    expect(r3.row.audit_hash_prev).toBe(r1.row.audit_hash);
   });
 
   it("multi-instance writers see the latest head via withFileLock (no fork)", async () => {

--- a/tests/application/ledger.test.ts
+++ b/tests/application/ledger.test.ts
@@ -184,6 +184,128 @@ describe("FileLedger", () => {
     expect(body.split("\n").filter(Boolean).length).toBe(2);
   });
 
+  it("PR #94 P1-D: emits ledger.duplicate log event exactly once per duplicate append", async () => {
+    const store = new MemoryStore();
+    const logger = new CollectingLogger();
+    const ledger = new FileLedger({ store, logger });
+    const r1 = await ledger.appendTransition(baseRow({}));
+    expect(r1.result).toBe("applied");
+    const r2 = await ledger.appendTransition(
+      baseRow({ transition_id: TX_ID_2 }),
+    );
+    expect(r2.result).toBe("duplicate");
+    const dupEvents = logger.events.filter(
+      (e) => e.event === "ledger.duplicate",
+    );
+    expect(dupEvents.length).toBe(1);
+    expect(dupEvents[0]?.fields).toMatchObject({
+      idempotency_key: r1.row.idempotency_key,
+      result: "duplicate",
+    });
+  });
+
+  it("PR #94 P0-1: same-byte external content swap forces re-replay (tail fingerprint)", async () => {
+    const store = new MemoryStore();
+    const a = new FileLedger({ store });
+    // Prime a's cache with a single applied row.
+    const ra = await a.appendTransition(baseRow({}));
+    const bodyAfterA = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+    // External writer (sibling FileLedger b) replaces the ndjson with a
+    // *different* row whose serialized byte length matches ra's exactly.
+    // Without the tail fingerprint, a's cache would short-circuit on the
+    // (still-equal) lastReplayedSize and chain its next applied row off
+    // the now-stale cachedHead, corrupting the audit_hash chain.
+    const b = new FileLedger({ store });
+    // Build an alternate single-row body; pick fields so the serialized
+    // length matches bodyAfterA. transition_id and idempotency_key both
+    // have fixed lengths in baseRow, so we can simply re-prime b on a
+    // fresh store with a different idempotency_key/transition_id and
+    // swap b's body in for a's.
+    const altStore = new MemoryStore();
+    const bSeed = new FileLedger({ store: altStore });
+    // Alt idempotency_key is chosen to match the original key's byte length
+    // exactly so the serialized row's overall length is identical (the only
+    // other variable-length field is audit_hash[_prev] which is fixed at
+    // 64 hex chars). This is the worst-case input for the size-only cache:
+    // an external writer swap that is byte-equivalent in size.
+    const altKey = "intake|kind=human_seed&id=issue:9";
+    expect(altKey.length).toBe(
+      "intake|kind=human_seed&id=issue:1".length,
+    );
+    const rb = await bSeed.appendTransition(
+      baseRow({ transition_id: TX_ID_2, idempotency_key: altKey }),
+    );
+    const bodyAlt = (await altStore.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+    // Sanity: same byte length, different content (different audit_hash
+    // line means same-size swap is realistic).
+    expect(bodyAlt.length).toBe(bodyAfterA.length);
+    expect(bodyAlt).not.toBe(bodyAfterA);
+    await store.writeAtomic(LEDGER_TRANSITIONS_PATH, bodyAlt);
+    // a's next append must observe the swap: audit_hash_prev should be
+    // rb's audit_hash (the new tail), NOT ra's stale cachedHead.
+    void b;
+    const ra2 = await a.appendTransition(
+      baseRow({ transition_id: TX_ID_3, idempotency_key: "k3" }),
+    );
+    expect(ra2.result).toBe("applied");
+    expect(ra2.row.audit_hash_prev).toBe(rb.row.audit_hash);
+  });
+
+  it("PR #94 P0-2: concurrent runDaemonPrelude calls for the same role emit exactly one noop row", async () => {
+    // Singleflight regression: two callers from the same role race into
+    // the gate simultaneously; both observe non-RUNNING + miss memo;
+    // without the in-flight registry both would appendTransition. With
+    // the singleflight, the second call awaits the first's promise and
+    // returns its outcome.
+    const { FsStore } = await import("../../src/adapters/store/fs.js");
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const {
+      __resetDaemonPreludeMemo,
+      applyControlSignal,
+      runDaemonPrelude,
+    } = await import("../../src/application/control-state.js");
+    const { HumanSignalEnvelope } = await import(
+      "../../src/domain/schema/human-signal.js"
+    );
+    const { FixedClock } = await import("../../src/ports/clock.js");
+    __resetDaemonPreludeMemo();
+    const store = new FsStore({ workdir: mkdtempSync(join(tmpdir(), "p94-")) });
+    const clock = new FixedClock(Date.parse("2026-05-09T00:00:00.000Z"));
+    const ledger = new FileLedger({ store, auditHashSeed: "seed-94" });
+    await applyControlSignal(
+      store,
+      clock,
+      HumanSignalEnvelope.parse({
+        target_kind: "system",
+        target_id: "system",
+        actor: "operator",
+        created_at: "2026-05-09T00:00:00.000Z",
+        source: "fs_drop",
+        signal_id: "sig-pause",
+        signal_type: "pause",
+      }),
+    );
+    const deps = {
+      store,
+      clock,
+      ledger,
+      callerId: "test-caller",
+      targetId: "test-target",
+      role: "turn-worker",
+    };
+    const [a, b] = await Promise.all([
+      runDaemonPrelude(deps),
+      runDaemonPrelude(deps),
+    ]);
+    expect(a.action).toBe("paused");
+    expect(b.action).toBe("paused");
+    const body = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+    const lines = body.split("\n").filter((s) => s.length > 0);
+    expect(lines.length).toBe(1);
+  });
+
   it("incident-2 P0: 1000 same-key duplicate appends grow the file exactly once (cache smoke)", async () => {
     const store = new MemoryStore();
     const ledger = new FileLedger({ store });

--- a/tests/integration/lease-recovery.test.ts
+++ b/tests/integration/lease-recovery.test.ts
@@ -488,13 +488,13 @@ describe("Phase 4 lease + recovery integration", () => {
     });
     expect(second.expiredLeases.length).toBe(1);
     const afterRows = readLedgerRows(workdir).length;
-    // The duplicate recover rows must be absorbed by ledger dedup. They
-    // still get APPENDED but with result=duplicate.
+    // incident-2 P0: duplicate rows are now NOT persisted to disk. The
+    // ledger absorbs them entirely — file row count stays flat across the
+    // re-run sweep.
+    expect(afterRows).toBe(beforeRows);
     const duplicateRows = readLedgerRows(workdir).filter(
       (r) => r.result === "duplicate",
     );
-    expect(duplicateRows.length).toBeGreaterThanOrEqual(1);
-    void beforeRows;
-    void afterRows;
+    expect(duplicateRows.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Skip file append when `appendTransition` is a duplicate (idempotency_key already applied) — stops O(n²) ledger growth from paused-daemon noop emissions.
- Cache `replay()` result per-process (FileLedger in-memory head + appliedKeys, invalidate on stat-size mismatch) — drops steady-state appendTransition cost from O(n) to O(1).
- Bump `FsStore.lockTimeoutMs` default 5s → 30s as defense-in-depth.
- `runDaemonPrelude` self-throttles per-role (signal_id, state) so same-state cycles skip appendTransition entirely.

## Test plan
- [x] npm run typecheck
- [x] npm run test (912 passing, was 904)
- [x] npm run build

Refs: incident-2 (run `/Users/macpro/llm-team-runs/20260510T015239Z/incident-2.md`). Resolves the ledger lock-timeout crash that killed all 6 daemon roles after the live run accumulated 10k duplicate noop rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)