### PR TITLE
fix(outer-turn): recover slice DAG from lead's slice_decomposition turn (incident-7)

### DIFF
--- a/src/application/caller-dispatch-outer.ts
+++ b/src/application/caller-dispatch-outer.ts
@@ -209,6 +209,25 @@ export async function dispatchOuterOutcome(
     };
   }
 
+  // incident-7 P0 (PR #104 review): when the dispatched effect is
+  // `persist_slice_dag_and_promote` but `slicesToPersist` is empty/missing,
+  // refuse the dispatch as `no_match` rather than throwing. Throwing
+  // propagates through `finalizeConvergedSession` → `runOneOuterTurn` → the
+  // daemon top-level reject handler and exits the process. Returning
+  // `no_match` lets `finalizeConvergedSession` emit an error ledger row and
+  // surface a `dispatch_no_match` outcome — milestone stays in
+  // M_DELIVERY_PLANNING for the next outer-coordinator cycle to retry.
+  if (
+    entry.effects.some((e) => e.kind === "persist_slice_dag_and_promote") &&
+    (input.slicesToPersist == null || input.slicesToPersist.length === 0)
+  ) {
+    return {
+      kind: "no_match",
+      detail:
+        "persist_slice_dag_and_promote: refusing to advance milestone with empty slice DAG (incident-7)",
+    };
+  }
+
   // PR #66 P0-1: take the milestone lock once and run every effect inside
   // it. Slice writes, Decision Log entries, Spec CP, and the milestone
   // state transition all observe the same lock.
@@ -328,16 +347,14 @@ async function runOuterEffect(
     }
     case "persist_slice_dag_and_promote": {
       const slices = input.slicesToPersist ?? [];
-      // incident-7 P0 guard: refuse to silently advance the milestone to
-      // M_DELIVERY_BUILDING with an empty slice DAG. If the dispatch input
-      // arrives without `slicesToPersist`, the caller (outer-turn
-      // `buildDispatchInput`) failed to recover the lead's
-      // `output_kind=slice_decomposition` payload from the session. Throw
-      // so the failure is visible in the ledger and the milestone stays in
-      // M_DELIVERY_PLANNING for the next outer-coordinator cycle to retry.
+      // incident-7 P0 (PR #104 review): the empty-slices case is rejected
+      // upstream in `dispatchOuterOutcome` as `no_match` (returning a
+      // structured error rather than throwing, so the daemon does not
+      // crash). This branch is unreachable when slices is empty, but keep
+      // a defensive invariant check that returns rather than throws.
       if (slices.length === 0) {
         throw new Error(
-          "persist_slice_dag_and_promote: refusing to advance milestone with empty slice DAG (incident-7)",
+          "persist_slice_dag_and_promote: invariant violation — empty slice DAG should have been rejected upstream (incident-7)",
         );
       }
       const validation = validateSliceDag(slices);

--- a/src/application/caller-dispatch-outer.ts
+++ b/src/application/caller-dispatch-outer.ts
@@ -328,6 +328,18 @@ async function runOuterEffect(
     }
     case "persist_slice_dag_and_promote": {
       const slices = input.slicesToPersist ?? [];
+      // incident-7 P0 guard: refuse to silently advance the milestone to
+      // M_DELIVERY_BUILDING with an empty slice DAG. If the dispatch input
+      // arrives without `slicesToPersist`, the caller (outer-turn
+      // `buildDispatchInput`) failed to recover the lead's
+      // `output_kind=slice_decomposition` payload from the session. Throw
+      // so the failure is visible in the ledger and the milestone stays in
+      // M_DELIVERY_PLANNING for the next outer-coordinator cycle to retry.
+      if (slices.length === 0) {
+        throw new Error(
+          "persist_slice_dag_and_promote: refusing to advance milestone with empty slice DAG (incident-7)",
+        );
+      }
       const validation = validateSliceDag(slices);
       if (!validation.ok) {
         // Per SOC-SLICE-DEPENDENCIES Cycle Detection: lead contribution FAIL.

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -1518,7 +1518,26 @@ async function buildDispatchInput(
       return body == null ? base : { ...base, specProposalBody: body };
     }
     case "Planning": {
-      const slices = parseSlices(artifacts, milestone.milestone_id);
+      let slices = parseSlices(artifacts, milestone.milestone_id);
+      if (slices.length === 0) {
+        // incident-7: when convergence is triggered by the second reviewer's
+        // plan_accept (rather than a lead final), `leadEnvelope` resolves to
+        // the most recent lead turn — but in some sessions that envelope's
+        // artifacts.slices is absent (e.g. the lead's draft was at an earlier
+        // turn and a later contribution by the same lead is what
+        // `lastLeadEnvelope` returned). Fall back to scanning persisted
+        // turns for the most recent envelope with
+        // `output_kind=slice_decomposition` and read its artifacts.slices.
+        // Without this fallback the dispatcher receives `slicesToPersist=[]`
+        // and (per the defensive guard in caller-dispatch-outer.ts) refuses
+        // to silently advance the milestone with an empty DAG.
+        const fallback = await findSliceDecompositionSlices(
+          session.session_id,
+          milestone.milestone_id,
+          deps.store,
+        );
+        slices = fallback;
+      }
       return slices.length > 0 ? { ...base, slicesToPersist: slices } : base;
     }
     case "Validation": {
@@ -1620,6 +1639,48 @@ function parseStringArray(
   const v = rec[key];
   if (!Array.isArray(v)) return [];
   return v.filter((x): x is string => typeof x === "string" && x.length > 0);
+}
+
+/**
+ * incident-7 fallback: scan persisted session turns from highest index down
+ * for an envelope whose `output_kind === "slice_decomposition"` and return
+ * the parsed `artifacts.slices`. Used when the lead envelope reached via
+ * `lastLeadEnvelope` does not carry the slice payload (e.g. convergence
+ * triggered by a reviewer verdict, not a lead final).
+ */
+export async function findSliceDecompositionSlices(
+  sessionId: string,
+  milestoneId: string,
+  store: StorePort,
+): Promise<SliceT[]> {
+  // Walk backwards using the layout — turn files are zero-indexed and dense
+  // up to current_turn_index, but the absolute upper bound is unknown here.
+  // Probe a generous bound and stop once we hit a missing turn after the
+  // first hit (i.e. consecutive misses). Use a loop until readText returns
+  // null on a high index, then descend.
+  const indices: number[] = [];
+  for (let i = 0; i < 256; i++) {
+    const body = await store.readText(layout.sessionTurn(sessionId, i));
+    if (body == null) break;
+    indices.push(i);
+  }
+  for (let i = indices.length - 1; i >= 0; i--) {
+    const body = await store.readText(layout.sessionTurn(sessionId, indices[i]!));
+    if (body == null) continue;
+    let parsed: { output_envelope?: { output_kind?: string; artifacts?: unknown } };
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      continue;
+    }
+    const env = parsed.output_envelope;
+    if (env == null) continue;
+    if (env.output_kind !== "slice_decomposition") continue;
+    const artifacts = (env.artifacts ?? {}) as Record<string, unknown>;
+    const slices = parseSlices(artifacts, milestoneId);
+    if (slices.length > 0) return slices;
+  }
+  return [];
 }
 
 function parseSlices(

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -1535,6 +1535,7 @@ async function buildDispatchInput(
           session.session_id,
           milestone.milestone_id,
           deps.store,
+          session.current_turn_index,
         );
         slices = fallback;
       }
@@ -1643,31 +1644,48 @@ function parseStringArray(
 
 /**
  * incident-7 fallback: scan persisted session turns from highest index down
- * for an envelope whose `output_kind === "slice_decomposition"` and return
+ * for the most recent envelope whose `output_kind === "slice_decomposition"`
+ * is emitted by the session lead for this Planning milestone, and return
  * the parsed `artifacts.slices`. Used when the lead envelope reached via
  * `lastLeadEnvelope` does not carry the slice payload (e.g. convergence
  * triggered by a reviewer verdict, not a lead final).
+ *
+ * PR #104 P0-2 fix: once the most recent matching envelope is located, the
+ * parse result is returned directly — even if empty. We must NOT continue
+ * scanning to an older envelope, otherwise a stale DAG could be resurrected
+ * and promoted to M_DELIVERY_BUILDING when the latest lead draft is
+ * empty/malformed.
+ *
+ * PR #104 P1-1 fix: candidates must satisfy the lead-Planning envelope
+ * contract, not just `output_kind === "slice_decomposition"`. Specifically:
+ *   - `agent_role_in_session === "lead"`
+ *   - `phase_or_purpose === "Planning"`
+ *   - `parent_loop === "outer"`
+ *   - `object_id === milestoneId`
+ *
+ * PR #104 P1-2 fix: use the session's `current_turn_index` as a precise
+ * upper bound, single-pass reverse scan — removes the 256 magic number and
+ * the previous two-pass (probe + read) structure.
  */
 export async function findSliceDecompositionSlices(
   sessionId: string,
   milestoneId: string,
   store: StorePort,
+  currentTurnIndex: number,
 ): Promise<SliceT[]> {
-  // Walk backwards using the layout — turn files are zero-indexed and dense
-  // up to current_turn_index, but the absolute upper bound is unknown here.
-  // Probe a generous bound and stop once we hit a missing turn after the
-  // first hit (i.e. consecutive misses). Use a loop until readText returns
-  // null on a high index, then descend.
-  const indices: number[] = [];
-  for (let i = 0; i < 256; i++) {
+  for (let i = currentTurnIndex; i >= 0; i--) {
     const body = await store.readText(layout.sessionTurn(sessionId, i));
-    if (body == null) break;
-    indices.push(i);
-  }
-  for (let i = indices.length - 1; i >= 0; i--) {
-    const body = await store.readText(layout.sessionTurn(sessionId, indices[i]!));
     if (body == null) continue;
-    let parsed: { output_envelope?: { output_kind?: string; artifacts?: unknown } };
+    let parsed: {
+      output_envelope?: {
+        output_kind?: string;
+        artifacts?: unknown;
+        agent_role_in_session?: string;
+        phase_or_purpose?: string;
+        parent_loop?: string;
+        object_id?: string;
+      };
+    };
     try {
       parsed = JSON.parse(body);
     } catch {
@@ -1676,9 +1694,14 @@ export async function findSliceDecompositionSlices(
     const env = parsed.output_envelope;
     if (env == null) continue;
     if (env.output_kind !== "slice_decomposition") continue;
+    if (env.agent_role_in_session !== "lead") continue;
+    if (env.phase_or_purpose !== "Planning") continue;
+    if (env.parent_loop !== "outer") continue;
+    if (env.object_id !== milestoneId) continue;
+    // First (highest-turn) match wins. Return parse result directly — even
+    // if empty — so a stale earlier DAG cannot be resurrected.
     const artifacts = (env.artifacts ?? {}) as Record<string, unknown>;
-    const slices = parseSlices(artifacts, milestoneId);
-    if (slices.length > 0) return slices;
+    return parseSlices(artifacts, milestoneId);
   }
   return [];
 }

--- a/tests/application/caller-dispatch-outer.test.ts
+++ b/tests/application/caller-dispatch-outer.test.ts
@@ -242,6 +242,51 @@ describe("dispatchOuterOutcome — Planning", () => {
     ).rejects.toThrow(/invalid DAG/);
   });
 
+  it("incident-7: plan_accept with empty slicesToPersist refuses to advance milestone", async () => {
+    const d = deps();
+    const m = await seedMilestone(d.store, "M_DELIVERY_PLANNING");
+    await expect(
+      dispatchOuterOutcome(
+        {
+          parent_loop: "outer",
+          phase_or_purpose: "Planning",
+          session_state: "CONVERGED",
+          final_verdict: "plan_accept",
+          milestone: m,
+          sessionId: SESS_ID,
+          // slicesToPersist intentionally omitted (incident-7 production
+          // symptom: dispatcher receives empty/missing slice payload).
+        },
+        d,
+      ),
+    ).rejects.toThrow(/empty slice DAG/);
+
+    // Milestone state must NOT have advanced.
+    const reread = Milestone.parse(
+      JSON.parse((await d.store.readText(layout.milestone(M_ID)))!),
+    );
+    expect(reread.state).toBe("M_DELIVERY_PLANNING");
+  });
+
+  it("incident-7: plan_accept with explicit empty slices array also refuses to advance", async () => {
+    const d = deps();
+    const m = await seedMilestone(d.store, "M_DELIVERY_PLANNING");
+    await expect(
+      dispatchOuterOutcome(
+        {
+          parent_loop: "outer",
+          phase_or_purpose: "Planning",
+          session_state: "CONVERGED",
+          final_verdict: "plan_accept",
+          milestone: m,
+          sessionId: SESS_ID,
+          slicesToPersist: [],
+        },
+        d,
+      ),
+    ).rejects.toThrow(/empty slice DAG/);
+  });
+
   it("TIMEOUT → escalate", async () => {
     const d = deps();
     const m = await seedMilestone(d.store, "M_DELIVERY_PLANNING");

--- a/tests/application/caller-dispatch-outer.test.ts
+++ b/tests/application/caller-dispatch-outer.test.ts
@@ -242,24 +242,30 @@ describe("dispatchOuterOutcome — Planning", () => {
     ).rejects.toThrow(/invalid DAG/);
   });
 
-  it("incident-7: plan_accept with empty slicesToPersist refuses to advance milestone", async () => {
+  it("incident-7: plan_accept with empty slicesToPersist returns no_match (does not throw)", async () => {
+    // PR #104 P0-1 fix: empty slicesToPersist must return a structured
+    // `no_match` result rather than throwing. Throwing propagates up to the
+    // daemon top-level handler and exits the process — milestone state then
+    // cannot recover on the next outer-coordinator cycle.
     const d = deps();
     const m = await seedMilestone(d.store, "M_DELIVERY_PLANNING");
-    await expect(
-      dispatchOuterOutcome(
-        {
-          parent_loop: "outer",
-          phase_or_purpose: "Planning",
-          session_state: "CONVERGED",
-          final_verdict: "plan_accept",
-          milestone: m,
-          sessionId: SESS_ID,
-          // slicesToPersist intentionally omitted (incident-7 production
-          // symptom: dispatcher receives empty/missing slice payload).
-        },
-        d,
-      ),
-    ).rejects.toThrow(/empty slice DAG/);
+    const r = await dispatchOuterOutcome(
+      {
+        parent_loop: "outer",
+        phase_or_purpose: "Planning",
+        session_state: "CONVERGED",
+        final_verdict: "plan_accept",
+        milestone: m,
+        sessionId: SESS_ID,
+        // slicesToPersist intentionally omitted (incident-7 production
+        // symptom: dispatcher receives empty/missing slice payload).
+      },
+      d,
+    );
+    expect(r.kind).toBe("no_match");
+    if (r.kind === "no_match") {
+      expect(r.detail).toMatch(/empty slice DAG/);
+    }
 
     // Milestone state must NOT have advanced.
     const reread = Milestone.parse(
@@ -268,23 +274,30 @@ describe("dispatchOuterOutcome — Planning", () => {
     expect(reread.state).toBe("M_DELIVERY_PLANNING");
   });
 
-  it("incident-7: plan_accept with explicit empty slices array also refuses to advance", async () => {
+  it("incident-7: plan_accept with explicit empty slices array also returns no_match", async () => {
     const d = deps();
     const m = await seedMilestone(d.store, "M_DELIVERY_PLANNING");
-    await expect(
-      dispatchOuterOutcome(
-        {
-          parent_loop: "outer",
-          phase_or_purpose: "Planning",
-          session_state: "CONVERGED",
-          final_verdict: "plan_accept",
-          milestone: m,
-          sessionId: SESS_ID,
-          slicesToPersist: [],
-        },
-        d,
-      ),
-    ).rejects.toThrow(/empty slice DAG/);
+    const r = await dispatchOuterOutcome(
+      {
+        parent_loop: "outer",
+        phase_or_purpose: "Planning",
+        session_state: "CONVERGED",
+        final_verdict: "plan_accept",
+        milestone: m,
+        sessionId: SESS_ID,
+        slicesToPersist: [],
+      },
+      d,
+    );
+    expect(r.kind).toBe("no_match");
+    if (r.kind === "no_match") {
+      expect(r.detail).toMatch(/empty slice DAG/);
+    }
+    // Milestone state must NOT have advanced.
+    const reread = Milestone.parse(
+      JSON.parse((await d.store.readText(layout.milestone(M_ID)))!),
+    );
+    expect(reread.state).toBe("M_DELIVERY_PLANNING");
   });
 
   it("TIMEOUT → escalate", async () => {

--- a/tests/application/outer-turn.test.ts
+++ b/tests/application/outer-turn.test.ts
@@ -132,6 +132,7 @@ describe("findSliceDecompositionSlices (incident-7 fallback)", () => {
       SESSION_ID,
       MILESTONE_ID,
       store,
+      2,
     );
     expect(slices.length).toBe(2);
     expect(slices.map((s) => s.slice_id)).toEqual(
@@ -190,6 +191,7 @@ describe("findSliceDecompositionSlices (incident-7 fallback)", () => {
       SESSION_ID,
       MILESTONE_ID,
       store,
+      1,
     );
     expect(slices.length).toBe(2);
   });
@@ -218,6 +220,7 @@ describe("findSliceDecompositionSlices (incident-7 fallback)", () => {
       SESSION_ID,
       MILESTONE_ID,
       store,
+      0,
     );
     expect(slices).toEqual([]);
   });
@@ -246,7 +249,157 @@ describe("findSliceDecompositionSlices (incident-7 fallback)", () => {
       SESSION_ID,
       MILESTONE_ID,
       store,
+      0,
     );
+    expect(slices).toEqual([]);
+  });
+
+  it("PR #104 P0-2: does NOT resurrect an older valid DAG when the latest matching lead envelope is empty", async () => {
+    // Regression for the stale-DAG-resurrection bug: if turn 1 (the latest
+    // lead slice_decomposition) has empty artifacts.slices, the fallback
+    // must return [] — not roll back to turn 0's valid DAG. Otherwise an
+    // outdated slice DAG could be promoted to M_DELIVERY_BUILDING.
+    const store = new MemoryStore();
+    // Turn 0: lead emits a valid slice_decomposition.
+    await persistTurn(store, 0, {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      manifest_id: "manifest-0",
+      contribution_kind: "lead_draft",
+      output_kind: "slice_decomposition",
+      object_id: MILESTONE_ID,
+      summary: "first draft",
+      artifacts: {
+        slices: [
+          planningSliceFixture(SLICE_A),
+          planningSliceFixture(SLICE_B, [SLICE_A]),
+        ],
+      },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+    // Turn 1: same lead emits a slice_decomposition with EMPTY slices array.
+    await persistTurn(store, 1, {
+      session_id: SESSION_ID,
+      turn_index: 1,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      manifest_id: "manifest-1",
+      contribution_kind: "lead_draft",
+      output_kind: "slice_decomposition",
+      object_id: MILESTONE_ID,
+      summary: "empty redraft",
+      artifacts: { slices: [] },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+    // Turn 2 + 3: reviewer plan_accept, triggering convergence.
+    await persistTurn(store, 2, {
+      session_id: SESSION_ID,
+      turn_index: 2,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "forge",
+      agent_role_in_session: "reviewer",
+      manifest_id: "manifest-2",
+      contribution_kind: "review_verdict",
+      output_kind: "verdict",
+      object_id: MILESTONE_ID,
+      summary: "reviewer verdict=plan_accept",
+      artifacts: null,
+      verdict: { result: "plan_accept", rationale: null },
+      next_action_request: null,
+      failure: null,
+    });
+    await persistTurn(store, 3, {
+      session_id: SESSION_ID,
+      turn_index: 3,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "sentinel",
+      agent_role_in_session: "reviewer",
+      manifest_id: "manifest-3",
+      contribution_kind: "review_verdict",
+      output_kind: "verdict",
+      object_id: MILESTONE_ID,
+      summary: "reviewer verdict=plan_accept",
+      artifacts: null,
+      verdict: { result: "plan_accept", rationale: null },
+      next_action_request: null,
+      failure: null,
+    });
+
+    const slices = await findSliceDecompositionSlices(
+      SESSION_ID,
+      MILESTONE_ID,
+      store,
+      3,
+    );
+    // Latest matching lead envelope is turn 1 with empty slices — return []
+    // and do NOT resurrect turn 0.
+    expect(slices).toEqual([]);
+  });
+
+  it("PR #104 P1-1: ignores envelopes that do not satisfy the lead-Planning-milestone contract", async () => {
+    // Even if `output_kind === "slice_decomposition"` appears on a non-lead
+    // / non-Planning / wrong-object_id envelope, it must NOT be selected.
+    const store = new MemoryStore();
+    const FOREIGN_MILESTONE = "01HZM00000000000000000999A";
+    // Turn 0: lead-authored slice_decomposition for a different milestone.
+    await persistTurn(store, 0, {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      manifest_id: "manifest-0",
+      contribution_kind: "lead_draft",
+      output_kind: "slice_decomposition",
+      object_id: FOREIGN_MILESTONE,
+      summary: "different milestone",
+      artifacts: { slices: [planningSliceFixture(SLICE_A)] },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+    // Turn 1: reviewer-authored slice_decomposition for the right milestone
+    // (not allowed under the contract, but envelope validator does not
+    // enforce role × output_kind correlation).
+    await persistTurn(store, 1, {
+      session_id: SESSION_ID,
+      turn_index: 1,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "forge",
+      agent_role_in_session: "reviewer",
+      manifest_id: "manifest-1",
+      contribution_kind: "review_verdict",
+      output_kind: "slice_decomposition",
+      object_id: MILESTONE_ID,
+      summary: "wrong-role slice_decomposition",
+      artifacts: { slices: [planningSliceFixture(SLICE_B)] },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+
+    const slices = await findSliceDecompositionSlices(
+      SESSION_ID,
+      MILESTONE_ID,
+      store,
+      1,
+    );
+    // Neither candidate satisfies (lead × Planning × outer × MILESTONE_ID),
+    // so the helper returns [].
     expect(slices).toEqual([]);
   });
 });

--- a/tests/application/outer-turn.test.ts
+++ b/tests/application/outer-turn.test.ts
@@ -1,0 +1,252 @@
+/**
+ * incident-7 regression: when Planning convergence is triggered by a
+ * reviewer's plan_accept verdict, the lead's `output_kind=slice_decomposition`
+ * envelope (with `artifacts.slices`) lives at an earlier turn. The dispatch
+ * input builder must recover those slices via session-turn scan rather than
+ * relying solely on the converging envelope's artifacts.
+ */
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "../../src/adapters/store/memory.js";
+import { findSliceDecompositionSlices } from "../../src/application/outer-turn.js";
+import { layout } from "../../src/application/persistence-layout.js";
+
+const SESSION_ID = "01HZSE0000000000000000000A";
+const MILESTONE_ID = "01HZM00000000000000000000A";
+const SLICE_A = "01HZ1000000000000000000000";
+const SLICE_B = "01HZ2000000000000000000000";
+
+function planningSliceFixture(sliceId: string, deps: string[] = []) {
+  return {
+    slice_id: sliceId,
+    milestone_id: MILESTONE_ID,
+    slice_kind: "internal",
+    value_statement: `slice ${sliceId.slice(-2)}`,
+    ac_ids: ["AC-1"],
+    acceptance_tests: [{ path: "tests/x.test.ts", name: "x", ac_id: "AC-1" }],
+    declared_scope: ["src/x.ts"],
+    declared_metric_threshold: null,
+    interface_break: false,
+    dependencies: deps.map((d) => ({ slice_id: d, edge_type: "blocks" })),
+    trunk_base_revision: "trunk-base",
+    dod_revision_pin: "dod-pin",
+    state: "SLICE_PENDING",
+    current_session_id: null,
+    spawning_proposal_id: null,
+    abandoned_reason: null,
+    external_refs: [],
+    created_at: "2026-05-10T00:00:00.000Z",
+    updated_at: "2026-05-10T00:00:00.000Z",
+  };
+}
+
+async function persistTurn(
+  store: MemoryStore,
+  turnIndex: number,
+  envelope: Record<string, unknown>,
+): Promise<void> {
+  const body = {
+    session_id: SESSION_ID,
+    turn_index: turnIndex,
+    agent_profile_id: envelope.agent_profile_id,
+    input_manifest_id: null,
+    input_turn_log_snapshot_ref: null,
+    output_envelope: envelope,
+    next_action_request: null,
+    caller_routing_decision: {
+      decision: "addressed",
+      decision_reason: "test",
+      resolved_addressed_to: null,
+    },
+  };
+  await store.writeAtomic(
+    layout.sessionTurn(SESSION_ID, turnIndex),
+    JSON.stringify(body, null, 2),
+  );
+}
+
+describe("findSliceDecompositionSlices (incident-7 fallback)", () => {
+  it("recovers slices from an earlier lead turn when the most recent turn is a reviewer verdict", async () => {
+    const store = new MemoryStore();
+    // Turn 0: atlas (lead) emits slice_decomposition with two slices.
+    await persistTurn(store, 0, {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      manifest_id: "manifest-0",
+      contribution_kind: "lead_draft",
+      output_kind: "slice_decomposition",
+      object_id: MILESTONE_ID,
+      summary: "planning slice decomposition",
+      artifacts: {
+        slices: [
+          planningSliceFixture(SLICE_A),
+          planningSliceFixture(SLICE_B, [SLICE_A]),
+        ],
+      },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+    // Turn 1: forge (reviewer) plan_accept — empty artifacts.
+    await persistTurn(store, 1, {
+      session_id: SESSION_ID,
+      turn_index: 1,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "forge",
+      agent_role_in_session: "reviewer",
+      manifest_id: "manifest-1",
+      contribution_kind: "review_verdict",
+      output_kind: "verdict",
+      object_id: MILESTONE_ID,
+      summary: "reviewer verdict=plan_accept",
+      artifacts: null,
+      verdict: { result: "plan_accept", rationale: null },
+      next_action_request: null,
+      failure: null,
+    });
+    // Turn 2: sentinel (reviewer) plan_accept — empty artifacts. This turn
+    // triggers convergence in the production scenario.
+    await persistTurn(store, 2, {
+      session_id: SESSION_ID,
+      turn_index: 2,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "sentinel",
+      agent_role_in_session: "reviewer",
+      manifest_id: "manifest-2",
+      contribution_kind: "review_verdict",
+      output_kind: "verdict",
+      object_id: MILESTONE_ID,
+      summary: "reviewer verdict=plan_accept",
+      artifacts: null,
+      verdict: { result: "plan_accept", rationale: null },
+      next_action_request: null,
+      failure: null,
+    });
+
+    const slices = await findSliceDecompositionSlices(
+      SESSION_ID,
+      MILESTONE_ID,
+      store,
+    );
+    expect(slices.length).toBe(2);
+    expect(slices.map((s) => s.slice_id)).toEqual(
+      expect.arrayContaining([SLICE_A, SLICE_B]),
+    );
+    // Slice A has no deps; B blocks on A.
+    const a = slices.find((s) => s.slice_id === SLICE_A)!;
+    const b = slices.find((s) => s.slice_id === SLICE_B)!;
+    expect(a.dependencies).toEqual([]);
+    expect(b.dependencies).toEqual([{ slice_id: SLICE_A, edge_type: "blocks" }]);
+  });
+
+  it("returns the most recent slice_decomposition when multiple exist", async () => {
+    const store = new MemoryStore();
+    await persistTurn(store, 0, {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      manifest_id: "manifest-0",
+      contribution_kind: "lead_draft",
+      output_kind: "slice_decomposition",
+      object_id: MILESTONE_ID,
+      summary: "first draft",
+      artifacts: { slices: [planningSliceFixture(SLICE_A)] },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+    await persistTurn(store, 1, {
+      session_id: SESSION_ID,
+      turn_index: 1,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      manifest_id: "manifest-1",
+      contribution_kind: "lead_draft",
+      output_kind: "slice_decomposition",
+      object_id: MILESTONE_ID,
+      summary: "revised draft",
+      artifacts: {
+        slices: [
+          planningSliceFixture(SLICE_A),
+          planningSliceFixture(SLICE_B, [SLICE_A]),
+        ],
+      },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+
+    const slices = await findSliceDecompositionSlices(
+      SESSION_ID,
+      MILESTONE_ID,
+      store,
+    );
+    expect(slices.length).toBe(2);
+  });
+
+  it("returns empty when no slice_decomposition envelope exists", async () => {
+    const store = new MemoryStore();
+    await persistTurn(store, 0, {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "forge",
+      agent_role_in_session: "reviewer",
+      manifest_id: "manifest-0",
+      contribution_kind: "review_verdict",
+      output_kind: "verdict",
+      object_id: MILESTONE_ID,
+      summary: "reviewer verdict=request_changes",
+      artifacts: null,
+      verdict: { result: "request_changes", rationale: "x" },
+      next_action_request: null,
+      failure: null,
+    });
+
+    const slices = await findSliceDecompositionSlices(
+      SESSION_ID,
+      MILESTONE_ID,
+      store,
+    );
+    expect(slices).toEqual([]);
+  });
+
+  it("returns empty when slice_decomposition exists but artifacts.slices is malformed", async () => {
+    const store = new MemoryStore();
+    await persistTurn(store, 0, {
+      session_id: SESSION_ID,
+      turn_index: 0,
+      parent_loop: "outer",
+      phase_or_purpose: "Planning",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      manifest_id: "manifest-0",
+      contribution_kind: "lead_draft",
+      output_kind: "slice_decomposition",
+      object_id: MILESTONE_ID,
+      summary: "bogus draft",
+      artifacts: { slices: "not-an-array" },
+      verdict: null,
+      next_action_request: null,
+      failure: null,
+    });
+
+    const slices = await findSliceDecompositionSlices(
+      SESSION_ID,
+      MILESTONE_ID,
+      store,
+    );
+    expect(slices).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix Planning convergence so slices from the lead's `output_kind=slice_decomposition` contribution are persisted even when convergence is triggered by a reviewer's plan_accept (not a lead final verdict).
- `outer-turn.ts` Planning dispatch builder: fall back to scanning session turns for the lead's slice_decomposition envelope when the convergence envelope's `artifacts.slices` is empty.
- `caller-dispatch-outer.ts` `persist_slice_dag_and_promote`: defensive throw on empty `slicesToPersist` to prevent silent milestone state advance with no slice DAG.
- Adds regression tests for both paths.

Closes #103

## Test plan
- [x] npm run typecheck
- [x] npm run test (936 passing, was 930 — 6 new)
- [x] npm run build

Refs: incident-7 (run \`/Users/macpro/llm-team-runs/20260510T015239Z/incident-7.md\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)