### PR TITLE
fix(manifest-resolve): inline (slice_merge, body) + (verification_run, body) for middle review (incident-11)

### DIFF
--- a/src/application/dialogue-coordinator.ts
+++ b/src/application/dialogue-coordinator.ts
@@ -341,7 +341,14 @@ async function runMiddleReviewTurnInner(
       // timeout resolver, leaving prompt-budget overrides silent.
       contextBudget: deps.contextBudget,
     },
-    { llmRunner: deps.llmRunner, manifestBuilder },
+    // PR #112 review P0-1 (gpt5.5): incident-11 wired the
+    // `(slice_merge, body)` and `(verification_run, body)` resolvers in
+    // `manifest-resolve.ts`, but the middle review `callAgent` was still
+    // missing the StorePort dependency. Without `store`, `callAgent`
+    // skips body inlining and `# Inputs` falls back to
+    // `[BODY NOT INLINED]` — the very regression incident-11 set out to
+    // fix. Mirror the inner-cycle wiring at `turn-worker.ts:361`.
+    { llmRunner: deps.llmRunner, manifestBuilder, store: deps.store },
   );
 
   if (!agentOut.ok) {

--- a/src/application/manifest-resolve.ts
+++ b/src/application/manifest-resolve.ts
@@ -5,6 +5,8 @@ import { Milestone } from "../domain/schema/milestone.js";
 import { FeatureRequest } from "../domain/schema/feature-request.js";
 import { SessionTurn } from "../domain/schema/session-turn.js";
 import { Slice } from "../domain/schema/slice.js";
+import { SliceMerge } from "../domain/schema/slice-merge.js";
+import { VerificationRun } from "../domain/schema/verification.js";
 import { layout } from "./persistence-layout.js";
 
 /**
@@ -124,16 +126,21 @@ async function resolveEntry(
   if (entry.object_kind === "slice" && entry.fetch_scope === "body") {
     return resolveSliceBody(store, entry);
   }
+  if (entry.object_kind === "slice_merge" && entry.fetch_scope === "body") {
+    return resolveSliceMergeBody(store, entry);
+  }
+  if (entry.object_kind === "verification_run" && entry.fetch_scope === "body") {
+    return resolveVerificationRunBody(store, entry);
+  }
   // Other (kind, scope) pairs remain out of scope. For `required=true`
   // entries the resolver throws so the caller can surface an AGC-INVALID
   // outcome (no silent empty prompt). For non-required entries the caller
   // catches and skips (entry omitted from `# Inputs`). Future work can
-  // extend this switch with slice_merge / dialogue_session /
-  // verification_run resolution.
+  // extend this switch with dialogue_session resolution.
   if (entry.required) {
     throw new UnsupportedManifestEntryError(
       entry,
-      "resolver supports (milestone, body), (session_turn, body), (slice, body) only",
+      "resolver supports (milestone, body), (session_turn, body), (slice, body), (slice_merge, body), (verification_run, body) only",
     );
   }
   return null;
@@ -347,6 +354,127 @@ async function resolveSliceBody(
     state: slice.state,
     dod_revision_pin: slice.dod_revision_pin,
     trunk_base_revision: slice.trunk_base_revision,
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * incident-11 — resolve `(slice_merge, body)` so the middle review sentinel
+ * (and scout) can read the SliceMerge record (the review subject) inline
+ * under `# Inputs` instead of seeing `[BODY NOT INLINED]` and emitting
+ * `failure: need_context`.
+ *
+ * Layout: `slice_merges/<slice_merge_id>.json`.
+ *
+ * Revision pin: equality with `sliceMerge.pre_merge_workspace_revision`,
+ * falling back to `sliceMerge.slice_merge_id` when the pre-merge revision is
+ * null. This mirrors `MiddleReviewPinResolver` in `dialogue-coordinator.ts`,
+ * which is the authoring side of these manifest entries — both sides must
+ * agree or the resolver rejects fresh entries as stale.
+ */
+async function resolveSliceMergeBody(
+  store: StorePort,
+  entry: ManifestEntry,
+): Promise<string | null> {
+  const path = layout.sliceMerge(entry.object_id);
+  const raw = await store.readText(path);
+  if (raw == null) {
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  let sliceMerge: ReturnType<typeof SliceMerge.parse>;
+  try {
+    sliceMerge = SliceMerge.parse(JSON.parse(raw));
+  } catch {
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  // Revision pin matches MiddleReviewPinResolver:
+  //   sliceMerge.pre_merge_workspace_revision ?? sliceMerge.slice_merge_id
+  const expectedPin =
+    sliceMerge.pre_merge_workspace_revision ?? sliceMerge.slice_merge_id;
+  if (expectedPin !== entry.revision_pin) {
+    if (entry.required) {
+      throw new StaleManifestEntryError(entry, expectedPin);
+    }
+    return null;
+  }
+  // Project review-relevant fields. Caller / lease metadata
+  // (lease_token, merged_by_caller_id, audit_chain_predecessor_id,
+  // external_refs, timestamps) does not help reviewers decide.
+  const projection: Record<string, unknown> = {
+    slice_merge_id: sliceMerge.slice_merge_id,
+    slice_id: sliceMerge.slice_id,
+    target_id: sliceMerge.target_id,
+    state: sliceMerge.state,
+    pre_merge_workspace_revision: sliceMerge.pre_merge_workspace_revision,
+    merge_revision: sliceMerge.merge_revision,
+    inner_session_id: sliceMerge.inner_session_id,
+    review_session_id: sliceMerge.review_session_id,
+    verification_run_id: sliceMerge.verification_run_id,
+    merged_at: sliceMerge.merged_at,
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * incident-11 — resolve `(verification_run, body)` so the middle review
+ * sentinel can read the deterministic-evidence record inline under
+ * `# Inputs` instead of seeing `[BODY NOT INLINED]`.
+ *
+ * Layout: `verifications/<verification_run_id>.json` (see
+ * `persistence-layout.ts` — function name is `layout.verification`).
+ *
+ * Revision pin: equality with `entry.object_id` (i.e. the
+ * verification_run_id itself). Mirrors `MiddleReviewPinResolver` in
+ * `dialogue-coordinator.ts` which sets the manifest pin to
+ * `entry.object_id` for verification_run entries — VerificationRun records
+ * are immutable evidence so the ID is the freshness marker.
+ */
+async function resolveVerificationRunBody(
+  store: StorePort,
+  entry: ManifestEntry,
+): Promise<string | null> {
+  const path = layout.verification(entry.object_id);
+  const raw = await store.readText(path);
+  if (raw == null) {
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  let run: ReturnType<typeof VerificationRun.parse>;
+  try {
+    run = VerificationRun.parse(JSON.parse(raw));
+  } catch {
+    if (entry.required) {
+      throw new MissingRequiredManifestEntryError(entry, path);
+    }
+    return null;
+  }
+  // Pin equality with the verification_run_id itself (immutable evidence).
+  if (run.verification_run_id !== entry.revision_pin) {
+    if (entry.required) {
+      throw new StaleManifestEntryError(entry, run.verification_run_id);
+    }
+    return null;
+  }
+  // Project review-relevant fields. The schema has no stdout/stderr —
+  // log_ref points off-record when present. Include result + failed_tests
+  // so the reviewer can see exactly which AC-bound tests failed.
+  const projection: Record<string, unknown> = {
+    verification_run_id: run.verification_run_id,
+    target_id: run.target_id,
+    target_revision: run.target_revision,
+    commands_or_checks: run.commands_or_checks,
+    result: run.result,
+    failed_tests: run.failed_tests,
+    covers_ac_ids: run.covers_ac_ids,
+    log_ref: run.log_ref,
   };
   return JSON.stringify(projection, null, 2);
 }

--- a/src/application/manifest-resolve.ts
+++ b/src/application/manifest-resolve.ts
@@ -405,7 +405,9 @@ async function resolveSliceMergeBody(
   }
   // Project review-relevant fields. Caller / lease metadata
   // (lease_token, merged_by_caller_id, audit_chain_predecessor_id,
-  // external_refs, timestamps) does not help reviewers decide.
+  // external_refs, created_at, updated_at) does not help reviewers
+  // decide. `merged_at` IS retained — reviewers benefit from knowing
+  // whether/when the merge has already taken effect.
   const projection: Record<string, unknown> = {
     slice_merge_id: sliceMerge.slice_merge_id,
     slice_id: sliceMerge.slice_id,

--- a/tests/application/manifest-resolve.test.ts
+++ b/tests/application/manifest-resolve.test.ts
@@ -136,12 +136,13 @@ describe("resolveManifestEntries", () => {
   it("throws on required entries with unsupported (object_kind, fetch_scope)", async () => {
     const store = new MemoryStore();
     await seedMilestone(store, "raw");
-    // incident-9 made `(slice, body)` supported, so use `(slice_merge, body)`
-    // here as the still-unsupported pair.
+    // incident-9 made `(slice, body)` supported, and incident-11 made
+    // `(slice_merge, body)` and `(verification_run, body)` supported. Use
+    // `(slice_telemetry, body)` here as a still-unsupported pair.
     const manifest = buildManifest([
       {
-        object_kind: "slice_merge",
-        object_id: "01HZS00000000000000000000A",
+        object_kind: "slice_telemetry",
+        object_id: "01HZTM0000000000000000000A",
         fetch_scope: "body",
         revision_pin: "deadbeef",
         required: true,
@@ -696,6 +697,407 @@ describe("resolveManifestEntries — slice body (incident-9)", () => {
     });
     const resolved = await resolveManifestEntries(store, manifest);
     // Only the milestone entry survives.
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.manifest_entry_index).toBe(0);
+  });
+});
+
+/**
+ * incident-11 — `(slice_merge, body)` and `(verification_run, body)`
+ * resolver tests. Middle review sentinel (turn 10) was emitting
+ * `failure: need_context` because both entries rendered as
+ * `[BODY NOT INLINED]`. PR #108 covered (slice, body); this PR completes
+ * the manifest declared by `dialogueReviewTurn` in dialogue-coordinator.ts.
+ *
+ * Pin format mirrors `MiddleReviewPinResolver`:
+ *   - slice_merge → `pre_merge_workspace_revision ?? slice_merge_id`
+ *   - verification_run → `entry.object_id` (immutable evidence id)
+ */
+describe("resolveManifestEntries — slice_merge body (incident-11)", () => {
+  const SM_SESSION_ID = "01HZSE000000000000000000M1";
+  const SM_PRIMARY_MS = "01HZMS00000000000000000M02";
+  const SM_PRIMARY_FR = "01HZFR00000000000000000M02";
+  const SM_SLICE_ID = "01HZSC000000000000000000M2";
+  const SM_ID = "01HZSM000000000000000000M3";
+  const SM_INNER_SESSION = "01HZSE000000000000000000M2";
+  const SM_REVIEW_SESSION = "01HZSE000000000000000000M3";
+  const SM_VERIF_ID = "01HZVR000000000000000000M4";
+  const SM_ISO = "2026-05-09T09:00:00.000Z";
+  const SM_PRE_MERGE_REV = "trunk-pre-merge-deadbeef";
+
+  function buildSliceMerge(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      slice_merge_id: SM_ID,
+      slice_id: SM_SLICE_ID,
+      target_id: "team-a",
+      pre_merge_workspace_revision: SM_PRE_MERGE_REV,
+      merge_revision: null,
+      inner_session_id: SM_INNER_SESSION,
+      review_session_id: SM_REVIEW_SESSION,
+      verification_run_id: SM_VERIF_ID,
+      state: "SM_READY_FOR_REVIEW",
+      merged_at: null,
+      merged_by_caller_id: null,
+      lease_token: "lease-secret-do-not-leak",
+      audit_chain_predecessor_id: null,
+      external_refs: [],
+      created_at: SM_ISO,
+      updated_at: SM_ISO,
+      ...overrides,
+    };
+  }
+
+  async function seedSmMilestone(store: MemoryStore) {
+    await store.writeAtomic(
+      layout.milestone(SM_PRIMARY_MS),
+      JSON.stringify({
+        milestone_id: SM_PRIMARY_MS,
+        target_id: "team-a",
+        title: "Middle review fix",
+        state: "M_DELIVERY_BUILDING",
+        slot_kind: "delivery",
+        intake_source_kind: "feature_request",
+        intake_source_id: SM_PRIMARY_FR,
+        spec_revision_pin: null,
+        context_summary_id: null,
+        external_refs: [],
+        created_at: SM_ISO,
+        updated_at: SM_ISO,
+      }),
+    );
+    await store.writeAtomic(
+      layout.featureRequest(SM_PRIMARY_FR),
+      JSON.stringify({
+        request_id: SM_PRIMARY_FR,
+        title: "Middle review fix",
+        body: "raw scope",
+        submitted_by: "user@example.com",
+        submitted_at: SM_ISO,
+        state: "queued",
+        promoted_milestone_id: null,
+        processed_at: null,
+        rejection_reason: null,
+      }),
+    );
+  }
+
+  function manifestWithSliceMerge(extra: any) {
+    return ContextManifest.parse({
+      manifest_id: "01HZMA00000000000000000M01",
+      session_id: SM_SESSION_ID,
+      turn_index: 0,
+      purpose: "review",
+      target: { object_kind: "slice_merge", object_id: SM_ID },
+      entries: [
+        {
+          object_kind: "milestone",
+          object_id: SM_PRIMARY_MS,
+          fetch_scope: "body",
+          revision_pin: SM_ISO,
+          required: true,
+          purpose: "primary",
+        },
+        extra,
+      ],
+      created_at: SM_ISO,
+    });
+  }
+
+  it("resolves required slice_merge body — projects review-relevant subset", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    await store.writeAtomic(
+      layout.sliceMerge(SM_ID),
+      JSON.stringify(buildSliceMerge()),
+    );
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_PRE_MERGE_REV,
+      required: true,
+      purpose: "review subject",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(2);
+    const smEntry = resolved.find((r) => r.manifest_entry_index === 1)!;
+    const body = smEntry.body;
+    for (const key of [
+      "slice_merge_id",
+      "slice_id",
+      "target_id",
+      "state",
+      "pre_merge_workspace_revision",
+      "merge_revision",
+      "inner_session_id",
+      "review_session_id",
+      "verification_run_id",
+    ]) {
+      expect(body, `selected field ${key} missing`).toContain(`"${key}"`);
+    }
+    expect(body).toContain(SM_ID);
+    expect(body).toContain(SM_PRE_MERGE_REV);
+    expect(body).toContain("SM_READY_FOR_REVIEW");
+    // Lease/audit metadata must NOT leak.
+    for (const key of [
+      "lease_token",
+      "merged_by_caller_id",
+      "audit_chain_predecessor_id",
+      "external_refs",
+      "created_at",
+      "updated_at",
+    ]) {
+      expect(body, `excluded field ${key} leaked`).not.toContain(`"${key}"`);
+    }
+    expect(body).not.toContain("lease-secret-do-not-leak");
+  });
+
+  it("falls back to slice_merge_id as pin when pre_merge_workspace_revision is null", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    await store.writeAtomic(
+      layout.sliceMerge(SM_ID),
+      JSON.stringify(buildSliceMerge({ pre_merge_workspace_revision: null })),
+    );
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_ID,
+      required: true,
+      purpose: "review subject",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(2);
+  });
+
+  it("throws MissingRequiredManifestEntryError when slice_merge file is absent", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_PRE_MERGE_REV,
+      required: true,
+      purpose: "review subject",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("throws StaleManifestEntryError when revision_pin disagrees with stored slice_merge pin", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    await store.writeAtomic(
+      layout.sliceMerge(SM_ID),
+      JSON.stringify(buildSliceMerge({ pre_merge_workspace_revision: "trunk-other" })),
+    );
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_PRE_MERGE_REV,
+      required: true,
+      purpose: "review subject",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /revision_pin mismatch/,
+    );
+  });
+
+  it("silently skips non-required slice_merge body when file is absent", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_PRE_MERGE_REV,
+      required: false,
+      purpose: "advisory",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.manifest_entry_index).toBe(0);
+  });
+});
+
+describe("resolveManifestEntries — verification_run body (incident-11)", () => {
+  const VR_SESSION_ID = "01HZSE000000000000000000V1";
+  const VR_PRIMARY_MS = "01HZMS00000000000000000V02";
+  const VR_PRIMARY_FR = "01HZFR00000000000000000V02";
+  const VR_ID = "01HZVR000000000000000000V3";
+  const VR_ISO = "2026-05-09T10:00:00.000Z";
+
+  function buildRun(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      verification_run_id: VR_ID,
+      target_id: "team-a",
+      target_revision: "trunk-after-merge-cafe",
+      commands_or_checks: ["npm run typecheck", "npm run test"],
+      environment_fingerprint: "node-20-darwin-arm64",
+      started_at: VR_ISO,
+      finished_at: VR_ISO,
+      result: "fail",
+      failed_tests: [
+        { path: "tests/x.test.ts", name: "loop converges", message: "expected 2 got 3" },
+      ],
+      log_ref: "verifications/01HZVR000000000000000000V3.log",
+      covers_ac_ids: ["AC-1", "AC-2"],
+      ...overrides,
+    };
+  }
+
+  async function seedVrMilestone(store: MemoryStore) {
+    await store.writeAtomic(
+      layout.milestone(VR_PRIMARY_MS),
+      JSON.stringify({
+        milestone_id: VR_PRIMARY_MS,
+        target_id: "team-a",
+        title: "Verification body inline",
+        state: "M_DELIVERY_BUILDING",
+        slot_kind: "delivery",
+        intake_source_kind: "feature_request",
+        intake_source_id: VR_PRIMARY_FR,
+        spec_revision_pin: null,
+        context_summary_id: null,
+        external_refs: [],
+        created_at: VR_ISO,
+        updated_at: VR_ISO,
+      }),
+    );
+    await store.writeAtomic(
+      layout.featureRequest(VR_PRIMARY_FR),
+      JSON.stringify({
+        request_id: VR_PRIMARY_FR,
+        title: "Verification body inline",
+        body: "raw scope",
+        submitted_by: "user@example.com",
+        submitted_at: VR_ISO,
+        state: "queued",
+        promoted_milestone_id: null,
+        processed_at: null,
+        rejection_reason: null,
+      }),
+    );
+  }
+
+  function manifestWithRun(extra: any) {
+    return ContextManifest.parse({
+      manifest_id: "01HZMA00000000000000000V01",
+      session_id: VR_SESSION_ID,
+      turn_index: 0,
+      purpose: "review",
+      target: { object_kind: "milestone", object_id: VR_PRIMARY_MS },
+      entries: [
+        {
+          object_kind: "milestone",
+          object_id: VR_PRIMARY_MS,
+          fetch_scope: "body",
+          revision_pin: VR_ISO,
+          required: true,
+          purpose: "primary",
+        },
+        extra,
+      ],
+      created_at: VR_ISO,
+    });
+  }
+
+  it("resolves required verification_run body — projects evidence subset", async () => {
+    const store = new MemoryStore();
+    await seedVrMilestone(store);
+    await store.writeAtomic(
+      layout.verification(VR_ID),
+      JSON.stringify(buildRun()),
+    );
+    const manifest = manifestWithRun({
+      object_kind: "verification_run",
+      object_id: VR_ID,
+      fetch_scope: "body",
+      revision_pin: VR_ID,
+      required: true,
+      purpose: "evidence",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(2);
+    const vrEntry = resolved.find((r) => r.manifest_entry_index === 1)!;
+    const body = vrEntry.body;
+    for (const key of [
+      "verification_run_id",
+      "target_id",
+      "target_revision",
+      "commands_or_checks",
+      "result",
+      "failed_tests",
+      "covers_ac_ids",
+      "log_ref",
+    ]) {
+      expect(body, `selected field ${key} missing`).toContain(`"${key}"`);
+    }
+    expect(body).toContain(VR_ID);
+    expect(body).toContain("loop converges");
+    expect(body).toContain("\"fail\"");
+    // environment_fingerprint / timestamps not relevant to reviewer.
+    for (const key of [
+      "environment_fingerprint",
+      "started_at",
+      "finished_at",
+    ]) {
+      expect(body, `excluded field ${key} leaked`).not.toContain(`"${key}"`);
+    }
+  });
+
+  it("throws MissingRequiredManifestEntryError when verification file is absent", async () => {
+    const store = new MemoryStore();
+    await seedVrMilestone(store);
+    const manifest = manifestWithRun({
+      object_kind: "verification_run",
+      object_id: VR_ID,
+      fetch_scope: "body",
+      revision_pin: VR_ID,
+      required: true,
+      purpose: "evidence",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("throws StaleManifestEntryError when revision_pin differs from verification_run_id", async () => {
+    const store = new MemoryStore();
+    await seedVrMilestone(store);
+    await store.writeAtomic(
+      layout.verification(VR_ID),
+      JSON.stringify(buildRun()),
+    );
+    const manifest = manifestWithRun({
+      object_kind: "verification_run",
+      object_id: VR_ID,
+      fetch_scope: "body",
+      revision_pin: "01HZVR000000000000000000XX",
+      required: true,
+      purpose: "evidence",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /revision_pin mismatch/,
+    );
+  });
+
+  it("silently skips non-required verification_run body when file is absent", async () => {
+    const store = new MemoryStore();
+    await seedVrMilestone(store);
+    const manifest = manifestWithRun({
+      object_kind: "verification_run",
+      object_id: VR_ID,
+      fetch_scope: "body",
+      revision_pin: VR_ID,
+      required: false,
+      purpose: "advisory evidence",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
     expect(resolved).toHaveLength(1);
     expect(resolved[0]!.manifest_entry_index).toBe(0);
   });

--- a/tests/application/manifest-resolve.test.ts
+++ b/tests/application/manifest-resolve.test.ts
@@ -922,6 +922,62 @@ describe("resolveManifestEntries — slice_merge body (incident-11)", () => {
     expect(resolved).toHaveLength(1);
     expect(resolved[0]!.manifest_entry_index).toBe(0);
   });
+
+  // PR #112 review P1-2: parity with `(slice, body)` corrupt-JSON branch.
+  it("throws MissingRequiredManifestEntryError when slice_merge JSON is corrupt and required", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    await store.writeAtomic(layout.sliceMerge(SM_ID), "{not-json");
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_PRE_MERGE_REV,
+      required: true,
+      purpose: "review subject",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("throws MissingRequiredManifestEntryError when slice_merge fails Zod parse and required", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    // Valid JSON but missing required SliceMerge fields → Zod throws.
+    await store.writeAtomic(
+      layout.sliceMerge(SM_ID),
+      JSON.stringify({ slice_merge_id: SM_ID }),
+    );
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_PRE_MERGE_REV,
+      required: true,
+      purpose: "review subject",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("returns null for non-required slice_merge body when JSON is corrupt", async () => {
+    const store = new MemoryStore();
+    await seedSmMilestone(store);
+    await store.writeAtomic(layout.sliceMerge(SM_ID), "{not-json");
+    const manifest = manifestWithSliceMerge({
+      object_kind: "slice_merge",
+      object_id: SM_ID,
+      fetch_scope: "body",
+      revision_pin: SM_PRE_MERGE_REV,
+      required: false,
+      purpose: "advisory",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.manifest_entry_index).toBe(0);
+  });
 });
 
 describe("resolveManifestEntries — verification_run body (incident-11)", () => {
@@ -1089,6 +1145,61 @@ describe("resolveManifestEntries — verification_run body (incident-11)", () =>
   it("silently skips non-required verification_run body when file is absent", async () => {
     const store = new MemoryStore();
     await seedVrMilestone(store);
+    const manifest = manifestWithRun({
+      object_kind: "verification_run",
+      object_id: VR_ID,
+      fetch_scope: "body",
+      revision_pin: VR_ID,
+      required: false,
+      purpose: "advisory evidence",
+    });
+    const resolved = await resolveManifestEntries(store, manifest);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.manifest_entry_index).toBe(0);
+  });
+
+  // PR #112 review P1-2: parity with `(slice, body)` corrupt-JSON branch.
+  it("throws MissingRequiredManifestEntryError when verification_run JSON is corrupt and required", async () => {
+    const store = new MemoryStore();
+    await seedVrMilestone(store);
+    await store.writeAtomic(layout.verification(VR_ID), "{not-json");
+    const manifest = manifestWithRun({
+      object_kind: "verification_run",
+      object_id: VR_ID,
+      fetch_scope: "body",
+      revision_pin: VR_ID,
+      required: true,
+      purpose: "evidence",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("throws MissingRequiredManifestEntryError when verification_run fails Zod parse and required", async () => {
+    const store = new MemoryStore();
+    await seedVrMilestone(store);
+    await store.writeAtomic(
+      layout.verification(VR_ID),
+      JSON.stringify({ verification_run_id: VR_ID }),
+    );
+    const manifest = manifestWithRun({
+      object_kind: "verification_run",
+      object_id: VR_ID,
+      fetch_scope: "body",
+      revision_pin: VR_ID,
+      required: true,
+      purpose: "evidence",
+    });
+    await expect(resolveManifestEntries(store, manifest)).rejects.toThrow(
+      /required manifest entry not found/,
+    );
+  });
+
+  it("returns null for non-required verification_run body when JSON is corrupt", async () => {
+    const store = new MemoryStore();
+    await seedVrMilestone(store);
+    await store.writeAtomic(layout.verification(VR_ID), "{not-json");
     const manifest = manifestWithRun({
       object_kind: "verification_run",
       object_id: VR_ID,

--- a/tests/integration/middle-review-cycle.test.ts
+++ b/tests/integration/middle-review-cycle.test.ts
@@ -399,6 +399,64 @@ describe("Phase 3 middle review cycle", () => {
     ).toBeDefined();
   });
 
+  // PR #112 review P1-1: regression guard for incident-11 + this PR's
+  // P0 wiring fix. Without StorePort wired into the middle review
+  // `callAgent`, the new (slice_merge, body) + (verification_run, body)
+  // resolvers go un-invoked and the prompt's `# Inputs` falls back to
+  // `[BODY NOT INLINED]`, sending the sentinel right back to
+  // `failure: need_context`. Assert the prompt actually inlines both.
+  it("middle review prompt inlines slice_merge body + verification_run body (incident-11 regression guard)", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "middle-inline-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-"));
+    seedFixture(workdir);
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+    const ledger = new FileLedger({ store, logger });
+    const workspace = new FakeWorkspace(wsRoot);
+    await workspace.prepareInnerWorkspace({
+      sliceId: SLICE_ID,
+      trunkBaseRevision: "trunk-base",
+    });
+    await workspace.commit({
+      sliceId: SLICE_ID,
+      message: "initial",
+      files: [{ path: "src/add.ts", content: "x" }],
+    });
+
+    const adapter = new StampingFakeAdapter(envelopeFixture("approve"));
+    const llmRunner = new AdapterRunnerPort(adapter);
+
+    const out = await runOneMiddleReviewTurn({
+      store,
+      clock,
+      llmRunner,
+      workspace,
+      verification: new FakeVerification(clock, { test: { result: "pass" } }),
+      ledger,
+      callerId: "test-caller",
+      targetId: TARGET_ID,
+      environmentFingerprint: "vitest",
+      reverifyTestCommands: (cwd) => [{ argv: ["true"], cwd }],
+    });
+    expect(out.kind).toBe("turn_persisted");
+
+    // The middle review sentinel is the only agent invoked; capture its
+    // prompt and inspect the `# Inputs` section.
+    expect(adapter.receivedPrompts.length).toBeGreaterThan(0);
+    const prompt = adapter.receivedPrompts[0]!;
+    // `[BODY NOT INLINED]` is the placeholder agent-io emits when the
+    // resolver could not project the body — a regression of the entire
+    // incident-11 chain.
+    expect(prompt).not.toContain("[BODY NOT INLINED]");
+    // slice_merge body inlined.
+    expect(prompt).toContain(SLICE_MERGE_ID);
+    expect(prompt).toContain("SM_READY_FOR_REVIEW");
+    // verification_run body inlined.
+    expect(prompt).toContain(VERIFICATION_RUN_ID);
+    expect(prompt).toContain("\"target_revision\"");
+  });
+
   it("returns noop when no SM_READY_FOR_REVIEW exists", async () => {
     const workdir = mkdtempSync(join(tmpdir(), "middle-noop-"));
     const wsRoot = mkdtempSync(join(tmpdir(), "ws-"));
@@ -431,8 +489,13 @@ describe("Phase 3 middle review cycle", () => {
  */
 class StampingFakeAdapter {
   readonly id = "fake" as const;
+  // PR #112 review P1-1: capture each prompt the runner saw so tests can
+  // assert that `(slice_merge, body)` and `(verification_run, body)` are
+  // actually inlined under `# Inputs` (not `[BODY NOT INLINED]`).
+  readonly receivedPrompts: string[] = [];
   constructor(private readonly envelopeJson: string) {}
   async run(input: { stdin: string; agentCwd: string; timeoutSec: number }) {
+    this.receivedPrompts.push(input.stdin);
     const envelope = JSON.parse(this.envelopeJson) as Record<string, unknown>;
     const headers = parseFrontmatter(input.stdin);
     envelope.session_id = headers.session_id;


### PR DESCRIPTION
## Summary
- Extend `resolveManifestEntries` to handle the remaining two body kinds the middle review sentinel declares: `(slice_merge, body)` and `(verification_run, body)`. Without these, manifest entries rendered as `[BODY NOT INLINED]` and the sentinel correctly refused to fabricate, emitting `failure: need_context` and exhausting the 10-turn middle session budget.
- Pin formats mirror `MiddleReviewPinResolver` in `dialogue-coordinator.ts` (the authoring side): `slice_merge` → `pre_merge_workspace_revision ?? slice_merge_id`; `verification_run` → `entry.object_id` (immutable evidence id). Mismatches surface `StaleManifestEntryError` for required entries; missing files surface `MissingRequiredManifestEntryError` (existing types reused).
- Projections expose only review-relevant fields (no lease_token / audit chain / timestamps / environment_fingerprint leak).

## Closes
Closes #111 (incident-11 GitHub issue)

## Operator-side change (separate from this PR)
Live `target.json`'s `lease.ttl_by_lease_kind` will be bumped 5x post-merge to support the 1200s middle.review timeout (session_lease 300000→1500000, slice_lease 120000→600000, turn_lease 60000→300000). Heartbeat works correctly; bump is for margin against transient renewal failures.

## Out of scope (deferred to next incident)
- `(dialogue_session, body)` resolver
- Validation phase manifest dispatch
- AWAITING_REVALIDATION pickup audit

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 986 passing (was 977) — 9 new tests for `(slice_merge, body)` and `(verification_run, body)` resolution + missing-file errors + stale-pin errors + non-required skip
- [x] `npm run build` clean
- [x] No regressions in existing manifest-resolve tests (the prior `unsupported (slice_merge, body)` test was retargeted to `slice_telemetry`, which remains unsupported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)