### PR TITLE
fix(workspace-revision-pin): resolve trunk HEAD instead of placeholder string (incident-8)

### DIFF
--- a/src/adapters/workspace/fake.ts
+++ b/src/adapters/workspace/fake.ts
@@ -28,17 +28,37 @@ export interface FakeWorkspaceOptions {
    * with `result: "conflict"`. Tests use this to drive the SM_STALE branch.
    */
   rebaseConflictSlices?: ReadonlySet<string>;
+  /**
+   * incident-8: deterministic SHA returned by `getTrunkHead()`. Defaults to
+   * a 40-char fixture hash so tests can assert pin propagation without
+   * shelling out to git.
+   */
+  trunkHead?: string;
+  /**
+   * incident-8: refs that `verifyRef()` should accept. By default the fake
+   * accepts the configured `trunkHead` (or its default) plus any value
+   * supplied to `prepareInnerWorkspace` so existing test fixtures keep
+   * working without explicit allowlisting.
+   */
+  knownRefs?: ReadonlySet<string>;
 }
+
+const DEFAULT_FAKE_TRUNK_HEAD = "0".repeat(40);
 
 export class FakeWorkspace implements WorkspacePort {
   private readonly state = new Map<string, { head: string; commits: number }>();
   private readonly rebaseConflictSlices: ReadonlySet<string>;
+  private readonly trunkHead: string;
+  private readonly knownRefs: Set<string>;
 
   constructor(
     private readonly rootDir: string,
     options: FakeWorkspaceOptions = {},
   ) {
     this.rebaseConflictSlices = options.rebaseConflictSlices ?? new Set();
+    this.trunkHead = options.trunkHead ?? DEFAULT_FAKE_TRUNK_HEAD;
+    this.knownRefs = new Set(options.knownRefs ?? []);
+    this.knownRefs.add(this.trunkHead);
   }
 
   async prepareInnerWorkspace(input: {
@@ -54,6 +74,10 @@ export class FakeWorkspace implements WorkspacePort {
         commits: 0,
       });
     }
+    // incident-8: any ref the test seeded as the slice base is treated as a
+    // known ref so subsequent verifyRef() checks succeed without explicit
+    // configuration.
+    this.knownRefs.add(input.trunkBaseRevision);
     return {
       agentCwd: dir,
       headBefore: this.state.get(input.sliceId)!.head,
@@ -104,6 +128,15 @@ export class FakeWorkspace implements WorkspacePort {
     const dir = resolve(this.rootDir, `${input.sliceId}-readonly`);
     mkdirSync(dir, { recursive: true });
     return { agentCwd: dir, headBefore: input.revision };
+  }
+
+  async getTrunkHead(): Promise<string> {
+    return this.trunkHead;
+  }
+
+  async verifyRef(ref: string): Promise<boolean> {
+    if (typeof ref !== "string" || ref.length === 0) return false;
+    return this.knownRefs.has(ref);
   }
 
   async rebaseOntoTrunk(input: {

--- a/src/adapters/workspace/git-worktree.ts
+++ b/src/adapters/workspace/git-worktree.ts
@@ -132,6 +132,26 @@ export class GitWorktreeWorkspace implements WorkspacePort {
     return { result: "clean", commit: head };
   }
 
+  async getTrunkHead(): Promise<string> {
+    // incident-8: resolve the repo-root HEAD so outer-loop callers can pin
+    // sessions / slices to a real git ref instead of a placeholder string.
+    return (await git(this.cfg.repoRoot, ["rev-parse", "HEAD"])).stdout.trim();
+  }
+
+  async verifyRef(ref: string): Promise<boolean> {
+    // incident-8: `rev-parse --verify <ref>^{commit}` returns exit 0 only if
+    // <ref> resolves to a real commit object. Any non-zero exit (including
+    // the "fatal: invalid reference" case that crashed turn-worker) is
+    // surfaced as `false` so the caller can refuse to persist the slice.
+    if (typeof ref !== "string" || ref.length === 0) return false;
+    try {
+      await git(this.cfg.repoRoot, ["rev-parse", "--verify", `${ref}^{commit}`]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private worktreePath(sliceId: string): string {
     return resolve(this.cfg.workspacesDir, sliceId);
   }

--- a/src/adapters/workspace/git-worktree.ts
+++ b/src/adapters/workspace/git-worktree.ts
@@ -143,11 +143,31 @@ export class GitWorktreeWorkspace implements WorkspacePort {
     // <ref> resolves to a real commit object. Any non-zero exit (including
     // the "fatal: invalid reference" case that crashed turn-worker) is
     // surfaced as `false` so the caller can refuse to persist the slice.
+    //
+    // PR #106 review (P1): split invalid-ref (expected, silent false) from
+    // fatal failures (git binary missing / permission / disk). Fatal cases
+    // still return false so the caller can refuse to persist, but emit a
+    // console.warn so the silent failure doesn't mask infra problems in
+    // production. Do not throw — caller (caller-dispatch-outer
+    // persist_slice_dag_and_promote) treats false as
+    // noop_planning_request_changes which is the correct recovery path.
     if (typeof ref !== "string" || ref.length === 0) return false;
     try {
       await git(this.cfg.repoRoot, ["rev-parse", "--verify", `${ref}^{commit}`]);
       return true;
-    } catch {
+    } catch (err) {
+      const msg = (err as Error).message ?? "";
+      const looksInvalidRef =
+        msg.includes("Needed a single revision") ||
+        msg.includes("unknown revision") ||
+        msg.includes("ambiguous argument") ||
+        msg.includes("bad revision") ||
+        msg.includes("fatal: Not a valid object name");
+      if (!looksInvalidRef) {
+        console.warn(
+          `git-worktree.verifyRef: non-invalid-ref failure for ref=${ref}: ${msg.split("\n")[0] ?? msg}`,
+        );
+      }
       return false;
     }
   }

--- a/src/application/caller-dispatch-outer.ts
+++ b/src/application/caller-dispatch-outer.ts
@@ -35,6 +35,7 @@ import {
 } from "../domain/schema/slice.js";
 import type { ClockPort } from "../ports/clock.js";
 import type { StorePort } from "../ports/store.js";
+import type { WorkspacePort } from "../ports/workspace.js";
 import { idempotencyKey } from "./idempotency.js";
 import {
   recordDecision,
@@ -51,6 +52,14 @@ export interface OuterDispatchDeps {
   ledger: LedgerAppender;
   callerId: string;
   targetId: string;
+  /**
+   * incident-8: workspace adapter used by Specification convergence (pin
+   * milestone.spec_revision_pin to the real trunk HEAD on M_SPEC_APPROVED)
+   * and by `persist_slice_dag_and_promote` (verify each slice's
+   * trunk_base_revision before persistence). Optional for backward
+   * compatibility — when absent, the dispatch logic skips both safeguards.
+   */
+  workspace?: WorkspacePort;
 }
 
 export interface OuterDispatchInput {
@@ -295,11 +304,26 @@ async function runOuterEffect(
     }
     case "promote_milestone_to_spec_approved": {
       await persistSpecProposal(input, deps);
-      await transitionMilestoneInLock(liveMilestone, "M_SPEC_APPROVED", deps, {
-        phase: "Specification",
-        sessionId: input.sessionId,
-        finalVerdict: input.final_verdict,
-      });
+      // incident-8: capture the workspace HEAD at convergence so subsequent
+      // outer sessions (Planning) and the slice DAG that lead drafts can pin
+      // to a real ref. Without this, Planning's session_open path resolved
+      // milestone.spec_revision_pin=null → trunk HEAD anyway, but the slice
+      // DAG persisted by lead carried whatever string lead happened to emit
+      // (typically the leaked placeholder from before the pin was real).
+      const specPin =
+        liveMilestone.spec_revision_pin ??
+        (deps.workspace != null ? await deps.workspace.getTrunkHead() : null);
+      await transitionMilestoneInLock(
+        liveMilestone,
+        "M_SPEC_APPROVED",
+        deps,
+        {
+          phase: "Specification",
+          sessionId: input.sessionId,
+          finalVerdict: input.final_verdict,
+        },
+        specPin != null ? { spec_revision_pin: specPin } : undefined,
+      );
       return {
         effect: "promote_milestone_to_spec_approved",
         milestone_state: "M_SPEC_APPROVED",
@@ -356,6 +380,39 @@ async function runOuterEffect(
         throw new Error(
           "persist_slice_dag_and_promote: invariant violation — empty slice DAG should have been rejected upstream (incident-7)",
         );
+      }
+      // incident-8: verify each slice's trunk_base_revision before any
+      // write. The placeholder string "outer-trunk-base" leaked from the
+      // session_open fallback (now fixed) and crashed turn-worker on
+      // `git worktree add ... outer-trunk-base`. Reject the DAG and return
+      // `noop_planning_request_changes` so the milestone stays in
+      // M_DELIVERY_PLANNING for the next Planning re-engagement (consistent
+      // with incident-7 P0 #2 — refuse to advance on invalid input rather
+      // than crash the daemon).
+      if (deps.workspace != null) {
+        const invalid: string[] = [];
+        for (const s of slices) {
+          const ok = await deps.workspace.verifyRef(s.trunk_base_revision);
+          if (!ok) invalid.push(`${s.slice_id}=${s.trunk_base_revision}`);
+        }
+        if (invalid.length > 0) {
+          await emitMilestoneLedgerRow(
+            liveMilestone.state,
+            liveMilestone,
+            liveMilestone.state,
+            deps,
+            {
+              phase: "Planning",
+              sessionId: input.sessionId,
+              finalVerdict: input.final_verdict,
+              result: "noop",
+            },
+          );
+          return {
+            effect: "noop_planning_request_changes",
+            milestone_state: "M_DELIVERY_PLANNING",
+          };
+        }
       }
       const validation = validateSliceDag(slices);
       if (!validation.ok) {
@@ -609,11 +666,21 @@ async function transitionMilestoneInLock(
     finalVerdict: string | null;
     result?: "applied" | "noop" | "escalated";
   },
-  patch?: { context_summary_id?: string },
+  patch?: { context_summary_id?: string; spec_revision_pin?: string },
 ): Promise<MilestoneT> {
   const path = layout.milestone(liveMilestone.milestone_id);
   const fromState = liveMilestone.state;
-  if (liveMilestone.state === toState && patch?.context_summary_id == null) {
+  // incident-8: spec_revision_pin upgrades (null → real SHA) must trigger a
+  // writeAtomic even when state is unchanged on idempotent replay. Same
+  // rationale as the existing context_summary_id branch.
+  const pinChanged =
+    patch?.spec_revision_pin != null &&
+    patch.spec_revision_pin !== liveMilestone.spec_revision_pin;
+  if (
+    liveMilestone.state === toState &&
+    patch?.context_summary_id == null &&
+    !pinChanged
+  ) {
     // Idempotent re-run. Skip writeAtomic (no content change) but still
     // emit the ledger row so the audit trail is complete.
     await emitMilestoneLedgerRow(fromState, liveMilestone, toState, deps, ctx);
@@ -624,6 +691,8 @@ async function transitionMilestoneInLock(
     state: toState,
     context_summary_id:
       patch?.context_summary_id ?? liveMilestone.context_summary_id ?? null,
+    spec_revision_pin:
+      patch?.spec_revision_pin ?? liveMilestone.spec_revision_pin ?? null,
     updated_at: deps.clock.isoNow(),
   });
   await deps.store.writeAtomic(path, JSON.stringify(updated, null, 2));

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -58,6 +58,7 @@ import type { CallerRoutingDecision } from "../domain/schema/session-turn.js";
 import type { ClockPort } from "../ports/clock.js";
 import type { LlmRunnerPort } from "../ports/llm-runner.js";
 import type { StorePort } from "../ports/store.js";
+import type { WorkspacePort } from "../ports/workspace.js";
 import { callAgent } from "./agent-io.js";
 import {
   classifyAgentIoStageFailure,
@@ -114,6 +115,15 @@ export interface OuterTurnDeps {
    * shot CLI invocations work without explicit configuration.
    */
   agentCwd?: string;
+  /**
+   * incident-8: workspace adapter used to resolve the real trunk HEAD when
+   * milestone.spec_revision_pin is null (session_open path) and to verify
+   * slice trunk_base_revision values before persistence
+   * (`persist_slice_dag_and_promote`). Optional for backward compatibility
+   * with existing test deps that do not exercise these code paths; when
+   * absent the legacy fallback is used (placeholder pin / no verification).
+   */
+  workspace?: WorkspacePort;
 }
 
 export type RunOneOuterTurnOutcome =
@@ -184,12 +194,20 @@ export async function runOneOuterTurn(
   if (ready.existingSession != null) {
     session = ready.existingSession;
   } else {
+    // incident-8: when the milestone has not yet pinned a spec revision,
+    // resolve the workspace's real trunk HEAD instead of substituting the
+    // placeholder string "outer-trunk-base". The placeholder leaked through
+    // session.workspace_revision_pin → atlas envelopes → slice DAG and
+    // crashed turn-worker on `git worktree add ... outer-trunk-base`.
+    const workspaceRevisionPin = await resolveOuterWorkspaceRevisionPin(
+      milestone.spec_revision_pin,
+      deps.workspace,
+    );
     session = await openOuterSession(
       {
         milestone,
         phase,
-        workspaceRevisionPin:
-          milestone.spec_revision_pin ?? "outer-trunk-base",
+        workspaceRevisionPin,
       },
       {
         store: deps.store,
@@ -722,6 +740,7 @@ async function finalizeConvergedSession(
     ledger: deps.ledger,
     callerId: deps.callerId,
     targetId: deps.targetId,
+    workspace: deps.workspace,
   });
 
   // P0-6 fix (PR #69 review): treat `illegal_transition` the same as
@@ -882,6 +901,7 @@ async function finalizeNonConvergedSession(
     ledger: deps.ledger,
     callerId: deps.callerId,
     targetId: deps.targetId,
+    workspace: deps.workspace,
   });
 
   if (dispatch.kind === "no_match" || dispatch.kind === "illegal_transition") {
@@ -1460,6 +1480,27 @@ async function loadOuterTurnSummaries(
     }
   }
   return { summaries, evidence };
+}
+
+/**
+ * incident-8 helper. Resolve the workspace revision pin recorded on a new
+ * outer DialogueSession. Order:
+ *   1. milestone.spec_revision_pin (already-pinned spec carry-over).
+ *   2. workspace.getTrunkHead() — real repo HEAD.
+ *   3. Throw — refuse to substitute the legacy "outer-trunk-base"
+ *      placeholder. Callers without a workspace adapter can supply one in
+ *      OuterTurnDeps; tests that don't exercise this path retain the legacy
+ *      behaviour by seeding milestone.spec_revision_pin in their fixtures.
+ */
+async function resolveOuterWorkspaceRevisionPin(
+  specPin: string | null,
+  workspace: WorkspacePort | undefined,
+): Promise<string> {
+  if (specPin != null && specPin.length > 0) return specPin;
+  if (workspace != null) return await workspace.getTrunkHead();
+  throw new Error(
+    "outer-turn: cannot resolve workspace_revision_pin — milestone.spec_revision_pin is null and no WorkspacePort was supplied (incident-8)",
+  );
 }
 
 function lastLeadVerdict(turns: readonly TurnSummary[]): string | null {

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -199,6 +199,24 @@ export async function runOneOuterTurn(
     // placeholder string "outer-trunk-base". The placeholder leaked through
     // session.workspace_revision_pin → atlas envelopes → slice DAG and
     // crashed turn-worker on `git worktree add ... outer-trunk-base`.
+    //
+    // PR #106 review (P1, consensus): if the caller does not supply a
+    // WorkspacePort and the milestone has not yet pinned a spec revision,
+    // return a structured noop outcome instead of throwing. Throwing here
+    // bypasses RunOneOuterTurnOutcome / ledger entirely and aborts the
+    // caller, regressing existing harnesses that omit `workspace` for
+    // milestones whose spec_revision_pin is null.
+    if (
+      (milestone.spec_revision_pin == null ||
+        milestone.spec_revision_pin.length === 0) &&
+      deps.workspace == null
+    ) {
+      return {
+        kind: "noop",
+        detail:
+          "outer-turn: cannot open session — milestone.spec_revision_pin is null and no WorkspacePort was supplied (incident-8)",
+      };
+    }
     const workspaceRevisionPin = await resolveOuterWorkspaceRevisionPin(
       milestone.spec_revision_pin,
       deps.workspace,

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -445,6 +445,7 @@ async function main(argv: readonly string[]): Promise<number> {
             ledger,
             callerId: args.callerId,
             targetId: cfg.identity.target_id,
+            workspace,
           });
           outcomeJson = JSON.stringify({ role: args.role, outcome });
           break;

--- a/src/ports/workspace.ts
+++ b/src/ports/workspace.ts
@@ -79,4 +79,22 @@ export interface WorkspacePort {
     sliceId: string;
     trunkRevision: string;
   }): Promise<RebaseOutcome>;
+
+  /**
+   * incident-8: returns the current trunk HEAD revision (the SHA the inner
+   * agent will branch from when `prepareInnerWorkspace` is invoked next).
+   * Used by outer-loop callers to capture a real revision pin instead of
+   * propagating placeholder strings into Slice.trunk_base_revision /
+   * DialogueSession.workspace_revision_pin.
+   */
+  getTrunkHead(): Promise<string>;
+
+  /**
+   * incident-8: verify that the supplied string resolves to a real git
+   * commit object. Returns true when the ref exists, false otherwise.
+   * Used to gate `persist_slice_dag_and_promote` — slice DAG envelopes
+   * carrying a placeholder `trunk_base_revision` are rejected before any
+   * slice is persisted.
+   */
+  verifyRef(ref: string): Promise<boolean>;
 }

--- a/tests/application/caller-dispatch-outer.test.ts
+++ b/tests/application/caller-dispatch-outer.test.ts
@@ -1,8 +1,12 @@
 /**
  * Phase 5b.1: caller-dispatch-outer effect tests.
  */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { MemoryStore } from "../../src/adapters/store/memory.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
 import { dispatchOuterOutcome } from "../../src/application/caller-dispatch-outer.js";
 import { FileLedger } from "../../src/application/ledger.js";
 import { layout } from "../../src/application/persistence-layout.js";
@@ -166,6 +170,33 @@ describe("dispatchOuterOutcome — Specification", () => {
     );
     expect(reread.state).toBe("M_SPEC_APPROVED");
   });
+
+  it("incident-8: spec_accept captures workspace HEAD onto milestone.spec_revision_pin", async () => {
+    const d = deps();
+    const m = await seedMilestone(d.store, "M_SPECIFICATION_DRAFT");
+    expect(m.spec_revision_pin).toBeNull();
+    const workspaceDir = mkdtempSync(join(tmpdir(), "dispatch-outer-"));
+    const fixtureHead = "a".repeat(40);
+    const workspace = new FakeWorkspace(workspaceDir, { trunkHead: fixtureHead });
+    const r = await dispatchOuterOutcome(
+      {
+        parent_loop: "outer",
+        phase_or_purpose: "Specification",
+        session_state: "CONVERGED",
+        final_verdict: "spec_accept",
+        milestone: m,
+        sessionId: SESS_ID,
+        specProposalBody: "scenarios",
+      },
+      { ...d, workspace },
+    );
+    expect(r.kind).toBe("applied");
+    const reread = Milestone.parse(
+      JSON.parse((await d.store.readText(layout.milestone(M_ID)))!),
+    );
+    expect(reread.state).toBe("M_SPEC_APPROVED");
+    expect(reread.spec_revision_pin).toBe(fixtureHead);
+  });
 });
 
 describe("dispatchOuterOutcome — Planning", () => {
@@ -272,6 +303,71 @@ describe("dispatchOuterOutcome — Planning", () => {
       JSON.parse((await d.store.readText(layout.milestone(M_ID)))!),
     );
     expect(reread.state).toBe("M_DELIVERY_PLANNING");
+  });
+
+  it("incident-8: plan_accept with bogus slice trunk_base_revision returns noop_planning_request_changes (does NOT advance milestone)", async () => {
+    const d = deps();
+    const m = await seedMilestone(d.store, "M_DELIVERY_PLANNING");
+    // makeSlice() emits trunk_base_revision="trunk-base"; allowlist nothing
+    // so verifyRef() returns false for every slice → reject.
+    const workspaceDir = mkdtempSync(join(tmpdir(), "dispatch-outer-"));
+    const workspace = new FakeWorkspace(workspaceDir, {
+      knownRefs: new Set<string>(), // explicit empty: every ref invalid
+    });
+    const slices = [makeSlice(A), makeSlice(B, [{ slice_id: A, edge_type: "blocks" }])];
+    const r = await dispatchOuterOutcome(
+      {
+        parent_loop: "outer",
+        phase_or_purpose: "Planning",
+        session_state: "CONVERGED",
+        final_verdict: "plan_accept",
+        milestone: m,
+        sessionId: SESS_ID,
+        slicesToPersist: slices,
+      },
+      { ...d, workspace },
+    );
+    expect(r.kind).toBe("applied");
+    if (r.kind !== "applied") return;
+    expect(r.details[0]).toMatchObject({
+      effect: "noop_planning_request_changes",
+      milestone_state: "M_DELIVERY_PLANNING",
+    });
+    // No slice was persisted.
+    const sliceA = await d.store.readText(layout.slice(A));
+    expect(sliceA).toBeNull();
+    // Milestone stays in PLANNING.
+    const reread = Milestone.parse(
+      JSON.parse((await d.store.readText(layout.milestone(M_ID)))!),
+    );
+    expect(reread.state).toBe("M_DELIVERY_PLANNING");
+  });
+
+  it("incident-8: plan_accept with valid trunk_base_revision passes verifyRef and advances", async () => {
+    const d = deps();
+    const m = await seedMilestone(d.store, "M_DELIVERY_PLANNING");
+    const workspaceDir = mkdtempSync(join(tmpdir(), "dispatch-outer-"));
+    const workspace = new FakeWorkspace(workspaceDir, {
+      knownRefs: new Set(["trunk-base"]),
+    });
+    const slices = [makeSlice(A)];
+    const r = await dispatchOuterOutcome(
+      {
+        parent_loop: "outer",
+        phase_or_purpose: "Planning",
+        session_state: "CONVERGED",
+        final_verdict: "plan_accept",
+        milestone: m,
+        sessionId: SESS_ID,
+        slicesToPersist: slices,
+      },
+      { ...d, workspace },
+    );
+    expect(r.kind).toBe("applied");
+    const reread = Milestone.parse(
+      JSON.parse((await d.store.readText(layout.milestone(M_ID)))!),
+    );
+    expect(reread.state).toBe("M_DELIVERY_BUILDING");
   });
 
   it("incident-7: plan_accept with explicit empty slices array also returns no_match", async () => {

--- a/tests/e2e/outer-discovery-mock.test.ts
+++ b/tests/e2e/outer-discovery-mock.test.ts
@@ -17,8 +17,10 @@
 import { describe, expect, it } from "vitest";
 
 import { createE2eRun } from "../helpers/e2e-harness.js";
+import { resolve } from "node:path";
 import { AdapterRunnerPort } from "../../src/adapters/llm-runner/runtime-port.js";
 import { FsStore } from "../../src/adapters/store/fs.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
 import { FileLedger } from "../../src/application/ledger.js";
 import { runOneOuterTurn } from "../../src/application/outer-turn.js";
 import { layout } from "../../src/application/persistence-layout.js";
@@ -232,6 +234,10 @@ describe("Phase prod-5 — outer Discovery mock smoke (default-pass)", () => {
         sentinel: [reviewerVerdict(MILESTONE_ID, "spec_accept")],
       });
       const llmRunner = new AdapterRunnerPort(adapter);
+      // incident-8: deterministic workspace adapter so the session_open
+      // path resolves a real-looking trunk HEAD instead of crashing on the
+      // legacy placeholder fallback.
+      const workspace = new FakeWorkspace(resolve(handle.workdir, "workspaces"));
       const baseDeps = {
         store,
         clock,
@@ -239,6 +245,7 @@ describe("Phase prod-5 — outer Discovery mock smoke (default-pass)", () => {
         ledger,
         callerId: "e2e-caller",
         targetId,
+        workspace,
       };
 
       // Turn 0: lead draft.

--- a/tests/integration/outer-turn.test.ts
+++ b/tests/integration/outer-turn.test.ts
@@ -19,10 +19,11 @@
  */
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { AdapterRunnerPort } from "../../src/adapters/llm-runner/runtime-port.js";
 import { FsStore } from "../../src/adapters/store/fs.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
 import { FileLedger } from "../../src/application/ledger.js";
 import { runOneOuterTurn } from "../../src/application/outer-turn.js";
 import { layout } from "../../src/application/persistence-layout.js";
@@ -294,7 +295,15 @@ function setup() {
   const clock = new SystemClock();
   const logger = new CollectingLogger();
   const ledger = new FileLedger({ store, logger });
-  return { workdir, store, clock, logger, ledger };
+  // incident-8: provide a deterministic workspace adapter so resolveOuter
+  // WorkspaceRevisionPin can fall back to a real-looking SHA when
+  // milestone.spec_revision_pin is null. The Planning slice fixtures pin
+  // each slice's trunk_base_revision to "trunk-base"; allowlist that ref so
+  // verifyRef() succeeds without rewriting every fixture.
+  const workspace = new FakeWorkspace(resolve(workdir, "workspaces"), {
+    knownRefs: new Set(["trunk-base", "spec-rev-1"]),
+  });
+  return { workdir, store, clock, logger, ledger, workspace };
 }
 
 /**
@@ -387,6 +396,7 @@ describe("runOneOuterTurn — Discovery quorum_then_lead spec_accept", () => {
       ledger: env.ledger,
       callerId: "test",
       targetId: "demo",
+      workspace: env.workspace,
     };
 
     // Turn 0: lead draft
@@ -457,6 +467,7 @@ describe("runOneOuterTurn — Discovery reviewer request_changes re-engages lead
       ledger: env.ledger,
       callerId: "test",
       targetId: "demo",
+      workspace: env.workspace,
     };
 
     const t0 = await runOneOuterTurn(baseDeps);
@@ -507,6 +518,7 @@ describe("runOneOuterTurn — Specification quorum=2 spec_accept", () => {
       ledger: env.ledger,
       callerId: "test",
       targetId: "demo",
+      workspace: env.workspace,
     };
 
     // Specification needs quorum_min=2 reviewers + lead.
@@ -566,6 +578,7 @@ describe("runOneOuterTurn — Planning unanimous_approve persists slice DAG", ()
       ledger: env.ledger,
       callerId: "test",
       targetId: "demo",
+      workspace: env.workspace,
     };
 
     let last;
@@ -622,6 +635,7 @@ describe("runOneOuterTurn — Validation lead_only PASS finalizes M_DONE", () =>
       ledger: env.ledger,
       callerId: "test",
       targetId: "demo",
+      workspace: env.workspace,
     };
 
     const out = await runOneOuterTurn(baseDeps);
@@ -807,6 +821,7 @@ describe("runOneOuterTurn — Validation lead_only PASS finalizes M_DONE", () =>
       ledger: env.ledger,
       callerId: "test",
       targetId: "demo",
+      workspace: env.workspace,
     };
     const out = await runOneOuterTurn(baseDeps);
     expect(out.kind).toBe("turn_persisted");
@@ -824,6 +839,38 @@ describe("runOneOuterTurn — Validation lead_only PASS finalizes M_DONE", () =>
       JSON.parse((await env.store.readText(layout.milestone(MILESTONE_ID)))!),
     );
     expect(m.state).toBe("M_DELIVERY_BUILDING");
+  });
+});
+
+describe("runOneOuterTurn — incident-8 workspace_revision_pin resolution", () => {
+  it("opens session with workspace.getTrunkHead() when milestone.spec_revision_pin is null (NOT 'outer-trunk-base')", async () => {
+    const env = setup();
+    await seedMilestone(env.store, "M_DISCOVERY_DRAFT"); // spec_revision_pin=null
+    const { adapter } = makeStub({
+      atlas: [specProposalDraft(MILESTONE_ID, "draft")],
+    });
+    const llmRunner = new AdapterRunnerPort(adapter);
+    const fixtureHead = await env.workspace.getTrunkHead();
+
+    const out = await runOneOuterTurn({
+      store: env.store,
+      clock: env.clock,
+      llmRunner,
+      ledger: env.ledger,
+      callerId: "test",
+      targetId: "demo",
+      workspace: env.workspace,
+    });
+    expect(out.kind).toBe("turn_persisted");
+    if (out.kind !== "turn_persisted") return;
+
+    const session = DialogueSession.parse(
+      JSON.parse(
+        (await env.store.readText(layout.sessionMetadata(out.sessionId)))!,
+      ),
+    );
+    expect(session.workspace_revision_pin).toBe(fixtureHead);
+    expect(session.workspace_revision_pin).not.toBe("outer-trunk-base");
   });
 });
 


### PR DESCRIPTION
## Summary
- Outer-loop session_open path no longer leaks the literal `"outer-trunk-base"` into `DialogueSession.workspace_revision_pin` / `Slice.trunk_base_revision`. `WorkspacePort.getTrunkHead()` resolves the real repo HEAD when `milestone.spec_revision_pin` is null.
- Specification convergence (`M_SPECIFICATION_DRAFT → M_SPEC_APPROVED`) now captures `workspace.getTrunkHead()` onto `milestone.spec_revision_pin` so subsequent Planning/slice DAG envelopes inherit a real ref.
- `persist_slice_dag_and_promote` validates each slice's `trunk_base_revision` via the new `WorkspacePort.verifyRef()`. Bogus refs return `noop_planning_request_changes` (incident-7 P0 #2 pattern) — milestone stays in `M_DELIVERY_PLANNING` instead of crashing turn-worker on `git worktree add … <bogus>`.

## Changes
| Module | Artifact | Notes |
|---|---|---|
| `src/ports/workspace.ts` | `WorkspacePort` | `getTrunkHead()`, `verifyRef()` 추가 (additive — 기존 consumer 호환) |
| `src/adapters/workspace/git-worktree.ts` | impl | `git rev-parse HEAD` / `git rev-parse --verify <ref>^{commit}` |
| `src/adapters/workspace/fake.ts` | impl | deterministic SHA + `knownRefs` allowlist (configurable for tests) |
| `src/application/outer-turn.ts` | `runOneOuterTurn` | `resolveOuterWorkspaceRevisionPin` 헬퍼; placeholder fallback 제거; `OuterTurnDeps.workspace` 추가 (optional) |
| `src/application/caller-dispatch-outer.ts` | Specification + Planning effects | `OuterDispatchDeps.workspace` 추가; `transitionMilestoneInLock` patch 에 `spec_revision_pin` 지원; slice ref 검증 |
| `src/cli/daemon.ts` | outer-coordinator role | workspace 를 deps 로 전달 |
| `tests/**` | unit + integration | 4 신규 테스트 + 기존 픽스처 wiring (`workspace: env.workspace`) |

## Closes
Closes #105 (incident-8 GitHub issue)

## Operator recovery (already applied)
Live workdir's slice `01KR8B2QTP39JM1FBHQ3S040S1` and session `01KR8E1NNZZAKZYVDVK13140ZZ` had their `trunk_base_revision` / `workspace_revision_pin` patched from the placeholder `"outer-trunk-base"` to the real HEAD SHA `0b25ca1ec635cbc66f47653500beff016ce5a5b1` so the daemon can resume after this PR merges.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 946 passing / 4 skipped (was 938 / 4); new tests cover outer-turn pin fallback, Specification spec_revision_pin capture, persist_slice_dag rejection on bogus ref, valid ref pass-through
- [x] `npm run build` clean
- [x] No regressions in existing workspace / outer-turn / dispatch suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)