### PR TITLE
fix(manifest-resolve): inline (slice, body) so inner TDD forge can author patches (incident-9)

### DIFF
--- a/src/application/manifest-resolve.ts
+++ b/src/application/manifest-resolve.ts
@@ -4,6 +4,7 @@ import type { StorePort } from "../ports/store.js";
 import { Milestone } from "../domain/schema/milestone.js";
 import { FeatureRequest } from "../domain/schema/feature-request.js";
 import { SessionTurn } from "../domain/schema/session-turn.js";
+import { Slice } from "../domain/schema/slice.js";
 import { layout } from "./persistence-layout.js";
 
 /**
@@ -28,6 +29,14 @@ import { layout } from "./persistence-layout.js";
  *     agent-relevant subset under `# Inputs` so prior reviewer rationales
  *     reach the next lead/reviewer (breaks the
  *     `request_changes ↔ need_context` Discovery loop).
+ *   - `slice` + `body` — incident-9: load `slices/<slice_id>.json` and
+ *     project the agent-relevant subset (slice_id, slice_kind,
+ *     value_statement, ac_ids, acceptance_tests, declared_scope,
+ *     dependencies, state, dod_revision_pin, trunk_base_revision) so the
+ *     inner TDD `forge` agent can author patches instead of looping on
+ *     `failure: need_context`. Revision pin is matched by equality with
+ *     `slice.dod_revision_pin` (a logical marker like `selfhost-dod-v1`,
+ *     not a SHA — consistent with `SliceLocalPinResolver` in turn-worker).
  *   - Other (object_kind, fetch_scope) combinations throw an explicit
  *     "unsupported" error. The caller decides:
  *       - `required=true` → surface the error (caller turns into AGC-INVALID),
@@ -112,16 +121,19 @@ async function resolveEntry(
   if (entry.object_kind === "session_turn" && entry.fetch_scope === "body") {
     return resolveSessionTurnBody(store, entry);
   }
+  if (entry.object_kind === "slice" && entry.fetch_scope === "body") {
+    return resolveSliceBody(store, entry);
+  }
   // Other (kind, scope) pairs remain out of scope. For `required=true`
   // entries the resolver throws so the caller can surface an AGC-INVALID
   // outcome (no silent empty prompt). For non-required entries the caller
   // catches and skips (entry omitted from `# Inputs`). Future work can
-  // extend this switch with slice / slice_merge / dialogue_session /
+  // extend this switch with slice_merge / dialogue_session /
   // verification_run resolution.
   if (entry.required) {
     throw new UnsupportedManifestEntryError(
       entry,
-      "resolver supports (milestone, body) and (session_turn, body) only",
+      "resolver supports (milestone, body), (session_turn, body), (slice, body) only",
     );
   }
   return null;
@@ -266,6 +278,75 @@ async function resolveSessionTurnBody(
     verdict: env.verdict,
     failure: env.failure,
     next_action_request: env.next_action_request,
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * incident-9 — resolve `(slice, body)` so the inner TDD `forge` agent can
+ * read its primary input (slice scope, AC list, declared_scope,
+ * dod_revision_pin, trunk_base_revision) inline under `# Inputs` instead
+ * of returning `failure: need_context` because the body section reports
+ * `BODY NOT INLINED`.
+ *
+ * Layout: `slices/<slice_id>.json` (see `persistence-layout.ts`).
+ *
+ * Revision pin: equality with `slice.dod_revision_pin`. Unlike milestone
+ * (`updated_at`) and session_turn (full-body sha256) pins which are
+ * content-derived, the slice pin is a LOGICAL marker authored by the
+ * outer/middle loops (e.g. `selfhost-dod-v1`) and stored on the slice
+ * record itself. `SliceLocalPinResolver` in `turn-worker.ts` uses the
+ * same `slice.dod_revision_pin` to populate the manifest pin, so a match
+ * is the correct freshness check. Mismatches surface
+ * `StaleManifestEntryError` for required entries (mirrors milestone /
+ * session_turn body).
+ *
+ * Projection: agent-relevant subset only. The full Slice record contains
+ * caller/lease metadata (`current_session_id`, `spawning_proposal_id`,
+ * `abandoned_reason`, `external_refs`, timestamps) that don't help
+ * `forge` author the patch.
+ */
+async function resolveSliceBody(
+  store: StorePort,
+  entry: ManifestEntry,
+): Promise<string | null> {
+  const path = layout.slice(entry.object_id);
+  const raw = await store.readText(path);
+  if (raw == null) {
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  let slice: ReturnType<typeof Slice.parse>;
+  try {
+    slice = Slice.parse(JSON.parse(raw));
+  } catch {
+    // Persisted file is corrupt / not a Slice; treat as missing.
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  // Revision-pin check — equality with `slice.dod_revision_pin` (logical
+  // marker, not content hash). See doc comment above for rationale.
+  if (slice.dod_revision_pin !== entry.revision_pin) {
+    if (entry.required) {
+      throw new StaleManifestEntryError(entry, slice.dod_revision_pin);
+    }
+    return null;
+  }
+  const projection: Record<string, unknown> = {
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    value_statement: slice.value_statement,
+    ac_ids: slice.ac_ids,
+    acceptance_tests: slice.acceptance_tests,
+    declared_scope: slice.declared_scope,
+    dependencies: slice.dependencies,
+    state: slice.state,
+    dod_revision_pin: slice.dod_revision_pin,
+    trunk_base_revision: slice.trunk_base_revision,
   };
   return JSON.stringify(projection, null, 2);
 }

--- a/src/application/turn-worker.ts
+++ b/src/application/turn-worker.ts
@@ -307,7 +307,13 @@ async function runOneInnerTurnInner(
       },
       runtimeMetadata: { workspace_pin_before: prep.headBefore },
     },
-    { llmRunner: deps.llmRunner, manifestBuilder },
+    // incident-9: wire StorePort so `callAgent` resolves the
+    // `(slice, body)` manifest entry into the prompt's `# Inputs`
+    // section. Without this, the inner TDD `forge` agent saw the
+    // `BODY NOT INLINED` sentinel and (correctly) refused to author
+    // patches, returning `failure: need_context` indefinitely. The
+    // resolver gained `(slice, body)` support in this same change.
+    { llmRunner: deps.llmRunner, manifestBuilder, store: deps.store },
   );
   if (!agentOut.ok) {
     // P0 fix (PR #61 review): record an invalid ledger row so the audit

--- a/tests/application/manifest-resolve.test.ts
+++ b/tests/application/manifest-resolve.test.ts
@@ -136,9 +136,11 @@ describe("resolveManifestEntries", () => {
   it("throws on required entries with unsupported (object_kind, fetch_scope)", async () => {
     const store = new MemoryStore();
     await seedMilestone(store, "raw");
+    // incident-9 made `(slice, body)` supported, so use `(slice_merge, body)`
+    // here as the still-unsupported pair.
     const manifest = buildManifest([
       {
-        object_kind: "slice",
+        object_kind: "slice_merge",
         object_id: "01HZS00000000000000000000A",
         fetch_scope: "body",
         revision_pin: "deadbeef",
@@ -482,6 +484,215 @@ describe("resolveManifestEntries — session_turn body (incident-5)", () => {
       revision_pin: "len=0:",
       required: false,
       purpose: "advisory prior turn",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    // Only the milestone entry survives.
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.manifest_entry_index).toBe(0);
+  });
+});
+
+/**
+ * incident-9 — `(slice, body)` resolver tests. The inner TDD `forge` agent
+ * was stuck in `failure: need_context` for 29+ turns because the
+ * `(slice, body)` manifest entry rendered as `[BODY NOT INLINED]` in the
+ * prompt. These tests lock the new behaviour: body is read from
+ * `slices/<slice_id>.json`, projected to agent-relevant Slice fields, with
+ * the same revision_pin / required-missing / stale-pin failure modes as
+ * milestone / session_turn body resolution. Pin equality is matched
+ * against `slice.dod_revision_pin` (logical marker, not content hash).
+ */
+describe("resolveManifestEntries — slice body (incident-9)", () => {
+  const SLICE_SESSION_ID = "01HZSE000000000000000000S1";
+  const SLICE_PRIMARY_MS = "01HZMS00000000000000000S02";
+  const SLICE_PRIMARY_FR = "01HZFR00000000000000000S02";
+  const SLICE_ID = "01HZSC000000000000000000S2";
+  const SLICE_ISO = "2026-05-09T08:00:00.000Z";
+  const DOD_PIN = "selfhost-dod-v1";
+
+  function buildSlice(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      slice_id: SLICE_ID,
+      milestone_id: SLICE_PRIMARY_MS,
+      slice_kind: "internal",
+      value_statement: "Discovery loop fix — inline session_turn body",
+      ac_ids: ["AC-1", "AC-2"],
+      acceptance_tests: [
+        { path: "tests/x.test.ts", name: "loop converges", ac_id: "AC-1" },
+      ],
+      declared_scope: ["src/application/manifest-resolve.ts"],
+      declared_metric_threshold: null,
+      interface_break: false,
+      dependencies: [],
+      trunk_base_revision: "trunk-abc123",
+      dod_revision_pin: DOD_PIN,
+      state: "SLICE_BUILDING",
+      current_session_id: SLICE_SESSION_ID,
+      spawning_proposal_id: null,
+      abandoned_reason: null,
+      external_refs: [],
+      created_at: SLICE_ISO,
+      updated_at: SLICE_ISO,
+      ...overrides,
+    };
+  }
+
+  async function seedSliceMilestone(store: MemoryStore) {
+    await store.writeAtomic(
+      layout.milestone(SLICE_PRIMARY_MS),
+      JSON.stringify({
+        milestone_id: SLICE_PRIMARY_MS,
+        target_id: "team-a",
+        title: "Inner TDD slice resolution",
+        state: "M_DELIVERY_BUILDING",
+        slot_kind: "delivery",
+        intake_source_kind: "feature_request",
+        intake_source_id: SLICE_PRIMARY_FR,
+        spec_revision_pin: null,
+        context_summary_id: null,
+        external_refs: [],
+        created_at: SLICE_ISO,
+        updated_at: SLICE_ISO,
+      }),
+    );
+    await store.writeAtomic(
+      layout.featureRequest(SLICE_PRIMARY_FR),
+      JSON.stringify({
+        request_id: SLICE_PRIMARY_FR,
+        title: "Inner TDD slice resolution",
+        body: "raw scope text",
+        submitted_by: "user@example.com",
+        submitted_at: SLICE_ISO,
+        state: "queued",
+        promoted_milestone_id: null,
+        processed_at: null,
+        rejection_reason: null,
+      }),
+    );
+  }
+
+  function manifestWithSlice(extra: any) {
+    return ContextManifest.parse({
+      manifest_id: "01HZMA00000000000000000S01",
+      session_id: SLICE_SESSION_ID,
+      turn_index: 0,
+      purpose: "tdd_build",
+      target: { object_kind: "slice", object_id: SLICE_ID },
+      entries: [
+        {
+          object_kind: "milestone",
+          object_id: SLICE_PRIMARY_MS,
+          fetch_scope: "body",
+          revision_pin: SLICE_ISO,
+          required: true,
+          purpose: "primary",
+        },
+        extra,
+      ],
+      created_at: SLICE_ISO,
+    });
+  }
+
+  it("resolves required slice body — projects agent-relevant Slice subset", async () => {
+    const store = new MemoryStore();
+    await seedSliceMilestone(store);
+    await store.writeAtomic(
+      layout.slice(SLICE_ID),
+      JSON.stringify(buildSlice()),
+    );
+    const manifest = manifestWithSlice({
+      object_kind: "slice",
+      object_id: SLICE_ID,
+      fetch_scope: "body",
+      revision_pin: DOD_PIN,
+      required: true,
+      purpose: "primary input",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(2);
+    const sliceEntry = resolved.find((r) => r.manifest_entry_index === 1)!;
+    const body = sliceEntry.body;
+    // Selected fields must appear.
+    for (const key of [
+      "slice_id",
+      "slice_kind",
+      "value_statement",
+      "ac_ids",
+      "acceptance_tests",
+      "declared_scope",
+      "dependencies",
+      "state",
+      "dod_revision_pin",
+      "trunk_base_revision",
+    ]) {
+      expect(body, `selected field ${key} missing`).toContain(`"${key}"`);
+    }
+    expect(body).toContain(SLICE_ID);
+    expect(body).toContain(DOD_PIN);
+    expect(body).toContain("Discovery loop fix");
+    expect(body).toContain("trunk-abc123");
+    // Excluded fields (caller/lease metadata, timestamps).
+    for (const key of [
+      "current_session_id",
+      "spawning_proposal_id",
+      "abandoned_reason",
+      "external_refs",
+      "created_at",
+      "updated_at",
+      "milestone_id",
+      "interface_break",
+      "declared_metric_threshold",
+    ]) {
+      expect(body, `excluded field ${key} leaked`).not.toContain(`"${key}"`);
+    }
+  });
+
+  it("throws MissingRequiredManifestEntryError when slice file is absent and required", async () => {
+    const store = new MemoryStore();
+    await seedSliceMilestone(store);
+    const manifest = manifestWithSlice({
+      object_kind: "slice",
+      object_id: SLICE_ID,
+      fetch_scope: "body",
+      revision_pin: DOD_PIN,
+      required: true,
+      purpose: "primary input",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("throws StaleManifestEntryError when revision_pin differs from slice.dod_revision_pin", async () => {
+    const store = new MemoryStore();
+    await seedSliceMilestone(store);
+    await store.writeAtomic(
+      layout.slice(SLICE_ID),
+      JSON.stringify(buildSlice({ dod_revision_pin: "selfhost-dod-v2" })),
+    );
+    const manifest = manifestWithSlice({
+      object_kind: "slice",
+      object_id: SLICE_ID,
+      fetch_scope: "body",
+      revision_pin: DOD_PIN,
+      required: true,
+      purpose: "primary input",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /revision_pin mismatch/,
+    );
+  });
+
+  it("silently skips non-required slice body when file is absent", async () => {
+    const store = new MemoryStore();
+    await seedSliceMilestone(store);
+    const manifest = manifestWithSlice({
+      object_kind: "slice",
+      object_id: SLICE_ID,
+      fetch_scope: "body",
+      revision_pin: DOD_PIN,
+      required: false,
+      purpose: "advisory slice",
     });
     const resolved = await resolveManifestEntries(store, manifest);
     // Only the milestone entry survives.


### PR DESCRIPTION
## Summary
- Inner TDD `forge` was stuck for 29+ turns returning `failure: need_context` because the `(slice, body)` manifest entry rendered as `[BODY NOT INLINED]` in the prompt — the resolver explicitly excluded `(slice, body)` (PR #96) and the inner `callAgent` never wired `StorePort` so `resolveManifestEntries` was never even invoked.
- Adds `resolveSliceBody` (pin equality vs `slice.dod_revision_pin`, agent-relevant Slice projection) and wires `store: deps.store` into the inner-loop `callAgent` so the slice body is now inlined under `# Inputs`.

### 변경 내용
| Module | Artifact | Notes |
|---|---|---|
| `src/application/manifest-resolve.ts` | `resolveSliceBody` | New resolver mirroring milestone/session_turn patterns; ADD-only |
| `src/application/turn-worker.ts` | `callAgent` deps | Pass `store: deps.store` so `(slice, body)` resolves into prompt |
| `tests/application/manifest-resolve.test.ts` | 4 new tests | required-resolves projection, missing-file, stale-pin, non-required skip |

## Closes
Closes #107 (incident-9 GitHub issue)

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — new tests for (slice, body) resolution + missing-file error pass (946 passing, was 942)
- [x] No regressions in existing manifest-resolve tests (legacy "unsupported" test rewritten to use `(slice_merge, body)`, still out of scope)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)