### PR TITLE
fix(termination): honor evaluateTermination timeout/abandoned reasons + dispatch reset_slice_for_rebuild (incident-12)

### DIFF
--- a/src/application/caller-dispatch.ts
+++ b/src/application/caller-dispatch.ts
@@ -307,6 +307,24 @@ async function runEffect(
       };
     }
     case "reset_slice_for_rebuild": {
+      // PR #114 review (gpt5.5 [심각도:높음]): transition the slice to
+      // SLICE_BUILDING + clear current_session_id BEFORE closing the SM.
+      // Previous order (SM close → slice transition) left the orphan
+      // `SM_CLOSED + SLICE_REVIEWING + SESSION_OPEN` on a mid-dispatch
+      // crash, and `pickReadyMiddleReview` only re-picks SM_READY_FOR_REVIEW
+      // / SM_APPROVED so the dispatch could not be resumed. With this
+      // order, a crash between the slice and SM writes leaves
+      // `SLICE_BUILDING + stale SM_READY_FOR_REVIEW`; turn-worker /
+      // ready-object pick up SLICE_BUILDING and a new SliceMerge instance
+      // is authored on the next inner cycle (the stale SM is benign — it
+      // can no longer be picked because `pickReadyMiddleReview` requires
+      // slice.state === SLICE_REVIEWING). The terminal session write in
+      // the coordinator stays last, mirroring the CONVERGED branch.
+      await transitionSliceState(input.slice, "SLICE_BUILDING", deps, {
+        loop_kind: "middle",
+        session_id: input.sessionId,
+        clear_current_session: true,
+      });
       await closeSliceMergeRequestChanges(
         {
           sliceMerge: input.sliceMerge,
@@ -315,13 +333,6 @@ async function runEffect(
         },
         smOpDeps,
       );
-      // Slice → SLICE_BUILDING + clear current_session_id so the next pickup
-      // creates a new inner session + new SliceMerge instance.
-      await transitionSliceState(input.slice, "SLICE_BUILDING", deps, {
-        loop_kind: "middle",
-        session_id: input.sessionId,
-        clear_current_session: true,
-      });
       await emitTelemetryAfterTransition(input.slice.milestone_id, smOpDeps);
       return {
         effect: "reset_slice_for_rebuild",

--- a/src/application/dialogue-coordinator.ts
+++ b/src/application/dialogue-coordinator.ts
@@ -1130,10 +1130,18 @@ async function finalizeNonConvergedReview(
   // Idempotent: if the session was already persisted as TIMEOUT/ABANDONED on a
   // prior crashed run, pickReadyMiddleReview won't return it (the SM is
   // already SM_CLOSED), so this branch only fires the first time.
+  // PR #114 review (gpt5.5 [심각도:중간]): record abandoned_reason on the
+  // session record itself, not just in the idempotency key. Operations /
+  // recovery / audit paths that read the session metadata previously lost
+  // the distinction between `no_progress`, `regression`, and
+  // `scope_violation` because `decision.abandoned_reason` was only encoded
+  // into the per_session_outcome ledger key below.
   const finalizedSession = DialogueSession.parse({
     ...session,
     state: sessionState,
     final_verdict: finalVerdict,
+    abandoned_reason:
+      decision.reason === "abandoned" ? decision.abandoned_reason : null,
     finalization_decision: null,
     updated_at: deps.clock.isoNow(),
   });

--- a/src/application/dialogue-coordinator.ts
+++ b/src/application/dialogue-coordinator.ts
@@ -463,6 +463,25 @@ async function runMiddleReviewTurnInner(
   });
 
   if (!decision.converged) {
+    // incident-12: previously this branch silently dropped TIMEOUT /
+    // ABANDONED decisions and returned `dispatch: null`, leaving the session
+    // SESSION_OPEN. The next pickup re-ran the same session, and once
+    // `evaluateTermination` started returning timeout (turnCount >=
+    // max_turns) every subsequent turn produced an identical sentinel
+    // request_changes envelope, looping indefinitely. Honor timeout /
+    // abandoned terminal reasons here and drive them through dispatch +
+    // session-finalize, mirroring the converged branch below.
+    if (decision.reason === "timeout" || decision.reason === "abandoned") {
+      return finalizeNonConvergedReview(
+        slice,
+        sliceMerge,
+        sessionAfterTurn,
+        decision,
+        allTurns,
+        turnIndex,
+        deps,
+      );
+    }
     return {
       kind: "turn_persisted",
       sessionId: sessionAfterTurn.session_id,
@@ -991,6 +1010,187 @@ async function resumeIntegration(
   return {
     kind: "turn_persisted",
     sessionId: session.session_id,
+    sliceId: slice.slice_id,
+    sliceMergeId: sliceMerge.slice_merge_id,
+    decision,
+    dispatch,
+  };
+}
+
+/**
+ * incident-12: middle review session terminated as TIMEOUT or ABANDONED.
+ *
+ * Mirrors the CONVERGED branch above (dispatch FIRST, persist terminal
+ * session state LAST) so a mid-dispatch crash leaves SM/Slice at the target
+ * state and the orphan SESSION_OPEN row is reaped by the phase-4 sweep.
+ *
+ * Final-verdict carry-over: when prior turns recorded a `request_changes`
+ * verdict the session was destined to converge as `request_changes` (per
+ * `any_request_changes_blocks`); honor that intent and dispatch
+ * `reset_slice_for_rebuild` so the forge gets another build budget. With no
+ * prior RC, dispatch the existing `close_slice_merge_blocked` path
+ * (SLICE_BLOCKED).
+ */
+async function finalizeNonConvergedReview(
+  slice: SliceT,
+  sliceMerge: SliceMergeT,
+  session: DialogueSessionT,
+  decision:
+    | { converged: false; reason: "timeout" }
+    | {
+        converged: false;
+        reason: "abandoned";
+        abandoned_reason: "no_progress" | "regression" | "scope_violation";
+      },
+  allTurns: readonly TurnSummary[],
+  turnIndex: number,
+  deps: CoordinatorDeps,
+): Promise<RunMiddleReviewOutcome> {
+  const sessionState = decision.reason === "timeout" ? "TIMEOUT" : "ABANDONED";
+  const anyRC = allTurns.some((t) => t.verdict?.result === "request_changes");
+  const finalVerdict = anyRC ? "request_changes" : null;
+
+  const dispatchDeps: DispatchDeps = {
+    store: deps.store,
+    clock: deps.clock,
+    ledger: deps.ledger,
+    workspace: deps.workspace,
+    verification: deps.verification,
+    callerId: deps.callerId,
+    targetId: deps.targetId,
+  };
+  const dispatch = await dispatchOutcome(
+    {
+      parent_loop: "middle",
+      phase_or_purpose: "review",
+      session_state: sessionState,
+      final_verdict: finalVerdict,
+      slice,
+      sliceMerge,
+      sessionId: session.session_id,
+      verificationRunId: sliceMerge.verification_run_id,
+      trunkRevision: slice.trunk_base_revision,
+      testCommandsForReverify: deps.reverifyTestCommands,
+      environmentFingerprint: deps.environmentFingerprint,
+    },
+    dispatchDeps,
+  );
+
+  if (dispatch.kind === "no_match") {
+    await deps.ledger.appendTransition({
+      transition_id: newMonotonicId(deps.clock.now()),
+      target_id: deps.targetId,
+      object_id: session.session_id,
+      object_kind: "dialogue_session",
+      from_state: "SESSION_OPEN",
+      to_state: "SESSION_OPEN",
+      loop_kind: "middle",
+      phase: null,
+      slice_id: slice.slice_id,
+      slice_kind: slice.slice_kind,
+      dod_revision: slice.dod_revision_pin,
+      session_id: session.session_id,
+      turn_index: turnIndex,
+      slot_kind: "delivery",
+      agent_profile_id: "sentinel",
+      contribution_kind: null,
+      action_kind: "session_finalize",
+      final_verdict: finalVerdict,
+      caller_id: deps.callerId,
+      manifest_id: null,
+      input_revision_pins: [],
+      output_hash: null,
+      verification_run_id: sliceMerge.verification_run_id,
+      metric_run_id: null,
+      idempotency_key: idempotencyKey({
+        scope: "external_observation",
+        parts: {
+          kind: "dispatch_no_match",
+          session_id: session.session_id,
+          session_state: sessionState,
+          final_verdict: finalVerdict,
+        },
+      }),
+      lease_token: null,
+      lease_kind: null,
+      result: "error",
+      result_detail: dispatch.detail.slice(0, 200),
+      timestamp: deps.clock.isoNow(),
+    });
+    return {
+      kind: "dispatch_no_match",
+      sessionId: session.session_id,
+      sliceId: slice.slice_id,
+      sliceMergeId: sliceMerge.slice_merge_id,
+      detail: dispatch.detail,
+    };
+  }
+
+  // Persist terminal session state LAST (atomicity — see CONVERGED comment).
+  // Idempotent: if the session was already persisted as TIMEOUT/ABANDONED on a
+  // prior crashed run, pickReadyMiddleReview won't return it (the SM is
+  // already SM_CLOSED), so this branch only fires the first time.
+  const finalizedSession = DialogueSession.parse({
+    ...session,
+    state: sessionState,
+    final_verdict: finalVerdict,
+    finalization_decision: null,
+    updated_at: deps.clock.isoNow(),
+  });
+  await deps.store.writeAtomic(
+    layout.sessionMetadata(finalizedSession.session_id),
+    JSON.stringify(finalizedSession, null, 2),
+  );
+  await deps.ledger.appendTransition({
+    transition_id: newMonotonicId(deps.clock.now()),
+    target_id: deps.targetId,
+    object_id: finalizedSession.session_id,
+    object_kind: "dialogue_session",
+    from_state: "SESSION_OPEN",
+    to_state: sessionState,
+    loop_kind: "middle",
+    phase: null,
+    slice_id: slice.slice_id,
+    slice_kind: slice.slice_kind,
+    dod_revision: slice.dod_revision_pin,
+    session_id: finalizedSession.session_id,
+    turn_index: turnIndex,
+    slot_kind: "delivery",
+    agent_profile_id: "sentinel",
+    contribution_kind: null,
+    action_kind: "session_finalize",
+    final_verdict: finalVerdict,
+    caller_id: deps.callerId,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: sliceMerge.verification_run_id,
+    metric_run_id: null,
+    idempotency_key: idempotencyKey({
+      scope: "per_session_outcome",
+      parts: {
+        session_id: finalizedSession.session_id,
+        // Carry the carry-over verdict (request_changes) when present;
+        // otherwise the terminal session state is the dispatch key.
+        final_verdict: finalVerdict ?? sessionState,
+        finalization_decision:
+          decision.reason === "abandoned"
+            ? `abandoned:${decision.abandoned_reason}`
+            : "timeout",
+        workspace_revision_pin_at_convergence:
+          sliceMerge.pre_merge_workspace_revision,
+      },
+    }),
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: null,
+    timestamp: deps.clock.isoNow(),
+  });
+
+  return {
+    kind: "turn_persisted",
+    sessionId: finalizedSession.session_id,
     sliceId: slice.slice_id,
     sliceMergeId: sliceMerge.slice_merge_id,
     decision,

--- a/src/domain/dispatch-matrix.ts
+++ b/src/domain/dispatch-matrix.ts
@@ -117,6 +117,27 @@ export const DISPATCH_MATRIX: readonly DispatchEntry[] = [
     final_verdict: null,
     effects: [{ kind: "close_slice_merge_blocked" }],
   },
+  // incident-12: middle review TIMEOUT / ABANDONED with prior request_changes
+  // verdicts → SM_CLOSED + SLICE_BUILDING (forge re-iteration). Without these
+  // rows, max_turns hits but the dispatch silently dropped the decision and
+  // the same review session was re-picked indefinitely (sentinel rationale
+  // unchanged each turn). The coordinator carries the accumulated
+  // request_changes verdict into the dispatch key when prior turns blocked
+  // the session via `any_request_changes_blocks`.
+  {
+    parent_loop: "middle",
+    phase_or_purpose: "review",
+    session_state: "TIMEOUT",
+    final_verdict: "request_changes",
+    effects: [{ kind: "reset_slice_for_rebuild" }],
+  },
+  {
+    parent_loop: "middle",
+    phase_or_purpose: "review",
+    session_state: "ABANDONED",
+    final_verdict: "request_changes",
+    effects: [{ kind: "reset_slice_for_rebuild" }],
+  },
   // ---- Phase 5b.1 outer-loop entries ----
   // Outer Discovery (purpose="design").
   {

--- a/tests/application/dispatch-matrix.test.ts
+++ b/tests/application/dispatch-matrix.test.ts
@@ -56,6 +56,34 @@ describe("DISPATCH_MATRIX", () => {
     }
   });
 
+  it("incident-12: middle review TIMEOUT/ABANDONED with prior request_changes → reset_slice_for_rebuild", () => {
+    for (const state of ["TIMEOUT", "ABANDONED"] as const) {
+      const entry = lookupDispatch({
+        parent_loop: "middle",
+        phase_or_purpose: "review",
+        session_state: state,
+        final_verdict: "request_changes",
+      });
+      expect(entry, state).not.toBeNull();
+      expect(entry?.effects.map((e) => e.kind)).toContain(
+        "reset_slice_for_rebuild",
+      );
+    }
+    // The verdict-null fallback (no prior RC) still routes to
+    // close_slice_merge_blocked → SLICE_BLOCKED.
+    for (const state of ["TIMEOUT", "ABANDONED"] as const) {
+      const entry = lookupDispatch({
+        parent_loop: "middle",
+        phase_or_purpose: "review",
+        session_state: state,
+        final_verdict: null,
+      });
+      expect(entry?.effects.map((e) => e.kind)).toContain(
+        "close_slice_merge_blocked",
+      );
+    }
+  });
+
   it("returns null for unknown tuples", () => {
     // inner tdd_build doesn't accept spec_accept verdict.
     expect(

--- a/tests/integration/middle-review-cycle.test.ts
+++ b/tests/integration/middle-review-cycle.test.ts
@@ -457,6 +457,247 @@ describe("Phase 3 middle review cycle", () => {
     expect(prompt).toContain("\"target_revision\"");
   });
 
+  // ------------------------------------------------------------------
+  // incident-12: dialogue coordinator must honor evaluateTermination
+  // TIMEOUT / ABANDONED reasons. Previously the coordinator silently
+  // dropped non-converged decisions (`return { dispatch: null }`),
+  // leaving the session SESSION_OPEN. The next pickup re-ran the same
+  // session and looped forever once max_turns was first crossed.
+  // ------------------------------------------------------------------
+  it("incident-12: timeout with prior request_changes → reset_slice_for_rebuild + session TIMEOUT", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "middle-timeout-rc-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-"));
+    seedFixture(workdir);
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+    const ledger = new FileLedger({ store, logger });
+    const workspace = new FakeWorkspace(wsRoot);
+
+    const adapter = new StampingFakeAdapter(envelopeFixture("request_changes"));
+    const llmRunner = new AdapterRunnerPort(adapter);
+
+    const out = await runOneMiddleReviewTurn({
+      store,
+      clock,
+      llmRunner,
+      workspace,
+      verification: new FakeVerification(clock, { test: { result: "pass" } }),
+      ledger,
+      callerId: "test-caller",
+      targetId: TARGET_ID,
+      environmentFingerprint: "vitest",
+      reverifyTestCommands: (cwd) => [{ argv: ["true"], cwd }],
+      // maxReviewTurns=1 so a single request_changes turn pushes the
+      // session over the cap (turnCount=1 >= max_turns=1) and
+      // evaluateTermination returns reason=timeout.
+      maxReviewTurns: 1,
+    });
+
+    expect(out.kind).toBe("turn_persisted");
+    if (out.kind !== "turn_persisted") return;
+    expect(out.decision.converged).toBe(false);
+    if (out.decision.converged) return;
+    expect(out.decision.reason).toBe("timeout");
+    expect(out.dispatch?.kind).toBe("applied");
+
+    // Session is TIMEOUT with the carried-over request_changes verdict.
+    const session = readJson(
+      workdir,
+      layout.sessionMetadata(out.sessionId),
+      (raw) => DialogueSession.parse(raw),
+    );
+    expect(session.state).toBe("TIMEOUT");
+    expect(session.final_verdict).toBe("request_changes");
+
+    // Slice routed back to SLICE_BUILDING (forge re-iteration), not BLOCKED.
+    const slice = readJson(workdir, layout.slice(SLICE_ID), (raw) =>
+      Slice.parse(raw),
+    );
+    expect(slice.state).toBe("SLICE_BUILDING");
+    expect(slice.current_session_id).toBeNull();
+
+    const sm = readJson(workdir, layout.sliceMerge(SLICE_MERGE_ID), (raw) =>
+      SliceMerge.parse(raw),
+    );
+    expect(sm.state).toBe("SM_CLOSED");
+
+    const rows = readLedgerRows(workdir);
+    expect(
+      rows.find(
+        (r) => r.object_kind === "dialogue_session" && r.to_state === "TIMEOUT",
+      ),
+    ).toBeDefined();
+    expect(
+      rows.find(
+        (r) => r.object_kind === "slice" && r.to_state === "SLICE_BUILDING",
+      ),
+    ).toBeDefined();
+    expect(
+      rows.find(
+        (r) => r.object_kind === "slice_merge" && r.to_state === "SM_CLOSED",
+      ),
+    ).toBeDefined();
+  });
+
+  it("incident-12: timeout with no prior request_changes → close_slice_merge_blocked + SLICE_BLOCKED", async () => {
+    // Sentinel emits an envelope with a non-RC verdict (`approve`-shaped but
+    // without the verification turning evidence_only true… actually the
+    // simplest way to exercise the no-RC path is to seed a session that
+    // hits max_turns=0). Instead we use a custom envelope whose verdict is
+    // not request_changes; the existing approve path would converge before
+    // hitting timeout because finalization_AND_evidence is satisfied.
+    // Here we feed an `approve` envelope but set verification.result=fail
+    // so the evidence half doesn't satisfy and the session continues —
+    // except evaluateTermination's max_turns hard cap fires first.
+    const workdir = mkdtempSync(join(tmpdir(), "middle-timeout-norc-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-"));
+    seedFixture(workdir);
+    // Override the seeded VerificationRun result to "fail" so the
+    // verification_green evidence is unsatisfied; the lead's `approve`
+    // verdict alone can't converge under finalization_AND_evidence.
+    const vrPath = join(workdir, layout.verification(VERIFICATION_RUN_ID));
+    writeFileSync(
+      vrPath,
+      JSON.stringify({
+        verification_run_id: VERIFICATION_RUN_ID,
+        target_id: TARGET_ID,
+        target_revision: "inner-commit-1",
+        commands_or_checks: ["true"],
+        environment_fingerprint: "vitest",
+        started_at: ISO,
+        finished_at: ISO,
+        result: "fail",
+        failed_tests: [],
+        log_ref: null,
+      }),
+      "utf8",
+    );
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+    const ledger = new FileLedger({ store, logger });
+    const workspace = new FakeWorkspace(wsRoot);
+
+    const adapter = new StampingFakeAdapter(envelopeFixture("approve"));
+    const llmRunner = new AdapterRunnerPort(adapter);
+
+    const out = await runOneMiddleReviewTurn({
+      store,
+      clock,
+      llmRunner,
+      workspace,
+      verification: new FakeVerification(clock, { test: { result: "pass" } }),
+      ledger,
+      callerId: "test-caller",
+      targetId: TARGET_ID,
+      environmentFingerprint: "vitest",
+      reverifyTestCommands: (cwd) => [{ argv: ["true"], cwd }],
+      maxReviewTurns: 1,
+    });
+
+    expect(out.kind).toBe("turn_persisted");
+    if (out.kind !== "turn_persisted") return;
+    expect(out.decision.converged).toBe(false);
+    if (out.decision.converged) return;
+    expect(out.decision.reason).toBe("timeout");
+
+    const session = readJson(
+      workdir,
+      layout.sessionMetadata(out.sessionId),
+      (raw) => DialogueSession.parse(raw),
+    );
+    expect(session.state).toBe("TIMEOUT");
+    // No prior RC → no carry-over verdict.
+    expect(session.final_verdict).toBeNull();
+
+    const slice = readJson(workdir, layout.slice(SLICE_ID), (raw) =>
+      Slice.parse(raw),
+    );
+    expect(slice.state).toBe("SLICE_BLOCKED");
+
+    const sm = readJson(workdir, layout.sliceMerge(SLICE_MERGE_ID), (raw) =>
+      SliceMerge.parse(raw),
+    );
+    expect(sm.state).toBe("SM_CLOSED");
+  });
+
+  it("incident-12 regression: within max_turns + reason=continue → dispatch null preserved", async () => {
+    // Pre-fix the coordinator returned `dispatch: null` for the
+    // continue branch; that behavior must remain unchanged so the next
+    // pickup can re-run the same SESSION_OPEN session.
+    const workdir = mkdtempSync(join(tmpdir(), "middle-continue-"));
+    const wsRoot = mkdtempSync(join(tmpdir(), "ws-"));
+    seedFixture(workdir);
+    // Same evidence-fail trick to keep the session non-converged on the
+    // first turn; with maxReviewTurns=5 and only 1 turn persisted, the
+    // evaluator returns `continue` (not timeout).
+    const vrPath = join(workdir, layout.verification(VERIFICATION_RUN_ID));
+    writeFileSync(
+      vrPath,
+      JSON.stringify({
+        verification_run_id: VERIFICATION_RUN_ID,
+        target_id: TARGET_ID,
+        target_revision: "inner-commit-1",
+        commands_or_checks: ["true"],
+        environment_fingerprint: "vitest",
+        started_at: ISO,
+        finished_at: ISO,
+        result: "fail",
+        failed_tests: [],
+        log_ref: null,
+      }),
+      "utf8",
+    );
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const logger = new NdjsonLogger({ store, clock, relPath: LOG_DAEMON_PATH });
+    const ledger = new FileLedger({ store, logger });
+    const workspace = new FakeWorkspace(wsRoot);
+
+    const adapter = new StampingFakeAdapter(envelopeFixture("approve"));
+    const llmRunner = new AdapterRunnerPort(adapter);
+
+    const out = await runOneMiddleReviewTurn({
+      store,
+      clock,
+      llmRunner,
+      workspace,
+      verification: new FakeVerification(clock, { test: { result: "pass" } }),
+      ledger,
+      callerId: "test-caller",
+      targetId: TARGET_ID,
+      environmentFingerprint: "vitest",
+      reverifyTestCommands: (cwd) => [{ argv: ["true"], cwd }],
+      maxReviewTurns: 5,
+    });
+
+    expect(out.kind).toBe("turn_persisted");
+    if (out.kind !== "turn_persisted") return;
+    expect(out.decision.converged).toBe(false);
+    if (out.decision.converged) return;
+    expect(out.decision.reason).toBe("continue");
+    // dispatch must remain null on continue (no terminal effect).
+    expect(out.dispatch).toBeNull();
+
+    const session = readJson(
+      workdir,
+      layout.sessionMetadata(out.sessionId),
+      (raw) => DialogueSession.parse(raw),
+    );
+    expect(session.state).toBe("SESSION_OPEN");
+
+    const slice = readJson(workdir, layout.slice(SLICE_ID), (raw) =>
+      Slice.parse(raw),
+    );
+    expect(slice.state).toBe("SLICE_REVIEWING");
+
+    const sm = readJson(workdir, layout.sliceMerge(SLICE_MERGE_ID), (raw) =>
+      SliceMerge.parse(raw),
+    );
+    expect(sm.state).toBe("SM_READY_FOR_REVIEW");
+  });
+
   it("returns noop when no SM_READY_FOR_REVIEW exists", async () => {
     const workdir = mkdtempSync(join(tmpdir(), "middle-noop-"));
     const wsRoot = mkdtempSync(join(tmpdir(), "ws-"));


### PR DESCRIPTION
## Summary
- `runMiddleReviewTurnInner` previously dropped non-converged termination decisions via `if (!decision.converged) return { ..., dispatch: null }`, leaving the session SESSION_OPEN. Once `evaluateTermination` started returning `reason: "timeout"` (turnCount >= max_turns), the picker kept re-running the same session and the sentinel emitted identical `request_changes` envelopes turn after turn — observed live as session 01KR8NEX03Q9ZMVT8Q0F0YTTPP looping 6 turns with the same rationale.
- This PR honors `timeout` / `abandoned` reasons in the middle coordinator: it dispatches FIRST (mirroring the CONVERGED path's atomicity), then persists the session as TIMEOUT/ABANDONED. When prior turns recorded a `request_changes` verdict, the dispatch carries that verdict into the matrix key so middle review routes through `reset_slice_for_rebuild` (forge re-iteration) rather than `close_slice_merge_blocked` (SLICE_BLOCKED).
- Outer-turn already handles termination reasons correctly (`finalizeNonConvergedSession` at `src/application/outer-turn.ts:696`); no change needed there. Inner timeout/abandoned was already wired in incident-10.

### 변경 내용
| Module | Artifact | Notes |
|---|---|---|
| `src/application/dialogue-coordinator.ts` | `finalizeNonConvergedReview` helper + non-converged branch wire-up | Dispatch + session-finalize for TIMEOUT/ABANDONED. Carry-over `request_changes` verdict when any prior turn voted RC. |
| `src/domain/dispatch-matrix.ts` | 2 new rows | `(middle, review, TIMEOUT, request_changes)` and `(middle, review, ABANDONED, request_changes)` → `reset_slice_for_rebuild`. Existing `final_verdict: null` fallbacks (SLICE_BLOCKED) untouched. |
| `tests/integration/middle-review-cycle.test.ts` | 3 new tests | Timeout-with-prior-RC → SLICE_BUILDING + SM_CLOSED + session TIMEOUT; timeout-no-RC → SLICE_BLOCKED; `continue` regression guard preserves `dispatch: null`. |
| `tests/application/dispatch-matrix.test.ts` | 1 new test | Asserts both new entries plus the verdict-null fallbacks. |

### Idempotency
- Same atomicity model as the existing CONVERGED path: dispatch effects are idempotent (`per_merge` ledger keys + exists-checks on slice writes); a crash between dispatch and TIMEOUT-persist leaves SM/Slice at the target state and the orphan SESSION_OPEN row is reaped by the phase-4 sweep.
- Once persisted as TIMEOUT/ABANDONED, `pickReadyMiddleReview` skips the session (the SM is already SM_CLOSED, so the SM_READY_FOR_REVIEW filter excludes it) — no double-finalize.

## Closes
Closes #113 (incident-12 GitHub issue)

## Operator-side recovery (NOT in this PR)
Live workdir's middle review session 01KR8NEX03Q9ZMVT8Q0F0YTTPP looped 6 turns of identical sentinel `request_changes` because the timeout reason wasn't honored. After this PR merges, operator will manually patch state to unblock and let the daemon dispatch `reset_slice_for_rebuild` properly going forward:
- Session `01KR8NEX03Q9ZMVT8Q0F0YTTPP` → `state=TIMEOUT`, `final_verdict=request_changes`
- SliceMerge `01KR8NEWQ2…` → `state=SM_REQUEST_CHANGES` (or SM_CLOSED, matching the post-fix code path)
- Slice `01KR8B2QTP3…` → `state=SLICE_BUILDING`, `current_session_id=null`

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 997 passing (was 994), 4 skipped. New dialogue-coordinator timeout-honoring tests + matrix entry test + continue regression guard pass.
- [x] `npm run build` clean
- [x] No regressions in existing middle-review-cycle / outer-turn / dispatch-matrix tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)