### PR TITLE
refactor(phase-0.5): extract LLM-neutral helpers to agent-run-orchestrator

### DIFF
--- a/src/application/agent-io.ts
+++ b/src/application/agent-io.ts
@@ -1,7 +1,4 @@
-import { mkdtempSync } from "node:fs";
-import { mkdir, writeFile, readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
 import type { ContextManifest } from "../domain/schema/manifest.js";
 import type {
   AgentAuthoredEnvelope,
@@ -26,6 +23,11 @@ import { resolveManifestEntries } from "./manifest-resolve.js";
 import type { ContextBudget } from "../config/target-schema.js";
 import type { IdempotencyParts } from "./idempotency.js";
 import type { StorePort } from "../ports/store.js";
+import {
+  checkHeaderEcho as checkHeaderEchoFields,
+  writePromptTmp,
+  writePromptUnderWorkdir,
+} from "./agent-run-orchestrator.js";
 
 /**
  * Phase 2 agent-io pipeline (#AGC-PROMPT-SERIALIZATION + #ARC-CALL-SEMANTICS).
@@ -274,70 +276,35 @@ export async function callAgent(
   };
 }
 
-async function writePromptTmp(
-  sessionId: string,
-  turnIndex: number,
-  body: string,
-): Promise<string> {
-  const dir = mkdtempSync(join(tmpdir(), "llm-team-prompt-"));
-  const path = join(dir, `${sessionId}-${turnIndex}.md`);
-  await writeFile(path, body, "utf8");
-  return path;
-}
-
 /**
- * phase-0-stabilization C — write the composed prompt body to
- * `<workdirRoot>/prompts/<sessionId>/<turnIndex>.md` and return the absolute
- * path the LlmRunner consumes via `runInvoke.composeStdin → readFile`.
- *
- * Replaces `writePromptTmp` for callers that thread `workdirRoot` through
- * `AgentIoDeps`. The historical `mkdtempSync(tmpdir(), "llm-team-prompt-")`
- * behaviour leaked one tmp directory per turn (6,503 dirs accumulated on a
- * single self-host run) with no cleanup hook. Persisting under the workdir
- * gives a stable, predictable, operator-inspectable path for post-incident
- * replay, and a single tree to GC when the operator chooses.
- *
- * Idempotent on (sessionId, turnIndex): rewrite of an existing file is
- * tolerated because the runner re-reads the body on each invocation, but
- * the typical caller writes once before invoking the runner.
+ * Phase 0.5 — `writePromptTmp`, `writePromptUnderWorkdir`, and the
+ * field-level header-echo check now live in
+ * `./agent-run-orchestrator.ts` so the upcoming PR-first system can
+ * reuse the LLM-neutral helpers without dragging in envelope schema
+ * coupling. Behaviour is unchanged.
  */
-async function writePromptUnderWorkdir(
-  workdirRoot: string,
-  sessionId: string,
-  turnIndex: number,
-  body: string,
-): Promise<string> {
-  const path = join(workdirRoot, "prompts", sessionId, `${turnIndex}.md`);
-  await mkdir(dirname(path), { recursive: true });
-  // qwen review P1-2: pin the mode explicitly so the prompt body does not
-  // depend on the operator's umask. Mirrors `writeAtomic` (store/fs.ts)
-  // which also writes 0o644.
-  await writeFile(path, body, { encoding: "utf8", mode: 0o644 });
-  return path;
-}
-
 function checkHeaderEcho(
   envelope: AgentAuthoredEnvelope,
   input: AgentIoInput,
 ): string | null {
-  const mismatches: string[] = [];
-  const echo = (
-    field: string,
-    expected: string | number,
-    got: string | number,
-  ) => {
-    if (expected !== got) mismatches.push(`${field} expected=${expected} got=${got}`);
-  };
-  echo("session_id", input.sessionId, envelope.session_id);
-  echo("turn_index", input.turnIndex, envelope.turn_index);
-  echo("parent_loop", input.parentLoop, envelope.parent_loop);
-  echo("phase_or_purpose", input.phaseOrPurpose, envelope.phase_or_purpose);
-  echo("agent_profile_id", input.agentProfileId, envelope.agent_profile_id);
-  echo(
-    "agent_role_in_session",
-    input.agentRoleInSession,
-    envelope.agent_role_in_session,
+  return checkHeaderEchoFields(
+    {
+      session_id: input.sessionId,
+      turn_index: input.turnIndex,
+      parent_loop: input.parentLoop,
+      phase_or_purpose: input.phaseOrPurpose,
+      agent_profile_id: input.agentProfileId,
+      agent_role_in_session: input.agentRoleInSession,
+      manifest_id: input.manifest.manifest_id,
+    },
+    {
+      session_id: envelope.session_id,
+      turn_index: envelope.turn_index,
+      parent_loop: envelope.parent_loop,
+      phase_or_purpose: envelope.phase_or_purpose,
+      agent_profile_id: envelope.agent_profile_id,
+      agent_role_in_session: envelope.agent_role_in_session,
+      manifest_id: envelope.manifest_id,
+    },
   );
-  echo("manifest_id", input.manifest.manifest_id, envelope.manifest_id);
-  return mismatches.length > 0 ? mismatches.join("; ") : null;
 }

--- a/src/application/agent-run-orchestrator.ts
+++ b/src/application/agent-run-orchestrator.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * Phase 0.5 — agent-io neutral helper extraction (no-op refactor).
+ *
+ * Houses the LLM-neutral, envelope-무관 helpers that `agent-io.ts`
+ * historically owned. Phase 1 introduces a PR-first orchestration path
+ * (lead-invoker / reviewer-invoker / outbox / machine-block) that needs
+ * the same prompt-persistence and header-echo primitives without
+ * dragging in envelope-specific parsing/enrichment code.
+ *
+ * Behaviour MUST stay identical to the pre-extraction implementation —
+ * `agent-io.ts` re-exports / delegates to these helpers so existing
+ * callers (turn-worker / dialogue-coordinator / outer-turn / cli) remain
+ * source-compatible.
+ */
+
+/**
+ * Legacy prompt persistence — used when no `workdirRoot` is threaded
+ * through `AgentIoDeps`. Kept for single-shot tests and fixture-only
+ * adapters that have no workdir notion.
+ *
+ * Each call allocates a fresh `mkdtempSync` directory and writes
+ * `<sessionId>-<turnIndex>.md` inside it, returning the absolute path
+ * the LlmRunner consumes via `composeStdin → readFile`.
+ */
+export async function writePromptTmp(
+  sessionId: string,
+  turnIndex: number,
+  body: string,
+): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "llm-team-prompt-"));
+  const path = join(dir, `${sessionId}-${turnIndex}.md`);
+  await writeFile(path, body, "utf8");
+  return path;
+}
+
+/**
+ * phase-0-stabilization C — write the composed prompt body to
+ * `<workdirRoot>/prompts/<sessionId>/<turnIndex>.md` and return the
+ * absolute path the LlmRunner consumes via
+ * `runInvoke.composeStdin → readFile`.
+ *
+ * Replaces `writePromptTmp` for callers that thread `workdirRoot` through
+ * `AgentIoDeps`. The historical `mkdtempSync(tmpdir(), "llm-team-prompt-")`
+ * behaviour leaked one tmp directory per turn (6,503 dirs accumulated on a
+ * single self-host run) with no cleanup hook. Persisting under the workdir
+ * gives a stable, predictable, operator-inspectable path for post-incident
+ * replay, and a single tree to GC when the operator chooses.
+ *
+ * Idempotent on (sessionId, turnIndex): rewrite of an existing file is
+ * tolerated because the runner re-reads the body on each invocation, but
+ * the typical caller writes once before invoking the runner.
+ */
+export async function writePromptUnderWorkdir(
+  workdirRoot: string,
+  sessionId: string,
+  turnIndex: number,
+  body: string,
+): Promise<string> {
+  const path = join(workdirRoot, "prompts", sessionId, `${turnIndex}.md`);
+  await mkdir(dirname(path), { recursive: true });
+  // qwen review P1-2: pin the mode explicitly so the prompt body does not
+  // depend on the operator's umask. Mirrors `writeAtomic` (store/fs.ts)
+  // which also writes 0o644.
+  await writeFile(path, body, { encoding: "utf8", mode: 0o644 });
+  return path;
+}
+
+/**
+ * Header echo invariant — the agent must replay the seven prompt
+ * frontmatter fields back in its envelope. This helper compares
+ * `expected` (from prompt input) against `got` (from the agent-authored
+ * envelope or any structurally compatible payload). Returns a
+ * semicolon-joined mismatch string, or `null` when all seven fields
+ * match.
+ *
+ * Envelope-무관: the caller passes plain field bags so Phase 1
+ * (PR-first lead-invoker / reviewer-invoker) can reuse the same check
+ * against its own envelope shape without depending on
+ * `AgentAuthoredEnvelope`.
+ */
+export interface HeaderEchoFields {
+  session_id: string;
+  turn_index: number;
+  parent_loop: string;
+  phase_or_purpose: string;
+  agent_profile_id: string;
+  agent_role_in_session: string;
+  manifest_id: string;
+}
+
+export function checkHeaderEcho(
+  expected: HeaderEchoFields,
+  got: HeaderEchoFields,
+): string | null {
+  const mismatches: string[] = [];
+  const echo = (
+    field: keyof HeaderEchoFields,
+    a: string | number,
+    b: string | number,
+  ) => {
+    if (a !== b) mismatches.push(`${field} expected=${a} got=${b}`);
+  };
+  echo("session_id", expected.session_id, got.session_id);
+  echo("turn_index", expected.turn_index, got.turn_index);
+  echo("parent_loop", expected.parent_loop, got.parent_loop);
+  echo("phase_or_purpose", expected.phase_or_purpose, got.phase_or_purpose);
+  echo("agent_profile_id", expected.agent_profile_id, got.agent_profile_id);
+  echo(
+    "agent_role_in_session",
+    expected.agent_role_in_session,
+    got.agent_role_in_session,
+  );
+  echo("manifest_id", expected.manifest_id, got.manifest_id);
+  return mismatches.length > 0 ? mismatches.join("; ") : null;
+}

--- a/tests/application/agent-run-orchestrator.test.ts
+++ b/tests/application/agent-run-orchestrator.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  checkHeaderEcho,
+  writePromptTmp,
+  writePromptUnderWorkdir,
+  type HeaderEchoFields,
+} from "../../src/application/agent-run-orchestrator.js";
+
+const SESSION_ID = "01HZSE0000000000000000000A";
+const MANIFEST_ID = "01HZMA0000000000000000000A";
+
+function fields(overrides: Partial<HeaderEchoFields> = {}): HeaderEchoFields {
+  return {
+    session_id: SESSION_ID,
+    turn_index: 0,
+    parent_loop: "inner",
+    phase_or_purpose: "tdd_build",
+    agent_profile_id: "forge",
+    agent_role_in_session: "lead",
+    manifest_id: MANIFEST_ID,
+    ...overrides,
+  };
+}
+
+describe("agent-run-orchestrator (Phase 0.5 no-op extraction)", () => {
+  describe("writePromptTmp", () => {
+    it("writes the body under a fresh tmp dir and returns the absolute path", async () => {
+      const path = await writePromptTmp(SESSION_ID, 7, "hello-prompt");
+      expect(path.endsWith(`${SESSION_ID}-7.md`)).toBe(true);
+      expect(readFileSync(path, "utf8")).toBe("hello-prompt");
+    });
+  });
+
+  describe("writePromptUnderWorkdir", () => {
+    it("writes to <workdir>/prompts/<sessionId>/<turnIndex>.md with mode 0o644", async () => {
+      const workdir = mkdtempSync(join(tmpdir(), "workdir-"));
+      const path = await writePromptUnderWorkdir(
+        workdir,
+        SESSION_ID,
+        3,
+        "body-3",
+      );
+      expect(path).toBe(join(workdir, "prompts", SESSION_ID, "3.md"));
+      expect(readFileSync(path, "utf8")).toBe("body-3");
+      // Mode pin matches writeAtomic — low 9 bits should be 0o644.
+      expect(statSync(path).mode & 0o777).toBe(0o644);
+    });
+
+    it("is idempotent on (sessionId, turnIndex) — rewrites tolerated", async () => {
+      const workdir = mkdtempSync(join(tmpdir(), "workdir-"));
+      const a = await writePromptUnderWorkdir(workdir, SESSION_ID, 1, "v1");
+      const b = await writePromptUnderWorkdir(workdir, SESSION_ID, 1, "v2");
+      expect(a).toBe(b);
+      expect(readFileSync(b, "utf8")).toBe("v2");
+    });
+  });
+
+  describe("checkHeaderEcho", () => {
+    it("returns null when all seven echo fields match", () => {
+      expect(checkHeaderEcho(fields(), fields())).toBeNull();
+    });
+
+    it("reports a single mismatched field", () => {
+      const out = checkHeaderEcho(fields(), fields({ turn_index: 1 }));
+      expect(out).toBe("turn_index expected=0 got=1");
+    });
+
+    it("joins multiple mismatches with semicolons in field order", () => {
+      const out = checkHeaderEcho(
+        fields(),
+        fields({ session_id: "OTHER", manifest_id: "OTHER_MID" }),
+      );
+      expect(out).toBe(
+        `session_id expected=${SESSION_ID} got=OTHER; manifest_id expected=${MANIFEST_ID} got=OTHER_MID`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- agent-io.ts 의 envelope-무관 helper (prompt persistence / header echo) 를 src/application/agent-run-orchestrator.ts 로 추출
- 동작 변경 0 (no-op refactor). 기존 caller 시그니처 호환, agent-io.ts 가 새 모듈을 import 해서 위임
- 목적: Phase 1 의 PR-first 신규 시스템(lead-invoker / reviewer-invoker / outbox / machine-block) 이 동일 orchestration 헬퍼 재사용

근거: cli-spicy-anchor.md "Phase 0.5"

### 변경 내용
| Module | Artifact | Notes |
|---|---|---|
| src/application/agent-run-orchestrator.ts | new | writePromptTmp / writePromptUnderWorkdir / checkHeaderEcho (HeaderEchoFields 기반, envelope schema 미참조) |
| src/application/agent-io.ts | edit | 위 3 helper 를 새 모듈로 위임. 기존 export (callAgent / AgentIoOutcome / AgentIoInput / AgentIoDeps) 는 그대로 |
| tests/application/agent-run-orchestrator.test.ts | new | 6 cases — tmp/workdir 영속, 0o644 mode, idempotent rewrite, header echo match/single/multi mismatch |

### 추출 범위 결정
플랜이 나열한 후보 중 실제 `agent-io.ts` 에 존재하는 envelope-무관 helper 만 추출:
- `writePromptTmp`, `writePromptUnderWorkdir` (prompt persistence) → 추출
- `checkHeaderEcho` (header echo) → field bag 시그니처로 일반화 후 추출. `agent-io.ts` 는 `AgentAuthoredEnvelope → HeaderEchoFields` 매핑만 수행
- `classifyAgentIoStageFailure` (retry classification) → `failure-policy.ts` 거주, `agent-io.ts` 미포함이라 본 PR 범위 밖. 이미 envelope-무관이며 Phase 1 에서 그대로 import 가능
- diagnostics / LLM neutrality → `agent-io.ts` 는 runner port 의 `diagnosticsRef` 를 그대로 통과시킬 뿐 자체 로직 없음. 추출 대상 없음

## Test plan
- [x] 기존 1003 tests 0 regression (1009 passing 으로 +6 신규만 추가)
- [x] typecheck clean
- [x] build clean
- [x] agent-io.ts 의 caller 들 (turn-worker / dialogue-coordinator / outer-turn / cli) 동작 동일 (시그니처 미변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)