### PR TITLE
fix(timeout): per-phase timeout_sec + inner lr_invoke retry cap (incident-10)

### DIFF
--- a/src/application/dialogue-coordinator.ts
+++ b/src/application/dialogue-coordinator.ts
@@ -46,7 +46,11 @@ import { assertCanAcquire } from "./lease-acquisition-order.js";
 import { withLeaseHeartbeat } from "./lease-heartbeat.js";
 import { resolveLeaseTtl } from "./lease-ttl-resolver.js";
 import type { LeasePort } from "../ports/lease.js";
-import type { LeaseConfig } from "../config/target-schema.js";
+import {
+  resolveAgentTimeoutSec,
+  type ContextBudget,
+  type LeaseConfig,
+} from "../config/target-schema.js";
 import { idempotencyKey } from "./idempotency.js";
 import type { LedgerAppender } from "./ledger.js";
 import {
@@ -82,6 +86,12 @@ export interface CoordinatorDeps {
   reverifyTestCommands: (workspaceCwd: string) => CommandSpec[];
   environmentFingerprint: string;
   agentTimeoutSec?: number;
+  /**
+   * incident-10: TCC-CONTEXT-BUDGET map. When provided, `middle.review`
+   * `timeout_sec` overrides resolve via `resolveAgentTimeoutSec`. Falls
+   * back to `agentTimeoutSec ?? 120` for legacy callers.
+   */
+  contextBudget?: ContextBudget;
   maxReviewTurns?: number;
   /**
    * PR #63 review fix: phase-4 wire-up. When provided, the coordinator
@@ -304,7 +314,12 @@ async function runMiddleReviewTurnInner(
       manifest,
       workspaceRevisionPin: prep.headBefore,
       agentCwd: prep.agentCwd,
-      timeoutSec: deps.agentTimeoutSec ?? 120,
+      timeoutSec: resolveAgentTimeoutSec(
+        deps.contextBudget,
+        "middle",
+        "review",
+        deps.agentTimeoutSec ?? 120,
+      ),
       idempotency: {
         scope: "per_turn",
         parts: {

--- a/src/application/dialogue-coordinator.ts
+++ b/src/application/dialogue-coordinator.ts
@@ -318,7 +318,7 @@ async function runMiddleReviewTurnInner(
         deps.contextBudget,
         "middle",
         "review",
-        deps.agentTimeoutSec ?? 120,
+        deps.agentTimeoutSec,
       ),
       idempotency: {
         scope: "per_turn",
@@ -335,6 +335,11 @@ async function runMiddleReviewTurnInner(
         pre_merge_workspace_revision:
           sliceMerge.pre_merge_workspace_revision ?? "",
       },
+      // PR #110 review P1-b (gpt5.5): forward operator
+      // `context_budget` so per-phase `token_hard_cap` reaches
+      // `composePromptWithBudget`. Previously this only fed the
+      // timeout resolver, leaving prompt-budget overrides silent.
+      contextBudget: deps.contextBudget,
     },
     { llmRunner: deps.llmRunner, manifestBuilder },
   );

--- a/src/application/failure-policy.ts
+++ b/src/application/failure-policy.ts
@@ -35,6 +35,15 @@ export interface RetryConfig {
    * tighter than agent-side streaks. Default 3.
    */
   promptComposeTruncationLimit?: number;
+  /**
+   * incident-10: maximum consecutive `lr_invoke/lr_exit_status` failures
+   * whose detail string indicates a runner-level timeout
+   * (`exitStatus=timeout`) before an inner session is ABANDONED. Distinct
+   * from agent-side `no_progress` because no envelope is ever produced —
+   * the streak counter has no agent signal to advance, and the daemon
+   * would otherwise re-pick the session indefinitely. Default 5.
+   */
+  innerLrInvokeTimeoutLimit?: number;
 }
 
 export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
@@ -44,6 +53,7 @@ export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
   middleReviewAttemptsLimit: 3,
   sliceMergeRevalidationLimit: 1,
   promptComposeTruncationLimit: 3,
+  innerLrInvokeTimeoutLimit: 5,
 };
 
 export type FailureClassification =
@@ -52,7 +62,8 @@ export type FailureClassification =
   | "scope_violation"
   | "middle_review_attempt"
   | "slice_merge_revalidation"
-  | "prompt_compose_truncation";
+  | "prompt_compose_truncation"
+  | "inner_lr_invoke_timeout";
 
 export type RetryDecision =
   | { decision: "continue"; remaining: number }
@@ -90,6 +101,8 @@ function limitFor(
       return cfg.sliceMergeRevalidationLimit;
     case "prompt_compose_truncation":
       return cfg.promptComposeTruncationLimit;
+    case "inner_lr_invoke_timeout":
+      return cfg.innerLrInvokeTimeoutLimit;
   }
 }
 
@@ -109,9 +122,22 @@ function limitFor(
 export function classifyAgentIoStageFailure(outcome: {
   ok: boolean;
   stage?: string;
+  detail?: string;
 }): FailureClassification | null {
   if (outcome.ok) return null;
   if (outcome.stage === "prompt_compose") return "prompt_compose_truncation";
+  // incident-10: only the runner-level timeout flavor of `lr_invoke` failures
+  // contributes to the inner abandon counter. Other `lr_invoke` failures
+  // (e.g. spawn errors, non-zero exit) are surfaced as invalid envelopes
+  // but do not advance this streak — they are typically environmental and
+  // operator-recoverable, distinct from the "model is hanging" signal.
+  if (
+    outcome.stage === "lr_invoke" &&
+    typeof outcome.detail === "string" &&
+    outcome.detail.includes("exitStatus=timeout")
+  ) {
+    return "inner_lr_invoke_timeout";
+  }
   return null;
 }
 
@@ -146,6 +172,46 @@ export async function countPromptComposeFailuresFromLedger(
     if (
       typeof row.result_detail === "string" &&
       row.result_detail.startsWith("prompt_compose/")
+    ) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * incident-10: count prior `lr_invoke/lr_exit_status` invalid ledger rows
+ * for a given session whose detail string indicates a runner-level timeout
+ * (`exitStatus=timeout`). Mirrors `countPromptComposeFailuresFromLedger` —
+ * the ledger is the only durable record that survives daemon restarts, and
+ * timeouts produce no envelope so no agent-side streak counter advances.
+ *
+ * Format produced by `turn-worker.emitInvalidTurn`:
+ *   `result_detail = "lr_invoke/lr_exit_status: LlmRunner exitStatus=timeout; envelopeRef=..."`
+ *
+ * Callers use the returned count as `currentCount` for `evaluateRetry`.
+ */
+export async function countLrInvokeTimeoutsFromLedger(
+  store: { readText(relPath: string): Promise<string | null> },
+  sessionId: string,
+): Promise<number> {
+  const body = await store.readText("ledger/transitions.ndjson");
+  if (body == null || body.length === 0) return 0;
+  let count = 0;
+  for (const line of body.split("\n")) {
+    if (line.length === 0) continue;
+    let row: { session_id?: unknown; result?: unknown; result_detail?: unknown };
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (row.session_id !== sessionId) continue;
+    if (row.result !== "invalid") continue;
+    if (
+      typeof row.result_detail === "string" &&
+      row.result_detail.startsWith("lr_invoke/lr_exit_status") &&
+      row.result_detail.includes("exitStatus=timeout")
     ) {
       count += 1;
     }

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -59,6 +59,10 @@ import type { ClockPort } from "../ports/clock.js";
 import type { LlmRunnerPort } from "../ports/llm-runner.js";
 import type { StorePort } from "../ports/store.js";
 import type { WorkspacePort } from "../ports/workspace.js";
+import {
+  resolveAgentTimeoutSec,
+  type ContextBudget,
+} from "../config/target-schema.js";
 import { callAgent } from "./agent-io.js";
 import {
   classifyAgentIoStageFailure,
@@ -107,6 +111,13 @@ export interface OuterTurnDeps {
   callerId: string;
   targetId: string;
   agentTimeoutSec?: number;
+  /**
+   * incident-10: TCC-CONTEXT-BUDGET map. When provided, per-phase
+   * `timeout_sec` overrides resolve through `resolveAgentTimeoutSec` for
+   * each outer phase invocation. Falls back to `agentTimeoutSec ?? 120` for
+   * unknown (loop, step) pairs (defensive — outer phases are LoopStep-typed).
+   */
+  contextBudget?: ContextBudget;
   maxOuterTurns?: number;
   /**
    * Working directory passed to the LLM runner as `agentCwd`. Outer agents
@@ -445,7 +456,12 @@ export async function runOneOuterTurn(
       manifest,
       workspaceRevisionPin: session.workspace_revision_pin,
       agentCwd: deps.agentCwd ?? process.cwd(),
-      timeoutSec: deps.agentTimeoutSec ?? 120,
+      timeoutSec: resolveAgentTimeoutSec(
+        deps.contextBudget,
+        "outer",
+        phase,
+        deps.agentTimeoutSec ?? 120,
+      ),
       idempotency: {
         scope: "per_turn",
         parts: {

--- a/src/application/outer-turn.ts
+++ b/src/application/outer-turn.ts
@@ -460,7 +460,7 @@ export async function runOneOuterTurn(
         deps.contextBudget,
         "outer",
         phase,
-        deps.agentTimeoutSec ?? 120,
+        deps.agentTimeoutSec,
       ),
       idempotency: {
         scope: "per_turn",
@@ -473,6 +473,11 @@ export async function runOneOuterTurn(
         },
       },
       runtimeMetadata: { milestone_id: milestone.milestone_id, phase },
+      // PR #110 review P1-b (gpt5.5): forward operator
+      // `context_budget` so per-phase `token_hard_cap` reaches
+      // `composePromptWithBudget`. Previously this only fed the
+      // timeout resolver, leaving prompt-budget overrides silent.
+      contextBudget: deps.contextBudget,
     },
     { llmRunner: deps.llmRunner, manifestBuilder, store: deps.store },
   );

--- a/src/application/turn-worker.ts
+++ b/src/application/turn-worker.ts
@@ -19,10 +19,16 @@ import type {
   VerificationPort,
 } from "../ports/verification.js";
 import type { WorkspacePort } from "../ports/workspace.js";
-import type { LeaseConfig } from "../config/target-schema.js";
+import {
+  resolveAgentTimeoutSec,
+  type ContextBudget,
+  type FailurePolicy,
+  type LeaseConfig,
+} from "../config/target-schema.js";
 import { callAgent, type AgentIoOutcome } from "./agent-io.js";
 import {
   classifyAgentIoStageFailure,
+  countLrInvokeTimeoutsFromLedger,
   countPromptComposeFailuresFromLedger,
   evaluateRetry,
 } from "./failure-policy.js";
@@ -110,6 +116,20 @@ export type TurnWorkerOutcome =
       detail: string;
     }
   | {
+      /**
+       * incident-10: the inner session has hit the
+       * `inner_lr_invoke_timeout` retry cap (default 5 prior consecutive
+       * `lr_invoke/lr_exit_status: ... exitStatus=timeout` failures). The
+       * worker has flipped the DialogueSession to ABANDONED and appended
+       * the session_finalize ledger row, so the daemon stops picking this
+       * session.
+       */
+      kind: "inner_lr_invoke_escalated";
+      sessionId: string;
+      sliceId: string;
+      detail: string;
+    }
+  | {
       kind: "stale_pins";
       sessionId: string;
       sliceId: string;
@@ -129,6 +149,21 @@ export interface TurnWorkerCfg {
   environmentFingerprint: string;
   workspacePinSourceLabel?: string;
   agentTimeoutSec?: number;
+  /**
+   * incident-10: TCC-CONTEXT-BUDGET map. When provided, the `timeout_sec`
+   * override for `inner.tdd_build` is resolved via `resolveAgentTimeoutSec`
+   * before each `callAgent`. Falls back to `agentTimeoutSec ?? 120` (kept
+   * for backward compatibility with existing tests that do not wire the
+   * budget map).
+   */
+  contextBudget?: ContextBudget;
+  /**
+   * incident-10: TCC-FAILURE-POLICY map. When provided,
+   * `inner_lr_timeout_cap` overrides `DEFAULT_RETRY_CONFIG
+   * .innerLrInvokeTimeoutLimit` for the inner abandon decision after
+   * consecutive `lr_invoke/lr_exit_status: ... exitStatus=timeout` failures.
+   */
+  failurePolicy?: FailurePolicy;
 }
 
 export interface TurnWorkerDeps {
@@ -294,7 +329,12 @@ async function runOneInnerTurnInner(
       manifest,
       workspaceRevisionPin: prep.headBefore,
       agentCwd: prep.agentCwd,
-      timeoutSec: deps.cfg.agentTimeoutSec ?? 120,
+      timeoutSec: resolveAgentTimeoutSec(
+        deps.cfg.contextBudget,
+        "inner",
+        "tdd_build",
+        deps.cfg.agentTimeoutSec ?? 120,
+      ),
       idempotency: {
         scope: "per_turn",
         parts: {
@@ -333,23 +373,62 @@ async function runOneInnerTurnInner(
     // `outer-turn.ts` for the rationale. When prior `prompt_compose`
     // failures for this session reach the cap, mark the session ABANDONED
     // so the inner ready-object selector stops re-picking it.
+    //
+    // incident-10: the same shape applies to runner-level timeouts at the
+    // `lr_invoke` stage — no envelope is produced, so no agent-side streak
+    // (no_progress / regression / scope_violation) advances either. The
+    // operator-tunable `inner_lr_timeout_cap` (default 5) bounds the retry
+    // loop; on cap-hit, the session is ABANDONED via the same finalize
+    // ledger path (with a distinct idempotency tag).
     const classification = classifyAgentIoStageFailure(agentOut);
-    if (classification != null) {
+    if (classification === "prompt_compose_truncation") {
       const totalFailures = await countPromptComposeFailuresFromLedger(
         deps.store,
         session.session_id,
       );
       const decision = evaluateRetry(classification, totalFailures - 1);
       if (decision.decision === "escalate") {
-        await abandonInnerSessionForPromptCompose(
+        await abandonInnerSession(
           deps,
           slice,
           session,
           turnIndex,
           decision.reason,
+          "prompt_compose_truncation",
         );
         return {
           kind: "prompt_compose_escalated",
+          sessionId: session.session_id,
+          sliceId: slice.slice_id,
+          detail: decision.reason,
+        };
+      }
+    } else if (classification === "inner_lr_invoke_timeout") {
+      const totalFailures = await countLrInvokeTimeoutsFromLedger(
+        deps.store,
+        session.session_id,
+      );
+      // Only pass the override field when set — passing
+      // `{ innerLrInvokeTimeoutLimit: undefined }` would clobber the
+      // DEFAULT_RETRY_CONFIG entry in the spread below evaluateRetry.
+      const cap = deps.cfg.failurePolicy?.inner_lr_timeout_cap;
+      const decision =
+        cap != null
+          ? evaluateRetry(classification, totalFailures - 1, {
+              innerLrInvokeTimeoutLimit: cap,
+            })
+          : evaluateRetry(classification, totalFailures - 1);
+      if (decision.decision === "escalate") {
+        await abandonInnerSession(
+          deps,
+          slice,
+          session,
+          turnIndex,
+          decision.reason,
+          "inner_lr_invoke_timeout",
+        );
+        return {
+          kind: "inner_lr_invoke_escalated",
           sessionId: session.session_id,
           sliceId: slice.slice_id,
           detail: decision.reason,
@@ -706,22 +785,27 @@ async function emitInvalidTurn(
 
 /**
  * PR #95 review P0-1 (incident-3): flip a SESSION_OPEN inner session to
- * ABANDONED after the `prompt_compose_truncation` retry cap is hit, and
- * record a session_finalize ledger row so the daemon's pickReadyInnerTurn
- * selector (which guards on `state === "SESSION_OPEN"`) stops re-picking
- * it. The session stays attached to its slice; the slice itself is left
- * in its current state — operator/recovery sweep handles the slice-side
- * cleanup, identical to the existing TIMEOUT path. `abandoned_reason` is
- * `no_progress` because `AbandonedReason` does not have a dedicated
- * `prompt_compose_truncation` value and the semantics align (prompt
- * cannot be composed → no progress is achievable).
+ * ABANDONED after a retry cap is hit, and record a session_finalize ledger
+ * row so the daemon's pickReadyInnerTurn selector (which guards on
+ * `state === "SESSION_OPEN"`) stops re-picking it. The session stays
+ * attached to its slice; the slice itself is left in its current state —
+ * operator/recovery sweep handles the slice-side cleanup, identical to the
+ * existing TIMEOUT path. `abandoned_reason` is `no_progress` because
+ * `AbandonedReason` does not have a dedicated value for either incident-3
+ * (`prompt_compose_truncation`) or incident-10 (`inner_lr_invoke_timeout`)
+ * — the semantics align (prompt cannot be composed / runner keeps timing
+ * out → no progress is achievable).
+ *
+ * `tag` differentiates the idempotency key + finalization_decision label so
+ * separate cap-hits do not collide.
  */
-async function abandonInnerSessionForPromptCompose(
+async function abandonInnerSession(
   deps: TurnWorkerDeps,
   slice: SliceT,
   session: DialogueSessionT,
   turnIndex: number,
   reason: string,
+  tag: "prompt_compose_truncation" | "inner_lr_invoke_timeout",
 ): Promise<void> {
   const finalized = DialogueSession.parse({
     ...session,
@@ -765,7 +849,7 @@ async function abandonInnerSessionForPromptCompose(
       parts: {
         session_id: finalized.session_id,
         final_verdict: "ABANDONED",
-        finalization_decision: "abandoned:prompt_compose_truncation",
+        finalization_decision: `abandoned:${tag}`,
         workspace_revision_pin_at_convergence: finalized.workspace_revision_pin,
       },
     }),

--- a/src/application/turn-worker.ts
+++ b/src/application/turn-worker.ts
@@ -333,7 +333,7 @@ async function runOneInnerTurnInner(
         deps.cfg.contextBudget,
         "inner",
         "tdd_build",
-        deps.cfg.agentTimeoutSec ?? 120,
+        deps.cfg.agentTimeoutSec,
       ),
       idempotency: {
         scope: "per_turn",
@@ -346,6 +346,11 @@ async function runOneInnerTurnInner(
         },
       },
       runtimeMetadata: { workspace_pin_before: prep.headBefore },
+      // PR #110 review P1-b (gpt5.5): forward operator
+      // `context_budget` so per-phase `token_hard_cap` reaches
+      // `composePromptWithBudget`. Previously this only fed the
+      // timeout resolver, leaving prompt-budget overrides silent.
+      contextBudget: deps.cfg.contextBudget,
     },
     // incident-9: wire StorePort so `callAgent` resolves the
     // `(slice, body)` manifest entry into the prompt's `# Inputs`
@@ -787,14 +792,21 @@ async function emitInvalidTurn(
  * PR #95 review P0-1 (incident-3): flip a SESSION_OPEN inner session to
  * ABANDONED after a retry cap is hit, and record a session_finalize ledger
  * row so the daemon's pickReadyInnerTurn selector (which guards on
- * `state === "SESSION_OPEN"`) stops re-picking it. The session stays
- * attached to its slice; the slice itself is left in its current state —
- * operator/recovery sweep handles the slice-side cleanup, identical to the
- * existing TIMEOUT path. `abandoned_reason` is `no_progress` because
- * `AbandonedReason` does not have a dedicated value for either incident-3
- * (`prompt_compose_truncation`) or incident-10 (`inner_lr_invoke_timeout`)
- * — the semantics align (prompt cannot be composed / runner keeps timing
- * out → no progress is achievable).
+ * `state === "SESSION_OPEN"`) stops re-picking it. `abandoned_reason` is
+ * `no_progress` because `AbandonedReason` does not have a dedicated value
+ * for either incident-3 (`prompt_compose_truncation`) or incident-10
+ * (`inner_lr_invoke_timeout`) — the semantics align (prompt cannot be
+ * composed / runner keeps timing out → no progress is achievable).
+ *
+ * PR #110 review P0 (gpt5.5): the slice MUST also be restored to
+ * SLICE_READY with `current_session_id: null` in the same flow. Otherwise
+ * the slice is left in SLICE_BUILDING pointing at an ABANDONED session,
+ * and the next `pickReadyInnerTurn` re-selects that SLICE_BUILDING slice
+ * (line 76 of ready-object), reads the session metadata at line 100, sees
+ * `state !== "SESSION_OPEN"`, and throws `SessionNotOpenError` — wedging
+ * the slice permanently. Wrapping the slice write in `withFileLock` is
+ * symmetric to `recovery.reanimateSliceIfNeeded` so a concurrent recovery
+ * sweep cannot interleave.
  *
  * `tag` differentiates the idempotency key + finalization_decision label so
  * separate cap-hits do not collide.
@@ -819,6 +831,27 @@ async function abandonInnerSession(
     layout.sessionMetadata(finalized.session_id),
     JSON.stringify(finalized, null, 2),
   );
+
+  // PR #110 review P0: restore slice → SLICE_READY + clear
+  // current_session_id so `pickReadyInnerTurn` does not re-select a
+  // SLICE_BUILDING slice that points at an ABANDONED session and throw
+  // `SessionNotOpenError`. File-lock symmetry with the success path
+  // (`SLICE_REVIEWING`) and `recovery.reanimateSliceIfNeeded`.
+  const slicePath = layout.slice(slice.slice_id);
+  const previousSliceState = slice.state;
+  await deps.store.withFileLock(slicePath, async () => {
+    const restoredSlice = Slice.parse({
+      ...slice,
+      state: "SLICE_READY",
+      current_session_id: null,
+      updated_at: deps.clock.isoNow(),
+    });
+    await deps.store.writeAtomic(
+      slicePath,
+      JSON.stringify(restoredSlice, null, 2),
+    );
+  });
+
   await deps.ledger.appendTransition({
     transition_id: newMonotonicId(deps.clock.now()),
     target_id: deps.cfg.targetId,
@@ -851,6 +884,50 @@ async function abandonInnerSession(
         final_verdict: "ABANDONED",
         finalization_decision: `abandoned:${tag}`,
         workspace_revision_pin_at_convergence: finalized.workspace_revision_pin,
+      },
+    }),
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: reason,
+    timestamp: deps.clock.isoNow(),
+  });
+
+  // PR #110 review P0: ledger row for the slice rollback so the audit
+  // trail records the SLICE_BUILDING → SLICE_READY transition that
+  // accompanies the abandonment.
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.cfg.targetId,
+    object_id: slice.slice_id,
+    object_kind: "slice",
+    from_state: previousSliceState,
+    to_state: "SLICE_READY",
+    loop_kind: "inner",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: finalized.session_id,
+    turn_index: null,
+    slot_kind: "delivery",
+    agent_profile_id: "forge",
+    contribution_kind: null,
+    action_kind: "session_progress",
+    final_verdict: null,
+    caller_id: deps.cfg.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: null,
+    metric_run_id: null,
+    idempotency_key: idempotencyKey({
+      scope: "external_observation",
+      parts: {
+        kind: "abandon_slice_rollback",
+        slice_id: slice.slice_id,
+        session_id: finalized.session_id,
+        tag,
       },
     }),
     lease_token: null,

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -404,6 +404,9 @@ async function main(argv: readonly string[]): Promise<number> {
               targetId: cfg.identity.target_id,
               testCommands,
               environmentFingerprint: `node${process.version}`,
+              // incident-10: per-phase timeout overrides + lr_invoke retry cap.
+              contextBudget: cfg.context_budget,
+              failurePolicy: cfg.failure_policy,
             },
             lease,
             leaseConfig: cfg.lease,
@@ -424,6 +427,8 @@ async function main(argv: readonly string[]): Promise<number> {
             targetId: cfg.identity.target_id,
             environmentFingerprint: `node${process.version}`,
             reverifyTestCommands: testCommands,
+            // incident-10: per-phase middle.review timeout override.
+            contextBudget: cfg.context_budget,
             lease,
             leaseConfig: cfg.lease,
           });
@@ -446,6 +451,8 @@ async function main(argv: readonly string[]): Promise<number> {
             callerId: args.callerId,
             targetId: cfg.identity.target_id,
             workspace,
+            // incident-10: per-phase outer.* timeout overrides.
+            contextBudget: cfg.context_budget,
           });
           outcomeJson = JSON.stringify({ role: args.role, outcome });
           break;

--- a/src/config/target-schema.ts
+++ b/src/config/target-schema.ts
@@ -287,6 +287,19 @@ export const ContextBudgetEntry = z
   .object({
     token_hard_cap: z.number().int().positive(),
     soft_warn_pct: z.number().min(0).max(1).optional(),
+    /**
+     * incident-10: per-(parent_loop, phase_or_purpose) wall-clock timeout for
+     * the LlmRunner invocation, in seconds. When omitted, callers fall back
+     * to `TIMEOUT_SEC_DEFAULTS[loop.step]` (see `resolveAgentTimeoutSec`),
+     * then to the caller-supplied ultimate fallback (120s).
+     *
+     * Inner `tdd_build` defaults to 600s because an authoring forge may
+     * legitimately run multi-minute red→green→refactor cycles inside a
+     * single 1-shot — the previous 120s ceiling caused incident-10 (the
+     * forge wrote a 138-line test file but the runner timed out before
+     * envelope emit, looping the daemon on `lr_invoke/lr_exit_status`).
+     */
+    timeout_sec: z.number().int().positive().optional(),
   })
   .strict();
 export type ContextBudgetEntry = z.infer<typeof ContextBudgetEntry>;
@@ -332,6 +345,70 @@ export function resolveContextBudget(
   return CONTEXT_BUDGET_DEFAULTS[parsed.data];
 }
 
+/**
+ * incident-10: architecture defaults for per-phase LlmRunner wall-clock
+ * timeouts (seconds). Outer phases run read-only analysis, middle review
+ * runs evaluator agents, and inner `tdd_build` may legitimately cycle
+ * red→green→refactor for several minutes inside a single 1-shot.
+ */
+export const TIMEOUT_SEC_DEFAULTS: Readonly<Record<LoopStep, number>> =
+  Object.freeze({
+    "outer.Discovery": 120,
+    "outer.Specification": 120,
+    "outer.Planning": 120,
+    "outer.Validation": 120,
+    "middle.review": 180,
+    "middle.merge": 180,
+    "inner.tdd_build": 600,
+  });
+
+/**
+ * Resolves the LlmRunner timeout (seconds) for a `(parent_loop,
+ * phase_or_purpose)` pair. Lookup order:
+ *   1. Operator override at `cfg[loop.step].timeout_sec` (if present)
+ *   2. `TIMEOUT_SEC_DEFAULTS[loop.step]` (if `(loop, step)` is a known LoopStep)
+ *   3. Caller-supplied `fallbackSec` (preserves the legacy `?? 120` semantics)
+ *
+ * Unlike `resolveContextBudget`, this never returns null — an unknown
+ * (loop, step) simply falls through to `fallbackSec`. Callers are typically
+ * already inside a `LoopStep`-typed branch, so this is defensive.
+ */
+export function resolveAgentTimeoutSec(
+  cfg: ContextBudget | undefined,
+  parentLoop: string,
+  phaseOrPurpose: string,
+  fallbackSec: number,
+): number {
+  const key = `${parentLoop}.${phaseOrPurpose}`;
+  const parsed = LoopStep.safeParse(key);
+  if (!parsed.success) return fallbackSec;
+  const override = cfg?.[parsed.data]?.timeout_sec;
+  if (override != null && override > 0) return override;
+  const def = TIMEOUT_SEC_DEFAULTS[parsed.data];
+  return def ?? fallbackSec;
+}
+
+/**
+ * incident-10: operator-tunable retry caps for the inner `lr_invoke` failure
+ * lane. Mirrors the existing `prompt_compose_truncation` limit shape but
+ * lives in target.json (so operators can dial the cap without touching code).
+ *
+ * Only the inner timeout cap is exposed today — this block is a place to grow
+ * additional retry caps as further incidents surface. All fields are optional
+ * with sensible defaults provided by `failure-policy.ts DEFAULT_RETRY_CONFIG`.
+ */
+export const FailurePolicy = z
+  .object({
+    /**
+     * Maximum consecutive `lr_invoke/lr_exit_status` (timeout) failures for an
+     * inner session before it is ABANDONED. Default 5 — see
+     * `failure-policy.ts DEFAULT_RETRY_CONFIG.innerLrInvokeTimeoutLimit`.
+     */
+    inner_lr_timeout_cap: z.number().int().positive().optional(),
+  })
+  .strict();
+export type FailurePolicy = z.infer<typeof FailurePolicy>;
+
 export const TargetConfig = z
   .object({
     identity: Identity,
@@ -349,6 +426,7 @@ export const TargetConfig = z
     dual_track: DualTrack.optional(),
     invariant_enforcement: InvariantEnforcement.optional(),
     context_budget: ContextBudget.optional(),
+    failure_policy: FailurePolicy.optional(),
   })
   .strict();
 

--- a/src/config/target-schema.ts
+++ b/src/config/target-schema.ts
@@ -365,27 +365,33 @@ export const TIMEOUT_SEC_DEFAULTS: Readonly<Record<LoopStep, number>> =
 /**
  * Resolves the LlmRunner timeout (seconds) for a `(parent_loop,
  * phase_or_purpose)` pair. Lookup order:
- *   1. Operator override at `cfg[loop.step].timeout_sec` (if present)
- *   2. `TIMEOUT_SEC_DEFAULTS[loop.step]` (if `(loop, step)` is a known LoopStep)
- *   3. Caller-supplied `fallbackSec` (preserves the legacy `?? 120` semantics)
+ *   1. Per-phase operator override at `cfg[loop.step].timeout_sec`
+ *   2. Caller-supplied legacy `agentTimeoutSec` override (only when
+ *      explicitly set — `undefined` skips this step). PR #110 review P1
+ *      (qwen): keeping legacy operator overrides ahead of architecture
+ *      defaults prevents `agentTimeoutSec: 30` from being silently
+ *      shadowed by `TIMEOUT_SEC_DEFAULTS[loop.step]`.
+ *   3. `TIMEOUT_SEC_DEFAULTS[loop.step]` (if `(loop, step)` is a known LoopStep)
+ *   4. `120` as final last-resort fallback (mirrors the previous default).
  *
  * Unlike `resolveContextBudget`, this never returns null — an unknown
- * (loop, step) simply falls through to `fallbackSec`. Callers are typically
- * already inside a `LoopStep`-typed branch, so this is defensive.
+ * (loop, step) falls through to step 2/4. Callers are typically already
+ * inside a `LoopStep`-typed branch, so this is defensive.
  */
 export function resolveAgentTimeoutSec(
   cfg: ContextBudget | undefined,
   parentLoop: string,
   phaseOrPurpose: string,
-  fallbackSec: number,
+  fallbackSec: number | undefined,
 ): number {
   const key = `${parentLoop}.${phaseOrPurpose}`;
   const parsed = LoopStep.safeParse(key);
-  if (!parsed.success) return fallbackSec;
+  if (!parsed.success) return fallbackSec ?? 120;
   const override = cfg?.[parsed.data]?.timeout_sec;
   if (override != null && override > 0) return override;
+  if (fallbackSec != null && fallbackSec > 0) return fallbackSec;
   const def = TIMEOUT_SEC_DEFAULTS[parsed.data];
-  return def ?? fallbackSec;
+  return def ?? 120;
 }
 
 /**

--- a/tests/application/failure-policy.test.ts
+++ b/tests/application/failure-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_RETRY_CONFIG,
   classifyAgentIoStageFailure,
+  countLrInvokeTimeoutsFromLedger,
   countPromptComposeFailuresFromLedger,
   evaluateRetry,
 } from "../../src/application/failure-policy.js";
@@ -144,6 +145,161 @@ describe("classifyAgentIoStageFailure (incident-3)", () => {
     expect(decisions[3]).toEqual({
       decision: "escalate",
       reason: "prompt_compose_truncation count=3 >= limit=3",
+    });
+  });
+});
+
+describe("incident-10 — inner_lr_invoke_timeout retry cap", () => {
+  it("DEFAULT_RETRY_CONFIG.innerLrInvokeTimeoutLimit defaults to 5", () => {
+    expect(DEFAULT_RETRY_CONFIG.innerLrInvokeTimeoutLimit).toBe(5);
+  });
+
+  it("evaluateRetry escalates inner_lr_invoke_timeout at the default cap", () => {
+    expect(evaluateRetry("inner_lr_invoke_timeout", 0)).toEqual({
+      decision: "continue",
+      remaining: 5,
+    });
+    expect(evaluateRetry("inner_lr_invoke_timeout", 4)).toEqual({
+      decision: "continue",
+      remaining: 1,
+    });
+    expect(evaluateRetry("inner_lr_invoke_timeout", 5)).toEqual({
+      decision: "escalate",
+      reason: "inner_lr_invoke_timeout count=5 >= limit=5",
+    });
+  });
+
+  it("evaluateRetry honors operator override (target failure_policy.inner_lr_timeout_cap)", () => {
+    expect(
+      evaluateRetry("inner_lr_invoke_timeout", 2, {
+        innerLrInvokeTimeoutLimit: 3,
+      }),
+    ).toEqual({ decision: "continue", remaining: 1 });
+    expect(
+      evaluateRetry("inner_lr_invoke_timeout", 3, {
+        innerLrInvokeTimeoutLimit: 3,
+      }),
+    ).toEqual({
+      decision: "escalate",
+      reason: "inner_lr_invoke_timeout count=3 >= limit=3",
+    });
+  });
+
+  it("classifyAgentIoStageFailure maps lr_invoke + exitStatus=timeout detail to inner_lr_invoke_timeout", () => {
+    expect(
+      classifyAgentIoStageFailure({
+        ok: false,
+        stage: "lr_invoke",
+        detail:
+          "LlmRunner exitStatus=timeout; envelopeRef=/tmp/foo/envelope.json",
+      }),
+    ).toBe("inner_lr_invoke_timeout");
+  });
+
+  it("classifyAgentIoStageFailure ignores non-timeout lr_invoke failures", () => {
+    expect(
+      classifyAgentIoStageFailure({
+        ok: false,
+        stage: "lr_invoke",
+        detail: "LlmRunner exitStatus=spawn_error; envelopeRef=",
+      }),
+    ).toBeNull();
+    // Bare lr_invoke without detail is also not a timeout signal.
+    expect(
+      classifyAgentIoStageFailure({ ok: false, stage: "lr_invoke" }),
+    ).toBeNull();
+  });
+
+  it("countLrInvokeTimeoutsFromLedger counts only lr_invoke timeout rows for the session", async () => {
+    const sessionId = "01HZS00000000000000000000C";
+    const otherSession = "01HZS00000000000000000000D";
+    const rows = [
+      // matching
+      {
+        session_id: sessionId,
+        result: "invalid",
+        result_detail:
+          "lr_invoke/lr_exit_status: LlmRunner exitStatus=timeout; envelopeRef=/tmp/a",
+      },
+      {
+        session_id: sessionId,
+        result: "invalid",
+        result_detail:
+          "lr_invoke/lr_exit_status: LlmRunner exitStatus=timeout; envelopeRef=/tmp/b",
+      },
+      // non-matching: not invalid
+      {
+        session_id: sessionId,
+        result: "applied",
+        result_detail:
+          "lr_invoke/lr_exit_status: LlmRunner exitStatus=timeout; envelopeRef=/tmp/c",
+      },
+      // non-matching: lr_invoke but not timeout
+      {
+        session_id: sessionId,
+        result: "invalid",
+        result_detail:
+          "lr_invoke/lr_exit_status: LlmRunner exitStatus=spawn_error; envelopeRef=",
+      },
+      // non-matching: prompt_compose
+      {
+        session_id: sessionId,
+        result: "invalid",
+        result_detail: "prompt_compose/context_budget_truncation: foo",
+      },
+      // non-matching: different session
+      {
+        session_id: otherSession,
+        result: "invalid",
+        result_detail:
+          "lr_invoke/lr_exit_status: LlmRunner exitStatus=timeout; envelopeRef=/tmp/d",
+      },
+    ];
+    const ndjson = rows.map((r) => JSON.stringify(r)).join("\n");
+    const fakeStore = {
+      readText: async (relPath: string) => {
+        expect(relPath).toBe("ledger/transitions.ndjson");
+        return ndjson;
+      },
+    };
+    expect(
+      await countLrInvokeTimeoutsFromLedger(fakeStore, sessionId),
+    ).toBe(2);
+    expect(
+      await countLrInvokeTimeoutsFromLedger(fakeStore, otherSession),
+    ).toBe(1);
+    expect(
+      await countLrInvokeTimeoutsFromLedger(
+        { readText: async () => null },
+        sessionId,
+      ),
+    ).toBe(0);
+    expect(
+      await countLrInvokeTimeoutsFromLedger(
+        { readText: async () => "" },
+        sessionId,
+      ),
+    ).toBe(0);
+  });
+
+  it("integration: 6 consecutive lr_invoke timeouts exhaust the default cap=5", () => {
+    let counter = 0;
+    const decisions: ReturnType<typeof evaluateRetry>[] = [];
+    for (let i = 0; i < 6; i++) {
+      const cls = classifyAgentIoStageFailure({
+        ok: false,
+        stage: "lr_invoke",
+        detail: "LlmRunner exitStatus=timeout; envelopeRef=",
+      });
+      expect(cls).toBe("inner_lr_invoke_timeout");
+      decisions.push(evaluateRetry(cls!, counter));
+      counter += 1;
+    }
+    expect(decisions[0]).toEqual({ decision: "continue", remaining: 5 });
+    expect(decisions[4]).toEqual({ decision: "continue", remaining: 1 });
+    expect(decisions[5]).toEqual({
+      decision: "escalate",
+      reason: "inner_lr_invoke_timeout count=5 >= limit=5",
     });
   });
 });

--- a/tests/config/target-schema-incident-10.test.ts
+++ b/tests/config/target-schema-incident-10.test.ts
@@ -1,0 +1,162 @@
+/**
+ * incident-10 — TCC-CONTEXT-BUDGET `timeout_sec` per-phase override + the new
+ * `failure_policy.inner_lr_timeout_cap` block. Mirrors the existing phase-8a
+ * conformance shape for `token_hard_cap` so operator overrides validate
+ * correctly and resolve through `resolveAgentTimeoutSec`.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ContextBudget,
+  ContextBudgetEntry,
+  TIMEOUT_SEC_DEFAULTS,
+  TargetConfig,
+  parseTargetConfig,
+  resolveAgentTimeoutSec,
+} from "../../src/config/target-schema.js";
+
+const PROFILES = {
+  atlas: { runner: "fake" as const },
+  forge: { runner: "fake" as const },
+  sentinel: { runner: "fake" as const },
+  scout: { runner: "fake" as const },
+};
+const ID = { target_id: "incident-10-test" };
+
+describe("incident-10 — ContextBudgetEntry.timeout_sec", () => {
+  it("accepts a positive integer per-phase timeout_sec", () => {
+    const e = ContextBudgetEntry.parse({
+      token_hard_cap: 128_000,
+      timeout_sec: 600,
+    });
+    expect(e.timeout_sec).toBe(600);
+  });
+
+  it("treats timeout_sec as optional (legacy entries still parse)", () => {
+    const e = ContextBudgetEntry.parse({ token_hard_cap: 128_000 });
+    expect(e.timeout_sec).toBeUndefined();
+  });
+
+  it("rejects zero / negative / non-integer timeout_sec", () => {
+    expect(() =>
+      ContextBudgetEntry.parse({ token_hard_cap: 100, timeout_sec: 0 }),
+    ).toThrow();
+    expect(() =>
+      ContextBudgetEntry.parse({ token_hard_cap: 100, timeout_sec: -1 }),
+    ).toThrow();
+    expect(() =>
+      ContextBudgetEntry.parse({ token_hard_cap: 100, timeout_sec: 1.5 }),
+    ).toThrow();
+  });
+
+  it("ContextBudget accepts timeout_sec for any LoopStep key", () => {
+    const cfg = ContextBudget.parse({
+      "outer.Discovery": { token_hard_cap: 256_000, timeout_sec: 90 },
+      "inner.tdd_build": { token_hard_cap: 128_000, timeout_sec: 900 },
+    });
+    expect(cfg["outer.Discovery"]?.timeout_sec).toBe(90);
+    expect(cfg["inner.tdd_build"]?.timeout_sec).toBe(900);
+  });
+
+  it("TargetConfig accepts a context_budget block with per-phase timeout_sec", () => {
+    const cfg = parseTargetConfig({
+      identity: ID,
+      agent_profiles: PROFILES,
+      context_budget: {
+        "inner.tdd_build": { token_hard_cap: 128_000, timeout_sec: 600 },
+      },
+    });
+    expect(
+      cfg.context_budget?.["inner.tdd_build"]?.timeout_sec,
+    ).toBe(600);
+  });
+});
+
+describe("incident-10 — resolveAgentTimeoutSec", () => {
+  it("prefers per-phase context_budget override when present", () => {
+    const cfg = ContextBudget.parse({
+      "inner.tdd_build": { token_hard_cap: 128_000, timeout_sec: 900 },
+    });
+    expect(resolveAgentTimeoutSec(cfg, "inner", "tdd_build", 120)).toBe(900);
+  });
+
+  it("falls back to architecture default for the (loop, step) pair", () => {
+    expect(resolveAgentTimeoutSec(undefined, "inner", "tdd_build", 120)).toBe(
+      TIMEOUT_SEC_DEFAULTS["inner.tdd_build"],
+    );
+    expect(resolveAgentTimeoutSec({}, "outer", "Discovery", 120)).toBe(
+      TIMEOUT_SEC_DEFAULTS["outer.Discovery"],
+    );
+    expect(resolveAgentTimeoutSec({}, "middle", "review", 120)).toBe(
+      TIMEOUT_SEC_DEFAULTS["middle.review"],
+    );
+  });
+
+  it("falls back to caller-supplied fallback for unknown (loop, step) pairs", () => {
+    expect(resolveAgentTimeoutSec({}, "rogue", "step", 77)).toBe(77);
+  });
+
+  it("ignores override when it is missing on the matching entry", () => {
+    const cfg = ContextBudget.parse({
+      "inner.tdd_build": { token_hard_cap: 128_000 },
+    });
+    expect(resolveAgentTimeoutSec(cfg, "inner", "tdd_build", 120)).toBe(
+      TIMEOUT_SEC_DEFAULTS["inner.tdd_build"],
+    );
+  });
+
+  it("architecture defaults match the contract: outer/middle short, inner.tdd_build 600", () => {
+    expect(TIMEOUT_SEC_DEFAULTS["outer.Discovery"]).toBe(120);
+    expect(TIMEOUT_SEC_DEFAULTS["outer.Specification"]).toBe(120);
+    expect(TIMEOUT_SEC_DEFAULTS["outer.Planning"]).toBe(120);
+    expect(TIMEOUT_SEC_DEFAULTS["outer.Validation"]).toBe(120);
+    expect(TIMEOUT_SEC_DEFAULTS["middle.review"]).toBe(180);
+    expect(TIMEOUT_SEC_DEFAULTS["middle.merge"]).toBe(180);
+    expect(TIMEOUT_SEC_DEFAULTS["inner.tdd_build"]).toBe(600);
+  });
+});
+
+describe("incident-10 — failure_policy.inner_lr_timeout_cap", () => {
+  it("accepts an optional positive integer cap", () => {
+    const cfg = TargetConfig.parse({
+      identity: ID,
+      agent_profiles: PROFILES,
+      failure_policy: { inner_lr_timeout_cap: 7 },
+    });
+    expect(cfg.failure_policy?.inner_lr_timeout_cap).toBe(7);
+  });
+
+  it("treats failure_policy as optional (legacy targets parse unchanged)", () => {
+    const cfg = TargetConfig.parse({
+      identity: ID,
+      agent_profiles: PROFILES,
+    });
+    expect(cfg.failure_policy).toBeUndefined();
+  });
+
+  it("rejects zero / negative inner_lr_timeout_cap", () => {
+    expect(() =>
+      TargetConfig.parse({
+        identity: ID,
+        agent_profiles: PROFILES,
+        failure_policy: { inner_lr_timeout_cap: 0 },
+      }),
+    ).toThrow();
+    expect(() =>
+      TargetConfig.parse({
+        identity: ID,
+        agent_profiles: PROFILES,
+        failure_policy: { inner_lr_timeout_cap: -1 },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects unknown keys inside failure_policy (.strict())", () => {
+    expect(() =>
+      TargetConfig.parse({
+        identity: ID,
+        agent_profiles: PROFILES,
+        failure_policy: { unknown: 1 } as unknown as Record<string, number>,
+      }),
+    ).toThrow();
+  });
+});

--- a/tests/config/target-schema-incident-10.test.ts
+++ b/tests/config/target-schema-incident-10.test.ts
@@ -76,17 +76,19 @@ describe("incident-10 — resolveAgentTimeoutSec", () => {
     const cfg = ContextBudget.parse({
       "inner.tdd_build": { token_hard_cap: 128_000, timeout_sec: 900 },
     });
-    expect(resolveAgentTimeoutSec(cfg, "inner", "tdd_build", 120)).toBe(900);
+    expect(resolveAgentTimeoutSec(cfg, "inner", "tdd_build", undefined)).toBe(
+      900,
+    );
   });
 
-  it("falls back to architecture default for the (loop, step) pair", () => {
-    expect(resolveAgentTimeoutSec(undefined, "inner", "tdd_build", 120)).toBe(
-      TIMEOUT_SEC_DEFAULTS["inner.tdd_build"],
-    );
-    expect(resolveAgentTimeoutSec({}, "outer", "Discovery", 120)).toBe(
+  it("falls back to architecture default for the (loop, step) pair when no caller override", () => {
+    expect(
+      resolveAgentTimeoutSec(undefined, "inner", "tdd_build", undefined),
+    ).toBe(TIMEOUT_SEC_DEFAULTS["inner.tdd_build"]);
+    expect(resolveAgentTimeoutSec({}, "outer", "Discovery", undefined)).toBe(
       TIMEOUT_SEC_DEFAULTS["outer.Discovery"],
     );
-    expect(resolveAgentTimeoutSec({}, "middle", "review", 120)).toBe(
+    expect(resolveAgentTimeoutSec({}, "middle", "review", undefined)).toBe(
       TIMEOUT_SEC_DEFAULTS["middle.review"],
     );
   });
@@ -95,13 +97,34 @@ describe("incident-10 — resolveAgentTimeoutSec", () => {
     expect(resolveAgentTimeoutSec({}, "rogue", "step", 77)).toBe(77);
   });
 
+  it("falls back to 120 when caller-supplied fallback is undefined and (loop, step) is unknown", () => {
+    expect(resolveAgentTimeoutSec({}, "rogue", "step", undefined)).toBe(120);
+  });
+
   it("ignores override when it is missing on the matching entry", () => {
     const cfg = ContextBudget.parse({
       "inner.tdd_build": { token_hard_cap: 128_000 },
     });
-    expect(resolveAgentTimeoutSec(cfg, "inner", "tdd_build", 120)).toBe(
+    expect(resolveAgentTimeoutSec(cfg, "inner", "tdd_build", undefined)).toBe(
       TIMEOUT_SEC_DEFAULTS["inner.tdd_build"],
     );
+  });
+
+  it("PR #110 P1-a: legacy agentTimeoutSec override wins over architecture default (operator-override precedence)", () => {
+    // Operator explicitly set `agentTimeoutSec: 30` (legacy global override)
+    // and did NOT set per-phase `context_budget.*.timeout_sec`. The
+    // resolver must honor 30s, not silently inflate to TIMEOUT_SEC_DEFAULTS.
+    expect(resolveAgentTimeoutSec(undefined, "inner", "tdd_build", 30)).toBe(
+      30,
+    );
+    expect(resolveAgentTimeoutSec({}, "outer", "Discovery", 45)).toBe(45);
+  });
+
+  it("PR #110 P1-a: per-phase context_budget.timeout_sec still wins over legacy agentTimeoutSec", () => {
+    const cfg = ContextBudget.parse({
+      "inner.tdd_build": { token_hard_cap: 128_000, timeout_sec: 900 },
+    });
+    expect(resolveAgentTimeoutSec(cfg, "inner", "tdd_build", 30)).toBe(900);
   });
 
   it("architecture defaults match the contract: outer/middle short, inner.tdd_build 600", () => {

--- a/tests/integration/inner-cycle-incident-10.test.ts
+++ b/tests/integration/inner-cycle-incident-10.test.ts
@@ -1,0 +1,345 @@
+/**
+ * incident-10 — turn-worker behaviour on per-phase timeout overrides + the
+ * `inner_lr_invoke_timeout` retry cap.
+ *
+ * Anchors:
+ *   - target-schema: ContextBudgetEntry.timeout_sec, FailurePolicy.inner_lr_timeout_cap
+ *   - failure-policy: countLrInvokeTimeoutsFromLedger, classifyAgentIoStageFailure
+ *   - turn-worker: agentTimeoutSec resolution + abandonInnerSession (lr_invoke tag)
+ *
+ * Two integration scenarios:
+ *   1. agentTimeoutSec resolution prefers `cfg.contextBudget["inner.tdd_build"].timeout_sec`
+ *      over the legacy `agentTimeoutSec` fallback. The runner records the
+ *      `timeoutSec` value it sees and the test asserts on it.
+ *   2. After 5 prior `lr_invoke/lr_exit_status: ... exitStatus=timeout`
+ *      ledger rows for the session, the next pickup classifies the session
+ *      as ABANDONED via `inner_lr_invoke_escalated`.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { NdjsonLogger } from "../../src/adapters/logger/ndjson.js";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import { FakeVerification } from "../../src/adapters/verification/fake.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import {
+  LOG_DAEMON_PATH,
+  layout,
+} from "../../src/application/persistence-layout.js";
+import { runOneInnerTurn } from "../../src/application/turn-worker.js";
+import { Slice } from "../../src/domain/schema/slice.js";
+import { DialogueSession } from "../../src/domain/schema/dialogue-session.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { SystemClock } from "../../src/ports/clock.js";
+import type {
+  LlmRunnerInput,
+  LlmRunnerPort,
+  LlmRunnerResult,
+} from "../../src/ports/llm-runner.js";
+
+const TARGET_ID = "demo-target";
+const SLICE_ID = "01HZS00000000000000000000A";
+const MILESTONE_ID = "01HZM00000000000000000000A";
+const ISO = "2026-05-08T00:00:00.000Z";
+
+function readJson<T>(workdir: string, rel: string, parse: (raw: unknown) => T): T {
+  const fs = require("node:fs") as typeof import("node:fs");
+  return parse(JSON.parse(fs.readFileSync(join(workdir, rel), "utf8")));
+}
+
+function readNdjsonLines(workdir: string, rel: string): string[] {
+  const fs = require("node:fs") as typeof import("node:fs");
+  if (!fs.existsSync(join(workdir, rel))) return [];
+  return fs
+    .readFileSync(join(workdir, rel), "utf8")
+    .split("\n")
+    .filter((s) => s.length > 0);
+}
+
+function seedReadySlice(workdir: string): void {
+  const slice = Slice.parse({
+    slice_id: SLICE_ID,
+    milestone_id: MILESTONE_ID,
+    slice_kind: "internal",
+    value_statement: "demo",
+    ac_ids: ["AC-1"],
+    acceptance_tests: [{ path: "tests/x.test.ts", name: "x", ac_id: "AC-1" }],
+    declared_scope: ["src/x.ts"],
+    declared_metric_threshold: null,
+    interface_break: false,
+    dependencies: [],
+    trunk_base_revision: "trunk-base",
+    dod_revision_pin: "dod-pin",
+    state: "SLICE_READY",
+    external_refs: [],
+    created_at: ISO,
+    updated_at: ISO,
+  });
+  mkdirSync(join(workdir, "slices"), { recursive: true });
+  writeFileSync(
+    join(workdir, layout.slice(SLICE_ID)),
+    JSON.stringify(slice),
+    "utf8",
+  );
+}
+
+/**
+ * Runner that always returns `exitStatus: "timeout"` and records the
+ * timeoutSec it was asked to honor. Used by both scenarios to (a) capture
+ * the per-phase override and (b) drive the retry-cap path.
+ */
+class TimeoutRunner implements LlmRunnerPort {
+  public lastTimeoutSec = -1;
+  public callCount = 0;
+
+  async invoke(input: LlmRunnerInput): Promise<LlmRunnerResult> {
+    this.lastTimeoutSec = input.timeoutSec;
+    this.callCount += 1;
+    const fs = await import("node:fs/promises");
+    const tmp = mkdtempSync(join(tmpdir(), "timeout-runner-"));
+    const envRef = join(tmp, "envelope.json");
+    const diagRef = join(tmp, "diagnostics.txt");
+    await fs.writeFile(envRef, "", "utf8");
+    await fs.writeFile(diagRef, "", "utf8");
+    return {
+      exitStatus: "timeout",
+      envelopeRef: envRef,
+      diagnosticsRef: diagRef,
+      consumedAt: new Date().toISOString(),
+    };
+  }
+}
+
+function buildDeps(opts: {
+  workdir: string;
+  wsRoot: string;
+  runner: LlmRunnerPort;
+  contextBudget?: import("../../src/config/target-schema.js").ContextBudget;
+  failurePolicy?: import("../../src/config/target-schema.js").FailurePolicy;
+  agentTimeoutSec?: number;
+}) {
+  const store = new FsStore({ workdir: opts.workdir });
+  const clock = new SystemClock();
+  const logger = new NdjsonLogger({
+    store,
+    clock,
+    relPath: LOG_DAEMON_PATH,
+  });
+  const ledger = new FileLedger({ store, logger });
+  const verification = new FakeVerification(clock, {
+    test: { result: "pass" },
+  });
+  return {
+    store,
+    clock,
+    llmRunner: opts.runner,
+    workspace: new FakeWorkspace(opts.wsRoot),
+    verification,
+    ledger,
+    cfg: {
+      callerId: "test-caller",
+      targetId: TARGET_ID,
+      environmentFingerprint: "vitest",
+      testCommands: (cwd: string) => [{ argv: ["true" as string], cwd }],
+      contextBudget: opts.contextBudget,
+      failurePolicy: opts.failurePolicy,
+      agentTimeoutSec: opts.agentTimeoutSec,
+    },
+  } as Parameters<typeof runOneInnerTurn>[0];
+}
+
+describe("incident-10 — agentTimeoutSec resolution", () => {
+  it("prefers context_budget per-phase timeout_sec over agentTimeoutSec fallback", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "incident-10-tmo-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-tmo-"));
+    seedReadySlice(workdir);
+    const runner = new TimeoutRunner();
+    await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        agentTimeoutSec: 120, // legacy fallback that the override must beat
+        contextBudget: {
+          "inner.tdd_build": { token_hard_cap: 128_000, timeout_sec: 600 },
+        },
+      }),
+    );
+    expect(runner.lastTimeoutSec).toBe(600);
+  });
+
+  it("falls back to architecture default (600) for inner.tdd_build when no override is set", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "incident-10-default-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-default-"));
+    seedReadySlice(workdir);
+    const runner = new TimeoutRunner();
+    await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        // No contextBudget, no agentTimeoutSec — should use TIMEOUT_SEC_DEFAULTS.
+      }),
+    );
+    expect(runner.lastTimeoutSec).toBe(600);
+  });
+
+  it("still honors the legacy agentTimeoutSec fallback when the (loop, step) entry has no timeout_sec", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "incident-10-legacy-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-legacy-"));
+    seedReadySlice(workdir);
+    const runner = new TimeoutRunner();
+    await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        // The architecture default for inner.tdd_build is 600s — without a
+        // per-entry timeout_sec, that wins over the caller-supplied 120s
+        // legacy fallback. This is the documented backward-compat semantics:
+        // operators who never customise stay on architecture defaults.
+        agentTimeoutSec: 120,
+        contextBudget: {
+          "inner.tdd_build": { token_hard_cap: 128_000 },
+        },
+      }),
+    );
+    expect(runner.lastTimeoutSec).toBe(600);
+  });
+});
+
+describe("incident-10 — inner_lr_invoke_timeout retry cap", () => {
+  it("after 5 prior lr_invoke timeout rows, next pickup classifies the session ABANDONED", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "incident-10-cap-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-cap-"));
+    seedReadySlice(workdir);
+
+    // First turn establishes the inner session via the standard pickup path.
+    // (The runner returns timeout, so an `lr_invoke/lr_exit_status` invalid
+    // row is appended automatically.) After this we know `current_session_id`.
+    const runner = new TimeoutRunner();
+    const first = await runOneInnerTurn(
+      buildDeps({ workdir, wsRoot, runner }),
+    );
+    expect(first.kind).toBe("invalid_envelope");
+    if (first.kind !== "invalid_envelope") return;
+    const sessionId = first.sessionId;
+
+    // Inject 4 more synthetic prior `lr_invoke/lr_exit_status` invalid
+    // rows for the same session via the public ledger API (so audit_hash
+    // chaining is preserved). Combined with the row produced by the
+    // first call above, the next pickup sees totalFailures=5.
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new NdjsonLogger({
+      store,
+      clock,
+      relPath: LOG_DAEMON_PATH,
+    });
+    const ledger = new FileLedger({ store, logger });
+    for (let i = 0; i < 4; i++) {
+      await ledger.appendTransition({
+        transition_id: `01HZSE000000000000000000${i}A`,
+        target_id: TARGET_ID,
+        object_id: sessionId,
+        object_kind: "session_turn",
+        from_state: null,
+        to_state: `turn_index=${i + 100}`,
+        loop_kind: "inner",
+        phase: null,
+        slice_id: SLICE_ID,
+        slice_kind: "internal",
+        dod_revision: "dod-pin",
+        session_id: sessionId,
+        turn_index: i + 100,
+        slot_kind: "delivery",
+        agent_profile_id: "forge",
+        contribution_kind: null,
+        action_kind: "session_progress",
+        final_verdict: null,
+        caller_id: "test-caller",
+        manifest_id: `01HZMA000000000000000000${i}A`,
+        input_revision_pins: [],
+        output_hash: null,
+        verification_run_id: null,
+        metric_run_id: null,
+        idempotency_key: `synthetic-${i}`,
+        lease_token: null,
+        lease_kind: null,
+        result: "invalid",
+        result_detail:
+          "lr_invoke/lr_exit_status: LlmRunner exitStatus=timeout; envelopeRef=/tmp/x",
+        timestamp: ISO,
+      });
+    }
+
+    // Second pickup of the same session: still SESSION_OPEN, runner still
+    // times out. evaluateRetry sees totalFailures-1 == 5 (after the
+    // emitInvalidTurn writes its row the new total is 6) → counter passed
+    // is 5 → 5 >= cap=5 → escalate.
+    const second = await runOneInnerTurn(
+      buildDeps({ workdir, wsRoot, runner }),
+    );
+    expect(second.kind).toBe("inner_lr_invoke_escalated");
+    if (second.kind !== "inner_lr_invoke_escalated") return;
+    expect(second.sessionId).toBe(sessionId);
+    expect(second.detail).toContain("inner_lr_invoke_timeout");
+
+    // Session metadata is now ABANDONED, so the next pickup will not
+    // re-select it (pickReadyInnerTurn guards on SESSION_OPEN).
+    const sessionLive = readJson(
+      workdir,
+      layout.sessionMetadata(sessionId),
+      DialogueSession.parse,
+    );
+    expect(sessionLive.state).toBe("ABANDONED");
+    expect(sessionLive.abandoned_reason).toBe("no_progress");
+
+    const rows = readNdjsonLines(workdir, "ledger/transitions.ndjson").map(
+      (l) => LedgerRow.parse(JSON.parse(l)),
+    );
+    const finalize = rows.find(
+      (r) =>
+        r.action_kind === "session_finalize" &&
+        r.session_id === sessionId &&
+        r.to_state === "ABANDONED",
+    );
+    expect(finalize, "must record session_finalize row").toBeDefined();
+    // idempotency tag distinguishes incident-10 from incident-3 cap-hits.
+    expect(finalize?.idempotency_key).toContain("ABANDONED");
+  });
+
+  it("respects operator override (failure_policy.inner_lr_timeout_cap = 1)", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "incident-10-override-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-override-"));
+    seedReadySlice(workdir);
+
+    const runner = new TimeoutRunner();
+    // First turn opens the session and records 1 timeout row. With
+    // operator override cap=1 the very next pickup escalates: after the
+    // 2nd `emitInvalidTurn` writes its row, ledger total=2 → counter
+    // passed to evaluateRetry is 1 → 1 >= cap=1 → escalate.
+    const first = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        failurePolicy: { inner_lr_timeout_cap: 1 },
+      }),
+    );
+    expect(first.kind).toBe("invalid_envelope");
+    if (first.kind !== "invalid_envelope") return;
+
+    const second = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        failurePolicy: { inner_lr_timeout_cap: 1 },
+      }),
+    );
+    expect(second.kind).toBe("inner_lr_invoke_escalated");
+  });
+});

--- a/tests/integration/inner-cycle-incident-10.test.ts
+++ b/tests/integration/inner-cycle-incident-10.test.ts
@@ -186,7 +186,7 @@ describe("incident-10 — agentTimeoutSec resolution", () => {
     expect(runner.lastTimeoutSec).toBe(600);
   });
 
-  it("still honors the legacy agentTimeoutSec fallback when the (loop, step) entry has no timeout_sec", async () => {
+  it("PR #110 P1-a: legacy agentTimeoutSec wins over architecture default when no per-phase timeout_sec is set", async () => {
     const workdir = mkdtempSync(join(tmpdir(), "incident-10-legacy-"));
     const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-legacy-"));
     seedReadySlice(workdir);
@@ -196,17 +196,18 @@ describe("incident-10 — agentTimeoutSec resolution", () => {
         workdir,
         wsRoot,
         runner,
-        // The architecture default for inner.tdd_build is 600s — without a
-        // per-entry timeout_sec, that wins over the caller-supplied 120s
-        // legacy fallback. This is the documented backward-compat semantics:
-        // operators who never customise stay on architecture defaults.
-        agentTimeoutSec: 120,
+        // Operator explicitly set the legacy global `agentTimeoutSec: 30`
+        // and did NOT supply a per-phase `context_budget.*.timeout_sec`.
+        // Per PR #110 P1-a, the explicit caller override must take
+        // precedence over `TIMEOUT_SEC_DEFAULTS["inner.tdd_build"]` so
+        // operator-set short timeouts are not silently inflated.
+        agentTimeoutSec: 30,
         contextBudget: {
           "inner.tdd_build": { token_hard_cap: 128_000 },
         },
       }),
     );
-    expect(runner.lastTimeoutSec).toBe(600);
+    expect(runner.lastTimeoutSec).toBe(30);
   });
 });
 
@@ -341,5 +342,96 @@ describe("incident-10 — inner_lr_invoke_timeout retry cap", () => {
       }),
     );
     expect(second.kind).toBe("inner_lr_invoke_escalated");
+  });
+
+  it("PR #110 P0: on inner_lr_invoke_escalated the slice is rolled back to SLICE_READY with current_session_id=null and a slice-transition ledger row is appended", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "incident-10-p0-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-p0-"));
+    seedReadySlice(workdir);
+
+    const runner = new TimeoutRunner();
+    // cap=1 so we escalate on the 2nd pickup without injecting synthetic rows.
+    const first = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        failurePolicy: { inner_lr_timeout_cap: 1 },
+      }),
+    );
+    expect(first.kind).toBe("invalid_envelope");
+    if (first.kind !== "invalid_envelope") return;
+    const sessionId = first.sessionId;
+
+    // After 1st turn the slice should be SLICE_BUILDING with current_session_id set.
+    const sliceMid = readJson(workdir, layout.slice(SLICE_ID), Slice.parse);
+    expect(sliceMid.state).toBe("SLICE_BUILDING");
+    expect(sliceMid.current_session_id).toBe(sessionId);
+
+    const second = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        failurePolicy: { inner_lr_timeout_cap: 1 },
+      }),
+    );
+    expect(second.kind).toBe("inner_lr_invoke_escalated");
+
+    // P0 contract: slice restored to SLICE_READY, current_session_id cleared.
+    const sliceAfter = readJson(workdir, layout.slice(SLICE_ID), Slice.parse);
+    expect(sliceAfter.state).toBe("SLICE_READY");
+    expect(sliceAfter.current_session_id).toBeNull();
+
+    // Ledger must contain a slice transition row recording the rollback.
+    const rows = readNdjsonLines(workdir, "ledger/transitions.ndjson").map(
+      (l) => LedgerRow.parse(JSON.parse(l)),
+    );
+    const sliceRollback = rows.find(
+      (r) =>
+        r.object_kind === "slice" &&
+        r.object_id === SLICE_ID &&
+        r.to_state === "SLICE_READY" &&
+        r.session_id === sessionId &&
+        r.idempotency_key.includes("abandon_slice_rollback"),
+    );
+    expect(
+      sliceRollback,
+      "must record slice SLICE_BUILDING → SLICE_READY rollback row",
+    ).toBeDefined();
+  });
+});
+
+describe("incident-10 — context_budget forwarding (PR #110 P1-b)", () => {
+  it("forwards cfg.contextBudget to callAgent so per-phase token_hard_cap reaches composePromptWithBudget", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "incident-10-budget-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-incident-10-budget-"));
+    seedReadySlice(workdir);
+
+    // Tiny per-phase token_hard_cap forces composePromptWithBudget to
+    // produce `context_budget_truncation` BEFORE the LLM runner is
+    // invoked. This is observable proof that `cfg.contextBudget` made it
+    // through callAgent → composePromptWithBudget. Without the P1-b fix,
+    // the resolver would only see contextBudget for the timeout path and
+    // composePromptWithBudget would fall back to architecture defaults
+    // (no truncation triggered).
+    const runner = new TimeoutRunner();
+    const outcome = await runOneInnerTurn(
+      buildDeps({
+        workdir,
+        wsRoot,
+        runner,
+        contextBudget: {
+          "inner.tdd_build": { token_hard_cap: 1 },
+        },
+      }),
+    );
+
+    expect(outcome.kind).toBe("invalid_envelope");
+    if (outcome.kind !== "invalid_envelope") return;
+    expect(outcome.stage).toBe("prompt_compose");
+    expect(outcome.reason).toBe("context_budget_truncation");
+    // Runner must NOT have been invoked — composePromptWithBudget short-circuits.
+    expect(runner.callCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Add optional per-phase `timeout_sec` to `context_budget` entries so target operators can lift the inner TDD ceiling beyond the legacy 120s — defaults `outer.*=120`, `middle.*=180`, `inner.tdd_build=600`.
- Add `inner_lr_invoke_timeout` retry classification + ledger counter so consecutive `lr_invoke/lr_exit_status: ... exitStatus=timeout` failures abandon the session at `failure_policy.inner_lr_timeout_cap` (default 5) instead of looping the daemon forever.

## Closes
Closes #109 (incident-10 GitHub issue)

## Operator recovery (no code action)
Live worktree of slice `01KR8B2QTP39JM1FBHQ3S040S1` contains the daemon's first authored artifact: `tests/docs/cli-doc.test.ts` (138 lines, 4 `it()` blocks). After this PR merges + daemon reboot with the 600s `inner.tdd_build` timeout, forge will retry turn 32 with the file already on disk and complete TDD red→green→refactor.

## Changes
| Module | Artifact | Notes |
|---|---|---|
| `src/config/target-schema.ts` | `ContextBudgetEntry.timeout_sec`, `TIMEOUT_SEC_DEFAULTS`, `resolveAgentTimeoutSec`, `FailurePolicy` | Backward-compat: all new fields optional. Architecture defaults documented inline. |
| `src/application/failure-policy.ts` | `inner_lr_invoke_timeout` classification, `innerLrInvokeTimeoutLimit` (default 5), `countLrInvokeTimeoutsFromLedger` | `classifyAgentIoStageFailure` now reads the failure detail to distinguish runner timeouts from other `lr_invoke` errors (spawn errors etc. stay unclassified). |
| `src/application/outer-turn.ts` | `OuterTurnDeps.contextBudget`, `resolveAgentTimeoutSec` wired at the `callAgent` site | `agentTimeoutSec ?? 120` preserved as ultimate fallback. |
| `src/application/turn-worker.ts` | `TurnWorkerCfg.contextBudget`/`failurePolicy`; `inner_lr_invoke_escalated` outcome; `abandonInnerSession` parametrised by tag | Mirrors the existing `prompt_compose_truncation` retry-cap shape; uses a distinct `finalization_decision` idempotency tag so cap-hits do not collide. |
| `src/application/dialogue-coordinator.ts` | `CoordinatorDeps.contextBudget` + `middle.review` timeout resolution | No retry-cap added (incident-10 scope is inner). |
| `src/cli/daemon.ts` | Pass `cfg.context_budget` + `cfg.failure_policy` to all three turn deps | |

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 972 passing (was 950 on main); +22 incident-10 tests across `target-schema-incident-10.test.ts`, `failure-policy.test.ts`, and the new `inner-cycle-incident-10.test.ts` integration suite
- [x] `npm run build` clean
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)