### PR TITLE
fix(manifest-resolve): inline (session_turn, body) so Discovery converges (incident-5)

### DIFF
--- a/src/application/manifest-builder.ts
+++ b/src/application/manifest-builder.ts
@@ -30,6 +30,11 @@ export interface ManifestEntryDraft {
   fetch_scope: FetchScope;
   required: boolean;
   purpose: string;
+  /**
+   * incident-5 — populated for `(session_turn, body)` drafts so the
+   * downstream resolver can locate `sessions/<id>/turns/<n>.json`.
+   */
+  turn_index?: number;
 }
 
 export interface RevisionPinResolver {
@@ -53,13 +58,14 @@ export class ManifestBuilder {
   async build(input: BuildManifestInput): Promise<ContextManifestT> {
     const entries: ManifestEntry[] = [];
     for (const d of input.drafts) {
-      const partial = {
+      const partial: Omit<ManifestEntry, "token_estimate"> = {
         object_kind: d.object_kind,
         object_id: d.object_id,
         fetch_scope: d.fetch_scope,
         revision_pin: await this.resolver.resolve(d),
         required: d.required,
         purpose: d.purpose,
+        ...(d.turn_index != null ? { turn_index: d.turn_index } : {}),
       };
       // TCC-CONTEXT-BUDGET / phase 8a — char/4 heuristic over the entry's
       // serialized header. Body fetch is not required at manifest-build
@@ -92,6 +98,7 @@ export class ManifestBuilder {
         fetch_scope: e.fetch_scope,
         required: e.required,
         purpose: e.purpose,
+        ...(e.turn_index != null ? { turn_index: e.turn_index } : {}),
       });
       if (current !== e.revision_pin) stale.push(e);
     }

--- a/src/application/manifest-resolve.ts
+++ b/src/application/manifest-resolve.ts
@@ -2,6 +2,7 @@ import type { ContextManifest, ManifestEntry } from "../domain/schema/manifest.j
 import type { StorePort } from "../ports/store.js";
 import { Milestone } from "../domain/schema/milestone.js";
 import { FeatureRequest } from "../domain/schema/feature-request.js";
+import { SessionTurn } from "../domain/schema/session-turn.js";
 import { layout } from "./persistence-layout.js";
 
 /**
@@ -95,16 +96,19 @@ async function resolveEntry(
   if (entry.object_kind === "milestone" && entry.fetch_scope === "body") {
     return resolveMilestoneBody(store, entry);
   }
-  // Other (kind, scope) pairs are out of scope for incident-1b. For
-  // `required=true` entries the resolver throws so the caller can surface an
-  // AGC-INVALID outcome (no silent empty prompt). For non-required entries
-  // the caller catches and skips (entry omitted from `# Inputs`). Future work
-  // can extend this switch with slice / slice_merge / dialogue_session /
-  // session_turn / verification_run resolution.
+  if (entry.object_kind === "session_turn" && entry.fetch_scope === "body") {
+    return resolveSessionTurnBody(store, entry);
+  }
+  // Other (kind, scope) pairs remain out of scope. For `required=true`
+  // entries the resolver throws so the caller can surface an AGC-INVALID
+  // outcome (no silent empty prompt). For non-required entries the caller
+  // catches and skips (entry omitted from `# Inputs`). Future work can
+  // extend this switch with slice / slice_merge / dialogue_session /
+  // verification_run resolution.
   if (entry.required) {
     throw new UnsupportedManifestEntryError(
       entry,
-      "resolver supports only (milestone, body) at incident-1b minimum",
+      "resolver supports (milestone, body) and (session_turn, body) only",
     );
   }
   return null;
@@ -156,4 +160,92 @@ async function resolveMilestoneBody(
   }
 
   return sections.join("\n\n");
+}
+
+/**
+ * incident-5 — resolve `(session_turn, body)` so Discovery atlas/sentinel
+ * can read prior turn rationales (especially reviewer `request_changes`)
+ * inline under `# Inputs` instead of looping forever in
+ * `request_changes ↔ need_context`.
+ *
+ * Layout: `sessions/<session_id>/turns/<turn_index>.json`. The persisted
+ * body is a SessionTurn record; we render only the agent-relevant fields
+ * (agent_profile_id, role, output_kind, summary, verdict, failure,
+ * next_action_request) so the prompt stays bounded — the full record can
+ * include adapter trace metadata that does not help the next turn.
+ *
+ * `entry.turn_index` is the new schema field (also pre-incident-5
+ * manifests embedded the index in `object_id` as `${session_id}#${i}`;
+ * we fall back to that legacy form so any in-flight manifest still
+ * resolves).
+ *
+ * Revision pin matches OuterPinResolver's session_turn fingerprint:
+ * `len=<bodyLength>:<first 32 non-whitespace chars>`. Mismatches surface
+ * StaleManifestEntryError for required entries (mirrors milestone body).
+ */
+async function resolveSessionTurnBody(
+  store: StorePort,
+  entry: ManifestEntry,
+): Promise<string | null> {
+  const sessionId = entry.object_id.includes("#")
+    ? entry.object_id.split("#")[0]!
+    : entry.object_id;
+  const turnIndex =
+    entry.turn_index ??
+    (entry.object_id.includes("#")
+      ? Number.parseInt(entry.object_id.split("#")[1]!, 10)
+      : NaN);
+  if (!Number.isInteger(turnIndex) || turnIndex < 0) {
+    if (entry.required) {
+      throw new UnsupportedManifestEntryError(
+        entry,
+        "session_turn entry must carry turn_index (or legacy ${session_id}#${i} object_id)",
+      );
+    }
+    return null;
+  }
+  const path = layout.sessionTurn(sessionId, turnIndex);
+  const raw = await store.readText(path);
+  if (raw == null) {
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  // Revision-pin check — must agree with OuterPinResolver.session_turn
+  // fingerprint format. Stale ⇒ throw for required, skip for non-required.
+  const expectedPin = `len=${raw.length}:${raw.slice(0, 32).replace(/\s+/g, "")}`;
+  if (expectedPin !== entry.revision_pin) {
+    if (entry.required) {
+      throw new StaleManifestEntryError(entry, expectedPin);
+    }
+    return null;
+  }
+  let turn: ReturnType<typeof SessionTurn.parse>;
+  try {
+    turn = SessionTurn.parse(JSON.parse(raw));
+  } catch {
+    // Persisted file is corrupt / not a SessionTurn; treat as missing.
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  const env = turn.output_envelope;
+  // Project the agent-relevant subset; full envelope can include adapter
+  // metadata that does not help the next turn. Keep deterministic key
+  // ordering for stable prompt diffs.
+  const projection: Record<string, unknown> = {
+    session_id: turn.session_id,
+    turn_index: turn.turn_index,
+    agent_profile_id: turn.agent_profile_id,
+    agent_role_in_session: env.agent_role_in_session,
+    output_kind: env.output_kind,
+    contribution_kind: env.contribution_kind,
+    summary: env.summary,
+    verdict: env.verdict,
+    failure: env.failure,
+    next_action_request: env.next_action_request,
+  };
+  return JSON.stringify(projection, null, 2);
 }

--- a/src/application/manifest-resolve.ts
+++ b/src/application/manifest-resolve.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ContextManifest, ManifestEntry } from "../domain/schema/manifest.js";
 import type { StorePort } from "../ports/store.js";
 import { Milestone } from "../domain/schema/milestone.js";
@@ -17,16 +18,28 @@ import { layout } from "./persistence-layout.js";
  * list of `ResolvedEntry` records that the prompt composer renders verbatim
  * under a new `# Inputs` section.
  *
- * Scope (incident-1b minimal):
+ * Scope (incident-1b minimum + incident-5):
  *   - `milestone` + `body` — load `milestones/<id>.json`, render title + intake
  *     source body (when the intake source is a `feature_request` we fetch the
  *     `feature_requests/<id>.json` body). Optionally append `milestones/<id>/spec.md`
  *     when present.
+ *   - `session_turn` + `body` — incident-5: load
+ *     `sessions/<session_id>/turns/<turn_index>.json` and project the
+ *     agent-relevant subset under `# Inputs` so prior reviewer rationales
+ *     reach the next lead/reviewer (breaks the
+ *     `request_changes ↔ need_context` Discovery loop).
  *   - Other (object_kind, fetch_scope) combinations throw an explicit
  *     "unsupported" error. The caller decides:
  *       - `required=true` → surface the error (caller turns into AGC-INVALID),
  *       - `required=false` → skip silently (entry omitted from `# Inputs`,
  *         prompt still renders so the agent can decide).
+ *
+ * TODO(incident-6+): slice / slice_merge / dialogue_session / verification_run
+ * resolvers — separate cycle. turn-worker (inner loop) and
+ * dialogue-coordinator (middle loop) currently DO NOT wire `StorePort` into
+ * `resolveManifestEntries`; only outer-turn does. Inner/middle loops still
+ * inline their own (slice, body) reads via composePrompt's legacy path until
+ * those resolvers exist here.
  *
  * Caller is `agent-io.callAgent` via the new optional `store` dep.
  */
@@ -180,8 +193,11 @@ async function resolveMilestoneBody(
  * resolves).
  *
  * Revision pin matches OuterPinResolver's session_turn fingerprint:
- * `len=<bodyLength>:<first 32 non-whitespace chars>`. Mismatches surface
- * StaleManifestEntryError for required entries (mirrors milestone body).
+ * full-body `sha256(raw)` hex (PR #96 P0-1 — replaces the original
+ * `len=<n>:<first 32 chars>` form, which silently passed when post-prefix
+ * fields like summary/verdict.rationale/failure/next_action_request changed
+ * without altering body length). Mismatches surface StaleManifestEntryError
+ * for required entries (mirrors milestone body).
  */
 async function resolveSessionTurnBody(
   store: StorePort,
@@ -214,7 +230,11 @@ async function resolveSessionTurnBody(
   }
   // Revision-pin check — must agree with OuterPinResolver.session_turn
   // fingerprint format. Stale ⇒ throw for required, skip for non-required.
-  const expectedPin = `len=${raw.length}:${raw.slice(0, 32).replace(/\s+/g, "")}`;
+  // PR #96 P0-1: full-body sha256 hex. The previous `len=N:<first 32 chars>`
+  // form missed mutations in summary / verdict.rationale / failure /
+  // next_action_request when the new body happened to be the same length,
+  // letting a stale-context turn pass the gate.
+  const expectedPin = createHash("sha256").update(raw).digest("hex");
   if (expectedPin !== entry.revision_pin) {
     if (entry.required) {
       throw new StaleManifestEntryError(entry, expectedPin);

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -347,7 +347,14 @@ export async function runOneOuterTurn(
       t.verdict?.result === "request_changes" ? " (request_changes)" : "";
     drafts.push({
       object_kind: "session_turn",
-      object_id: `${session.session_id}#${i}`,
+      // incident-5: object_id is the session id; the per-entry `turn_index`
+      // distinguishes which `sessions/<id>/turns/<n>.json` the resolver
+      // reads. Prior to incident-5 this was encoded as
+      // `${session_id}#${i}` and parsed by OuterPinResolver — replaced by
+      // the schema-level field so resolveManifestEntries can also locate
+      // the turn file.
+      object_id: session.session_id,
+      turn_index: i,
       fetch_scope: "body",
       required: false,
       purpose: `prior turn ${i} (${t.agent_role_in_session})${rcSuffix}`,
@@ -1010,18 +1017,22 @@ class OuterPinResolver implements RevisionPinResolver {
     }
     if (entry.object_kind === "session_turn") {
       // PR #69 P1-3: prior turn entries are pinned by the persisted body's
-      // hash-equivalent — we just use the turn body length + first 64
+      // hash-equivalent — we just use the turn body length + first 32
       // chars as a stable fingerprint (no native crypto needed for a
       // Phase-5 manifest pin). Turn bodies are append-only so this is
       // stable until/unless the turn is rewritten.
-      const idxStr = entry.object_id.includes("#")
-        ? entry.object_id.split("#")[1]!
-        : "0";
-      const idx = Number.parseInt(idxStr, 10);
+      // incident-5: prefer the schema-level `turn_index`; fall back to
+      // legacy `${session_id}#${i}` parsing for any in-flight manifests
+      // built before the field was introduced.
+      const idx =
+        entry.turn_index ??
+        (entry.object_id.includes("#")
+          ? Number.parseInt(entry.object_id.split("#")[1]!, 10)
+          : 0);
       const body = await this.store.readText(
         layout.sessionTurn(this.sessionId, idx),
       );
-      if (body == null) return `missing:${entry.object_id}`;
+      if (body == null) return `missing:${entry.object_id}#${idx}`;
       return `len=${body.length}:${body.slice(0, 32).replace(/\s+/g, "")}`;
     }
     if (entry.object_kind === "slice_telemetry") {

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -45,6 +45,7 @@
  * step takes its own `withFileLock(milestonePath)` inside
  * `dispatchOuterOutcome`.
  */
+import { createHash } from "node:crypto";
 import { newMonotonicId } from "../domain/ids.js";
 import {
   DialogueSession,
@@ -1017,23 +1018,33 @@ class OuterPinResolver implements RevisionPinResolver {
     }
     if (entry.object_kind === "session_turn") {
       // PR #69 P1-3: prior turn entries are pinned by the persisted body's
-      // hash-equivalent — we just use the turn body length + first 32
-      // chars as a stable fingerprint (no native crypto needed for a
-      // Phase-5 manifest pin). Turn bodies are append-only so this is
-      // stable until/unless the turn is rewritten.
+      // hash. Turn bodies are append-only so the hash is stable until/unless
+      // the turn is rewritten.
+      // PR #96 P0-1: full-body sha256 hex (replaces the previous
+      // `len=N:<first 32 chars>` fingerprint, which missed mutations in
+      // summary / verdict.rationale / failure / next_action_request when the
+      // new body happened to be the same length).
       // incident-5: prefer the schema-level `turn_index`; fall back to
       // legacy `${session_id}#${i}` parsing for any in-flight manifests
       // built before the field was introduced.
-      const idx =
-        entry.turn_index ??
-        (entry.object_id.includes("#")
-          ? Number.parseInt(entry.object_id.split("#")[1]!, 10)
-          : 0);
+      // PR #96 P1-D: when neither the schema field nor the legacy `#` suffix
+      // supplies a turn index, surface an explicit "no_turn_index" sentinel
+      // pin instead of silently defaulting to turn 0 (which would fingerprint
+      // an unrelated turn body and either falsely pass or surface a
+      // misleading stale-pin diagnostic).
+      let idx: number;
+      if (entry.turn_index != null) {
+        idx = entry.turn_index;
+      } else if (entry.object_id.includes("#")) {
+        idx = Number.parseInt(entry.object_id.split("#")[1]!, 10);
+      } else {
+        return `missing:${entry.object_id}:no_turn_index`;
+      }
       const body = await this.store.readText(
         layout.sessionTurn(this.sessionId, idx),
       );
       if (body == null) return `missing:${entry.object_id}#${idx}`;
-      return `len=${body.length}:${body.slice(0, 32).replace(/\s+/g, "")}`;
+      return createHash("sha256").update(body).digest("hex");
     }
     if (entry.object_kind === "slice_telemetry") {
       // KAC-SLICE-TELEMETRY (phase 8b): pin = telemetry audit_hash. Drift

--- a/src/domain/schema/manifest.ts
+++ b/src/domain/schema/manifest.ts
@@ -60,6 +60,15 @@ export const ManifestEntry = z
      * backward compatibility with manifests created before phase 8a.
      */
     token_estimate: z.number().int().nonnegative().optional(),
+    /**
+     * incident-5 — for `(session_turn, body)` entries the resolver needs to
+     * know which turn file under `sessions/<session_id>/turns/<n>.json` to
+     * read; `object_id` carries the session id, but the turn index is a
+     * separate dimension. Optional for backward compatibility — entries that
+     * are not session_turn-bodied ignore it; the resolver throws when
+     * required for session_turn body resolution.
+     */
+    turn_index: z.number().int().nonnegative().optional(),
   })
   .strict();
 export type ManifestEntry = z.infer<typeof ManifestEntry>;

--- a/tests/application/agent-io.test.ts
+++ b/tests/application/agent-io.test.ts
@@ -531,7 +531,9 @@ describe("callAgent — manifest body inline (incident-1b Bug B)", () => {
     };
     const turnRaw = JSON.stringify(priorTurn);
     await store.writeAtomic(layout.sessionTurn(SESSION_ID, 1), turnRaw);
-    const turnPin = `len=${turnRaw.length}:${turnRaw.slice(0, 32).replace(/\s+/g, "")}`;
+    // PR #96 P0-1: full-body sha256 hex (replaces previous `len=N:<first 32>` form).
+    const { createHash } = await import("node:crypto");
+    const turnPin = createHash("sha256").update(turnRaw).digest("hex");
 
     const manifest = ContextManifest.parse({
       manifest_id: MANIFEST_ID,

--- a/tests/application/agent-io.test.ts
+++ b/tests/application/agent-io.test.ts
@@ -436,4 +436,146 @@ describe("callAgent — manifest body inline (incident-1b Bug B)", () => {
       expect(out.reason).toBe("prompt_layout_violation");
     }
   });
+
+  /**
+   * incident-5 — Discovery atlas/sentinel were stuck looping because
+   * manifest entries for prior `(session_turn, body)` were silently
+   * dropped (resolver only knew `(milestone, body)`). End-to-end check:
+   * with the resolver extended, a session_turn body is rendered inline
+   * under `## Inputs` so the next turn can read the prior reviewer's
+   * `request_changes` rationale.
+   */
+  it("inlines session_turn body under `## Inputs` when prior turn entry is present", async () => {
+    const { MemoryStore } = await import("../../src/adapters/store/memory.js");
+    const { layout } = await import(
+      "../../src/application/persistence-layout.js"
+    );
+    const { composePrompt } = await import(
+      "../../src/application/prompt-compose.js"
+    );
+    const { resolveManifestEntries } = await import(
+      "../../src/application/manifest-resolve.js"
+    );
+    const store = new MemoryStore();
+    // Seed milestone + feature_request so the milestone entry resolves too.
+    await store.writeAtomic(
+      layout.milestone(MILESTONE_ID),
+      JSON.stringify({
+        milestone_id: MILESTONE_ID,
+        target_id: "team-a",
+        title: "Add ledger summary CLI",
+        state: "M_DISCOVERY_DRAFT",
+        slot_kind: "discovery",
+        intake_source_kind: "feature_request",
+        intake_source_id: REQUEST_ID,
+        spec_revision_pin: null,
+        context_summary_id: null,
+        external_refs: [],
+        created_at: ISO2,
+        updated_at: ISO2,
+      }),
+    );
+    await store.writeAtomic(
+      layout.featureRequest(REQUEST_ID),
+      JSON.stringify({
+        request_id: REQUEST_ID,
+        title: "Add ledger summary CLI",
+        body: "operators-want-a-ledger-summary-tool-FEATUREBODY",
+        submitted_by: "user@example.com",
+        submitted_at: ISO2,
+        state: "queued",
+        promoted_milestone_id: null,
+        processed_at: null,
+        rejection_reason: null,
+      }),
+    );
+    // Seed a prior reviewer turn with a request_changes verdict.
+    const priorTurn = {
+      session_id: SESSION_ID,
+      turn_index: 1,
+      agent_profile_id: "sentinel",
+      input_manifest_id: MANIFEST_ID,
+      input_turn_log_snapshot_ref: null,
+      output_envelope: {
+        session_id: SESSION_ID,
+        turn_index: 1,
+        parent_loop: "outer",
+        phase_or_purpose: "Discovery",
+        slice_id: null,
+        slice_kind: null,
+        tdd_phase: null,
+        agent_profile_id: "sentinel",
+        agent_role_in_session: "reviewer",
+        contribution_kind: "review_verdict",
+        parent_review_verdict_id: null,
+        output_kind: "verdict",
+        object_id: MILESTONE_ID,
+        manifest_id: MANIFEST_ID,
+        input_revision_pins: ["deadbeef"],
+        summary: "REVIEWER_OBJECTION_SHOULD_BE_VISIBLE",
+        artifacts: null,
+        verdict: {
+          result: "request_changes",
+          rationale: "scope must enumerate CLI flags",
+        },
+        next_action_request: null,
+        failure: null,
+        idempotency_key: "idemp:prior-turn:1",
+        runtime_metadata: {},
+      },
+      next_action_request: null,
+      caller_routing_decision: null,
+      workspace_commit: null,
+      verification_result_ref: null,
+      recorded_at: ISO2,
+    };
+    const turnRaw = JSON.stringify(priorTurn);
+    await store.writeAtomic(layout.sessionTurn(SESSION_ID, 1), turnRaw);
+    const turnPin = `len=${turnRaw.length}:${turnRaw.slice(0, 32).replace(/\s+/g, "")}`;
+
+    const manifest = ContextManifest.parse({
+      manifest_id: MANIFEST_ID,
+      session_id: SESSION_ID,
+      turn_index: 2,
+      purpose: "design",
+      target: { object_kind: "milestone", object_id: MILESTONE_ID },
+      entries: [
+        {
+          object_kind: "milestone",
+          object_id: MILESTONE_ID,
+          fetch_scope: "body",
+          revision_pin: ISO2,
+          required: true,
+          purpose: "primary input",
+        },
+        {
+          object_kind: "session_turn",
+          object_id: SESSION_ID,
+          turn_index: 1,
+          fetch_scope: "body",
+          revision_pin: turnPin,
+          required: false,
+          purpose: "prior turn 1 (reviewer) (request_changes)",
+        },
+      ],
+      created_at: ISO2,
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(2);
+    const prompt = composePrompt({
+      agentProfileId: "atlas",
+      agentRoleInSession: "lead",
+      parentLoop: "outer",
+      phaseOrPurpose: "Discovery",
+      sessionId: SESSION_ID,
+      turnIndex: 2,
+      manifest,
+      workspaceRevisionPin: "deadbeef",
+      resolvedEntries: resolved,
+    });
+    expect(prompt).toContain("## Inputs");
+    expect(prompt).toContain("REVIEWER_OBJECTION_SHOULD_BE_VISIBLE");
+    expect(prompt).toContain("scope must enumerate CLI flags");
+    expect(prompt).toContain("request_changes");
+  });
 });

--- a/tests/application/manifest-resolve.test.ts
+++ b/tests/application/manifest-resolve.test.ts
@@ -176,3 +176,226 @@ describe("resolveManifestEntries", () => {
     expect(resolved[0]!.manifest_entry_index).toBe(0);
   });
 });
+
+/**
+ * incident-5 — `(session_turn, body)` resolver tests. Discovery atlas /
+ * sentinel were stuck in `request_changes ↔ need_context` because
+ * resolveManifestEntries silently dropped prior turn bodies. These tests
+ * lock the new behaviour: body is read from
+ * `sessions/<session_id>/turns/<n>.json`, projected to agent-relevant
+ * envelope fields, with the same revision_pin / required-missing /
+ * stale-pin failure modes as milestone body resolution.
+ */
+describe("resolveManifestEntries — session_turn body (incident-5)", () => {
+  const TURN_SESSION_ID = "01HZSE000000000000000000T1";
+  const PRIMARY_MILESTONE = "01HZMS00000000000000000T01";
+  const PRIMARY_REQUEST = "01HZFR00000000000000000T01";
+  const ENV_BASE_ISO = "2026-05-08T10:00:00.000Z";
+
+  function seedTurn(index: number, summary: string) {
+    const envelope = {
+      session_id: TURN_SESSION_ID,
+      turn_index: index,
+      parent_loop: "outer",
+      phase_or_purpose: "Discovery",
+      slice_id: null,
+      slice_kind: null,
+      tdd_phase: null,
+      agent_profile_id: index % 2 === 0 ? "atlas" : "sentinel",
+      agent_role_in_session: index % 2 === 0 ? "lead" : "reviewer",
+      contribution_kind: index % 2 === 0 ? "lead_draft" : "review_verdict",
+      parent_review_verdict_id: null,
+      output_kind: index % 2 === 0 ? "spec_proposal" : "verdict",
+      object_id: PRIMARY_MILESTONE,
+      manifest_id: "01HZMA00000000000000000T01",
+      input_revision_pins: ["deadbeef"],
+      summary,
+      artifacts: null,
+      verdict:
+        index % 2 === 1
+          ? {
+              result: "request_changes",
+              rationale: "needs scope sharpening",
+            }
+          : null,
+      next_action_request: null,
+      failure: null,
+      idempotency_key: `idemp:${TURN_SESSION_ID}:${index}`,
+      runtime_metadata: {},
+    };
+    const turn = {
+      session_id: TURN_SESSION_ID,
+      turn_index: index,
+      agent_profile_id: envelope.agent_profile_id,
+      input_manifest_id: "01HZMA00000000000000000T01",
+      input_turn_log_snapshot_ref: null,
+      output_envelope: envelope,
+      next_action_request: null,
+      caller_routing_decision: null,
+      workspace_commit: null,
+      verification_result_ref: null,
+      recorded_at: ENV_BASE_ISO,
+    };
+    return JSON.stringify(turn);
+  }
+
+  function pinFor(raw: string): string {
+    return `len=${raw.length}:${raw.slice(0, 32).replace(/\s+/g, "")}`;
+  }
+
+  async function seedPrimaryMilestone(store: MemoryStore) {
+    await store.writeAtomic(
+      layout.milestone(PRIMARY_MILESTONE),
+      JSON.stringify({
+        milestone_id: PRIMARY_MILESTONE,
+        target_id: "team-a",
+        title: "Discovery loop fix",
+        state: "M_DISCOVERY_DRAFT",
+        slot_kind: "discovery",
+        intake_source_kind: "feature_request",
+        intake_source_id: PRIMARY_REQUEST,
+        spec_revision_pin: null,
+        context_summary_id: null,
+        external_refs: [],
+        created_at: ENV_BASE_ISO,
+        updated_at: ENV_BASE_ISO,
+      }),
+    );
+    await store.writeAtomic(
+      layout.featureRequest(PRIMARY_REQUEST),
+      JSON.stringify({
+        request_id: PRIMARY_REQUEST,
+        title: "Discovery loop fix",
+        body: "raw scope text",
+        submitted_by: "user@example.com",
+        submitted_at: ENV_BASE_ISO,
+        state: "queued",
+        promoted_milestone_id: null,
+        processed_at: null,
+        rejection_reason: null,
+      }),
+    );
+  }
+
+  function manifestWithSessionTurn(extra: any) {
+    return ContextManifest.parse({
+      manifest_id: "01HZMA00000000000000000T01",
+      session_id: TURN_SESSION_ID,
+      turn_index: 4,
+      purpose: "design",
+      target: { object_kind: "milestone", object_id: PRIMARY_MILESTONE },
+      entries: [
+        {
+          object_kind: "milestone",
+          object_id: PRIMARY_MILESTONE,
+          fetch_scope: "body",
+          revision_pin: ENV_BASE_ISO,
+          required: true,
+          purpose: "primary",
+        },
+        extra,
+      ],
+      created_at: ENV_BASE_ISO,
+    });
+  }
+
+  it("resolves required session_turn body via turn_index field", async () => {
+    const store = new MemoryStore();
+    await seedPrimaryMilestone(store);
+    const turnRaw = seedTurn(1, "reviewer flagged scope drift");
+    await store.writeAtomic(layout.sessionTurn(TURN_SESSION_ID, 1), turnRaw);
+    const manifest = manifestWithSessionTurn({
+      object_kind: "session_turn",
+      object_id: TURN_SESSION_ID,
+      turn_index: 1,
+      fetch_scope: "body",
+      revision_pin: pinFor(turnRaw),
+      required: true,
+      purpose: "prior turn 1 (reviewer) (request_changes)",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(2);
+    const turnEntry = resolved.find((r) => r.manifest_entry_index === 1)!;
+    expect(turnEntry.body).toContain("reviewer flagged scope drift");
+    expect(turnEntry.body).toContain("request_changes");
+    expect(turnEntry.body).toContain("needs scope sharpening");
+    // ULID guard — session_id projection must equal seed.
+    expect(turnEntry.body).toContain(TURN_SESSION_ID);
+    // Projection — top-level keys present.
+    expect(turnEntry.body).toContain("\"summary\"");
+    expect(turnEntry.body).toContain("\"verdict\"");
+    expect(turnEntry.body).toContain("\"agent_role_in_session\"");
+  });
+
+  it("resolves session_turn body via legacy ${session_id}#${i} object_id", async () => {
+    const store = new MemoryStore();
+    await seedPrimaryMilestone(store);
+    const turnRaw = seedTurn(0, "lead initial draft");
+    await store.writeAtomic(layout.sessionTurn(TURN_SESSION_ID, 0), turnRaw);
+    const manifest = manifestWithSessionTurn({
+      object_kind: "session_turn",
+      object_id: `${TURN_SESSION_ID}#0`,
+      fetch_scope: "body",
+      revision_pin: pinFor(turnRaw),
+      required: true,
+      purpose: "prior turn 0 (lead)",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(2);
+    expect(resolved[1]!.body).toContain("lead initial draft");
+  });
+
+  it("throws MissingRequiredManifestEntryError when turn file is absent and required", async () => {
+    const store = new MemoryStore();
+    await seedPrimaryMilestone(store);
+    const manifest = manifestWithSessionTurn({
+      object_kind: "session_turn",
+      object_id: TURN_SESSION_ID,
+      turn_index: 5,
+      fetch_scope: "body",
+      revision_pin: "len=0:",
+      required: true,
+      purpose: "missing prior turn",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("throws StaleManifestEntryError when revision_pin disagrees with stored body", async () => {
+    const store = new MemoryStore();
+    await seedPrimaryMilestone(store);
+    const turnRaw = seedTurn(2, "reviewer second pass");
+    await store.writeAtomic(layout.sessionTurn(TURN_SESSION_ID, 2), turnRaw);
+    const manifest = manifestWithSessionTurn({
+      object_kind: "session_turn",
+      object_id: TURN_SESSION_ID,
+      turn_index: 2,
+      fetch_scope: "body",
+      revision_pin: "len=999:bogus",
+      required: true,
+      purpose: "stale prior turn",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /revision_pin mismatch/,
+    );
+  });
+
+  it("silently skips non-required session_turn body when file is absent", async () => {
+    const store = new MemoryStore();
+    await seedPrimaryMilestone(store);
+    const manifest = manifestWithSessionTurn({
+      object_kind: "session_turn",
+      object_id: TURN_SESSION_ID,
+      turn_index: 7,
+      fetch_scope: "body",
+      revision_pin: "len=0:",
+      required: false,
+      purpose: "advisory prior turn",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    // Only the milestone entry survives.
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.manifest_entry_index).toBe(0);
+  });
+});

--- a/tests/application/manifest-resolve.test.ts
+++ b/tests/application/manifest-resolve.test.ts
@@ -4,6 +4,7 @@
  * section. This test fixes the supported (object_kind, fetch_scope) surface
  * to (`milestone`, `body`) and locks the failure modes for unsupported entries.
  */
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { MemoryStore } from "../../src/adapters/store/memory.js";
 import { resolveManifestEntries } from "../../src/application/manifest-resolve.js";
@@ -240,7 +241,9 @@ describe("resolveManifestEntries — session_turn body (incident-5)", () => {
   }
 
   function pinFor(raw: string): string {
-    return `len=${raw.length}:${raw.slice(0, 32).replace(/\s+/g, "")}`;
+    // PR #96 P0-1: full-body sha256 hex (replaces the previous
+    // `len=N:<first 32 chars>` fingerprint).
+    return createHash("sha256").update(raw).digest("hex");
   }
 
   async function seedPrimaryMilestone(store: MemoryStore) {
@@ -375,6 +378,93 @@ describe("resolveManifestEntries — session_turn body (incident-5)", () => {
       revision_pin: "len=999:bogus",
       required: true,
       purpose: "stale prior turn",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /revision_pin mismatch/,
+    );
+  });
+
+  it("PR #96 P1-A: projects only the agent-relevant subset (no input_manifest_id / runtime_metadata / idempotency_key leak)", async () => {
+    const store = new MemoryStore();
+    await seedPrimaryMilestone(store);
+    const turnRaw = seedTurn(1, "reviewer rationale text");
+    await store.writeAtomic(layout.sessionTurn(TURN_SESSION_ID, 1), turnRaw);
+    const manifest = manifestWithSessionTurn({
+      object_kind: "session_turn",
+      object_id: TURN_SESSION_ID,
+      turn_index: 1,
+      fetch_scope: "body",
+      revision_pin: pinFor(turnRaw),
+      required: true,
+      purpose: "prior turn 1 (reviewer)",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    const turnEntry = resolved.find((r) => r.manifest_entry_index === 1)!;
+    const body = turnEntry.body;
+    // Selected (must be present).
+    for (const key of [
+      "session_id",
+      "turn_index",
+      "agent_profile_id",
+      "agent_role_in_session",
+      "output_kind",
+      "contribution_kind",
+      "summary",
+      "verdict",
+      "failure",
+      "next_action_request",
+    ]) {
+      expect(body, `selected field ${key} missing`).toContain(`"${key}"`);
+    }
+    // Excluded (must NOT be present — the resolver projects an
+    // agent-relevant subset, not the verbatim envelope/turn record).
+    for (const key of [
+      "input_manifest_id",
+      "input_turn_log_snapshot_ref",
+      "runtime_metadata",
+      "idempotency_key",
+      "input_revision_pins",
+      "caller_routing_decision",
+      "workspace_commit",
+      "verification_result_ref",
+      "recorded_at",
+      "output_envelope",
+      "parent_loop",
+      "phase_or_purpose",
+      "object_id",
+      "manifest_id",
+      "artifacts",
+      "parent_review_verdict_id",
+      "tdd_phase",
+    ]) {
+      expect(body, `excluded field ${key} leaked`).not.toContain(`"${key}"`);
+    }
+  });
+
+  it("PR #96 P0-1 regression: equal-length post-prefix mutation (verdict.rationale) trips StaleManifestEntryError", async () => {
+    // Build two raws with identical length but a single-char difference deep
+    // in the body (verdict.rationale). The previous `len=N:<first 32 chars>`
+    // pin format would not distinguish them when the prefix is unchanged.
+    const store = new MemoryStore();
+    await seedPrimaryMilestone(store);
+    const baseRaw = seedTurn(1, "reviewer flagged scope drift");
+    // Replace one character in `rationale` (preserves length).
+    const mutatedRaw = baseRaw.replace(
+      "needs scope sharpening",
+      "needs scope sharpeninG",
+    );
+    expect(mutatedRaw.length).toBe(baseRaw.length);
+    expect(mutatedRaw).not.toBe(baseRaw);
+    // Pin computed from baseRaw, but stored body is mutatedRaw.
+    await store.writeAtomic(layout.sessionTurn(TURN_SESSION_ID, 1), mutatedRaw);
+    const manifest = manifestWithSessionTurn({
+      object_kind: "session_turn",
+      object_id: TURN_SESSION_ID,
+      turn_index: 1,
+      fetch_scope: "body",
+      revision_pin: pinFor(baseRaw),
+      required: true,
+      purpose: "prior turn 1 (reviewer) (request_changes)",
     });
     await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
       /revision_pin mismatch/,


### PR DESCRIPTION
## Summary
- Extend `resolveManifestEntries` to support `(session_turn, body)` so Discovery atlas/sentinel can read prior turn rationales and converge instead of looping forever in `request_changes ↔ need_context`.
- ManifestEntry gains optional `turn_index` field (Zod schema) so the resolver knows which turn file to read.
- Tests cover happy path, legacy `${session_id}#${i}` object_id form, missing-required, stale revision_pin, non-required-missing-skip, plus an end-to-end prompt-compose integration test.

### 변경 내용
| Module | Artifact | Notes |
|---|---|---|
| domain/schema/manifest.ts | `ManifestEntry.turn_index?: number` | optional, backward-compat |
| application/manifest-resolve.ts | `resolveSessionTurnBody` | reads `sessions/<id>/turns/<n>.json`, verifies `len=N:first32` revision_pin, projects to agent-relevant envelope subset |
| application/manifest-builder.ts | `ManifestEntryDraft.turn_index` | threaded into entries + `recheckPins` |
| application/outer-turn.ts | prior-turn draft + `OuterPinResolver` | `object_id=session_id` + `turn_index=i`; legacy `${session_id}#${i}` parse retained as fallback |
| tests/application/manifest-resolve.test.ts | +5 cases | turn_index happy / legacy object_id / missing-required / stale-pin / non-required-skip |
| tests/application/agent-io.test.ts | +1 case | composePrompt renders prior reviewer `request_changes` rationale under `## Inputs` |

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 928 passing (was 922, +6 new tests, no regressions)
- [x] `npm run build` clean

Refs: incident-5 (`/Users/macpro/llm-team-runs/20260510T015239Z/incident-5.md`). Closes the deferred wiring noted in PR #93 review-applier P1-A. Slice / slice_merge / dialogue_session / verification_run resolvers remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)