### PR TITLE
feat(phase-1): PR-first infra additive — capability + outbox + machine-block + ports

### DIFF
--- a/src/adapters/git-host/fs-mirror.ts
+++ b/src/adapters/git-host/fs-mirror.ts
@@ -7,9 +7,17 @@
 
 import type { ExternalRefHandle } from "../../ports/issue-tracker.js";
 import type {
+  DismissReviewInput,
   GitHostPort,
+  ListedReview,
+  MergePullRequestInput,
+  MergePullRequestResult,
   OpenPullRequestInput,
   PostPullRequestCommentInput,
+  PullRequestMergeState,
+  SubmitPullRequestReviewInput,
+  SubmittedReview,
+  UpdatePullRequestBodyInput,
   UpdatePullRequestInput,
 } from "../../ports/git-host.js";
 import type { StorePort } from "../../ports/store.js";
@@ -17,6 +25,14 @@ import type { StorePort } from "../../ports/store.js";
 const PROVIDER = "fs-mirror";
 const ROOT = "external_mirror";
 const COUNTER_PATH = `${ROOT}/_pr_counter.json`;
+
+interface StoredReview {
+  id: number;
+  author: string;
+  state: "approved" | "changes_requested" | "commented" | "dismissed" | "pending";
+  body: string;
+  submittedAt: string | null;
+}
 
 interface StoredPr {
   number: number;
@@ -29,6 +45,9 @@ interface StoredPr {
   base: string;
   linked_issue: string | null;
   comments: { id: number; body: string }[];
+  reviews: StoredReview[];
+  diff: string;
+  merge_commit_sha: string | null;
   revision: number;
 }
 
@@ -39,12 +58,18 @@ function prPath(n: number): string {
 interface Counter {
   next_pr: number;
   next_comment: number;
+  next_review: number;
 }
 
 async function readCounter(store: StorePort): Promise<Counter> {
   const raw = await store.readText(COUNTER_PATH);
-  if (raw == null) return { next_pr: 1, next_comment: 1 };
-  return JSON.parse(raw) as Counter;
+  if (raw == null) return { next_pr: 1, next_comment: 1, next_review: 1 };
+  const parsed = JSON.parse(raw) as Partial<Counter>;
+  return {
+    next_pr: parsed.next_pr ?? 1,
+    next_comment: parsed.next_comment ?? 1,
+    next_review: parsed.next_review ?? 1,
+  };
 }
 
 async function writeCounter(
@@ -80,6 +105,9 @@ export class FsMirrorGitHost implements GitHostPort {
           ? input.linkedIssueRef.id
           : null,
         comments: [],
+        reviews: [],
+        diff: "",
+        merge_commit_sha: null,
         revision: 1,
       };
       await this.store.writeAtomic(prPath(number), JSON.stringify(stored));
@@ -137,7 +165,7 @@ export class FsMirrorGitHost implements GitHostPort {
     const n = Number(prRef.id);
     const raw = await this.store.readText(prPath(n));
     if (raw == null || raw === "") return null;
-    const s = JSON.parse(raw) as StoredPr;
+    const s = readStoredPr(raw);
     return {
       state: s.state,
       draft: s.draft,
@@ -147,4 +175,274 @@ export class FsMirrorGitHost implements GitHostPort {
       revision: String(s.revision),
     };
   }
+
+  // ---------- Phase 1 additive surface ----------
+
+  /** Test seeder — overwrite the PR's diff body. */
+  async seedDiff(prRef: ExternalRefHandle, diff: string): Promise<void> {
+    const n = Number(prRef.id);
+    await this.store.withFileLock(prPath(n), async () => {
+      const raw = await this.store.readText(prPath(n));
+      if (raw == null) throw new Error(`fs-mirror: pr ${n} missing`);
+      const cur = readStoredPr(raw);
+      cur.diff = diff;
+      cur.revision += 1;
+      await this.store.writeAtomic(prPath(n), JSON.stringify(cur));
+    });
+  }
+
+  async submitPullRequestReview(
+    input: SubmitPullRequestReviewInput,
+  ): Promise<SubmittedReview> {
+    const n = Number(input.prRef.id);
+    return this.store.withFileLock(prPath(n), async () => {
+      const raw = await this.store.readText(prPath(n));
+      if (raw == null) throw new Error(`fs-mirror: pr ${n} missing`);
+      const cur = readStoredPr(raw);
+      const id = await this.store.withFileLock(COUNTER_PATH, async () => {
+        const c = await readCounter(this.store);
+        const next = c.next_review;
+        c.next_review = next + 1;
+        await writeCounter(this.store, c);
+        return next;
+      });
+      const state =
+        input.intent === "approve"
+          ? "approved"
+          : input.intent === "request_changes"
+            ? "changes_requested"
+            : "commented";
+      const review: StoredReview = {
+        id,
+        author: PROVIDER,
+        state,
+        body: input.body,
+        submittedAt: new Date(0).toISOString(),
+      };
+      cur.reviews.push(review);
+      cur.revision += 1;
+      await this.store.writeAtomic(prPath(n), JSON.stringify(cur));
+      return { externalReviewId: String(id) };
+    });
+  }
+
+  async listPullRequestReviews(
+    prRef: ExternalRefHandle,
+  ): Promise<ListedReview[]> {
+    const n = Number(prRef.id);
+    const raw = await this.store.readText(prPath(n));
+    if (raw == null || raw === "") return [];
+    const cur = readStoredPr(raw);
+    return cur.reviews.map((r) => ({
+      externalReviewId: String(r.id),
+      author: r.author,
+      state: r.state,
+      body: r.body,
+      submittedAt: r.submittedAt,
+    }));
+  }
+
+  async updatePullRequestBody(
+    input: UpdatePullRequestBodyInput,
+  ): Promise<ExternalRefHandle> {
+    return this.updatePullRequest({
+      prRef: input.prRef,
+      body: input.body,
+    });
+  }
+
+  async getPullRequestDiff(prRef: ExternalRefHandle): Promise<string> {
+    const n = Number(prRef.id);
+    const raw = await this.store.readText(prPath(n));
+    if (raw == null || raw === "") return "";
+    return readStoredPr(raw).diff;
+  }
+
+  async mergePullRequest(
+    input: MergePullRequestInput,
+  ): Promise<MergePullRequestResult> {
+    const n = Number(input.prRef.id);
+    return this.store.withFileLock(prPath(n), async () => {
+      const raw = await this.store.readText(prPath(n));
+      if (raw == null) throw new Error(`fs-mirror: pr ${n} missing`);
+      const cur = readStoredPr(raw);
+      cur.state = "merged";
+      cur.merge_commit_sha = `merge-${cur.number}-${cur.revision + 1}`;
+      cur.revision += 1;
+      await this.store.writeAtomic(prPath(n), JSON.stringify(cur));
+      return { mergeCommitSha: cur.merge_commit_sha };
+    });
+  }
+
+  async addLabel(
+    prRef: ExternalRefHandle,
+    label: string,
+  ): Promise<ExternalRefHandle> {
+    const n = Number(prRef.id);
+    return this.store.withFileLock(prPath(n), async () => {
+      const raw = await this.store.readText(prPath(n));
+      if (raw == null) throw new Error(`fs-mirror: pr ${n} missing`);
+      const cur = readStoredPr(raw);
+      if (!cur.labels.includes(label)) cur.labels.push(label);
+      cur.revision += 1;
+      await this.store.writeAtomic(prPath(n), JSON.stringify(cur));
+      return { provider: PROVIDER, id: String(n) };
+    });
+  }
+
+  async removeLabel(
+    prRef: ExternalRefHandle,
+    label: string,
+  ): Promise<ExternalRefHandle> {
+    const n = Number(prRef.id);
+    return this.store.withFileLock(prPath(n), async () => {
+      const raw = await this.store.readText(prPath(n));
+      if (raw == null) throw new Error(`fs-mirror: pr ${n} missing`);
+      const cur = readStoredPr(raw);
+      cur.labels = cur.labels.filter((l) => l !== label);
+      cur.revision += 1;
+      await this.store.writeAtomic(prPath(n), JSON.stringify(cur));
+      return { provider: PROVIDER, id: String(n) };
+    });
+  }
+
+  async dismissReview(input: DismissReviewInput): Promise<void> {
+    const n = Number(input.prRef.id);
+    await this.store.withFileLock(prPath(n), async () => {
+      const raw = await this.store.readText(prPath(n));
+      if (raw == null) throw new Error(`fs-mirror: pr ${n} missing`);
+      const cur = readStoredPr(raw);
+      const target = cur.reviews.find(
+        (r) => String(r.id) === input.externalReviewId,
+      );
+      if (target == null) return;
+      target.state = "dismissed";
+      cur.revision += 1;
+      await this.store.writeAtomic(prPath(n), JSON.stringify(cur));
+    });
+  }
+
+  // ---------- dedup probes ----------
+
+  async findOpenPullRequestByMachineKey(
+    headBranch: string,
+    idempotencyKey: string,
+  ): Promise<ExternalRefHandle | null> {
+    const ids = await this.store.list(`${ROOT}/prs`);
+    for (const entry of ids) {
+      const m = /^(\d+)\.json$/.exec(entry);
+      if (m == null) continue;
+      const raw = await this.store.readText(prPath(Number(m[1]))) ?? "";
+      if (raw.length === 0) continue;
+      const cur = readStoredPr(raw);
+      if (cur.state !== "open") continue;
+      if (cur.head !== headBranch) continue;
+      if (bodyContainsMachineKey(cur.body, "pr", idempotencyKey)) {
+        return { provider: PROVIDER, id: String(cur.number) };
+      }
+    }
+    return null;
+  }
+
+  async findPullRequestByBodyMachineKey(
+    prRef: ExternalRefHandle,
+    idempotencyKey: string,
+  ): Promise<ExternalRefHandle | null> {
+    const n = Number(prRef.id);
+    const raw = await this.store.readText(prPath(n));
+    if (raw == null || raw === "") return null;
+    const cur = readStoredPr(raw);
+    if (bodyContainsMachineKey(cur.body, "pr", idempotencyKey)) {
+      return { provider: PROVIDER, id: String(n) };
+    }
+    return null;
+  }
+
+  async findReviewByMachineKey(
+    prRef: ExternalRefHandle,
+    idempotencyKey: string,
+  ): Promise<ListedReview | null> {
+    const reviews = await this.listPullRequestReviews(prRef);
+    for (const r of reviews) {
+      if (bodyContainsMachineKey(r.body, "review", idempotencyKey)) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  async getPullRequestMergeState(
+    prRef: ExternalRefHandle,
+  ): Promise<PullRequestMergeState> {
+    const n = Number(prRef.id);
+    const raw = await this.store.readText(prPath(n));
+    if (raw == null || raw === "")
+      return { state: "closed", mergeCommitSha: null };
+    const cur = readStoredPr(raw);
+    return {
+      state: cur.state,
+      mergeCommitSha: cur.merge_commit_sha,
+    };
+  }
+
+  async listLabels(prRef: ExternalRefHandle): Promise<string[]> {
+    const n = Number(prRef.id);
+    const raw = await this.store.readText(prPath(n));
+    if (raw == null || raw === "") return [];
+    return [...readStoredPr(raw).labels];
+  }
+
+  async getReview(
+    prRef: ExternalRefHandle,
+    externalReviewId: string,
+  ): Promise<ListedReview | null> {
+    const reviews = await this.listPullRequestReviews(prRef);
+    return reviews.find((r) => r.externalReviewId === externalReviewId) ?? null;
+  }
+}
+
+function readStoredPr(raw: string): StoredPr {
+  const parsed = JSON.parse(raw) as Partial<StoredPr> & { number: number };
+  return {
+    number: parsed.number,
+    title: parsed.title ?? "",
+    body: parsed.body ?? "",
+    labels: parsed.labels ?? [],
+    state: parsed.state ?? "open",
+    draft: parsed.draft ?? false,
+    head: parsed.head ?? "",
+    base: parsed.base ?? "",
+    linked_issue: parsed.linked_issue ?? null,
+    comments: parsed.comments ?? [],
+    reviews: parsed.reviews ?? [],
+    diff: parsed.diff ?? "",
+    merge_commit_sha: parsed.merge_commit_sha ?? null,
+    revision: parsed.revision ?? 1,
+  };
+}
+
+/**
+ * Lightweight regex check shared by dedup probes. The authoritative
+ * machine-block parser lives in `src/application/machine-block.ts` (Phase 1).
+ * Here we only need the idempotency_key inside the last machine block of a
+ * given block_kind.
+ */
+function bodyContainsMachineKey(
+  body: string,
+  blockKind: "pr" | "review",
+  idempotencyKey: string,
+): boolean {
+  const re = new RegExp(
+    `<!--\\s*llm-team:${blockKind}-machine\\b([\\s\\S]*?)-->`,
+    "g",
+  );
+  let last: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) last = m;
+  if (last == null) return false;
+  const inner = last[1] ?? "";
+  const keyRe = /^idempotency_key:\s*(.+)$/m;
+  const km = keyRe.exec(inner);
+  if (km == null) return false;
+  return km[1]?.trim() === idempotencyKey;
 }

--- a/src/adapters/git-host/github.ts
+++ b/src/adapters/git-host/github.ts
@@ -9,9 +9,17 @@
 
 import type { ExternalRefHandle } from "../../ports/issue-tracker.js";
 import type {
+  DismissReviewInput,
   GitHostPort,
+  ListedReview,
+  MergePullRequestInput,
+  MergePullRequestResult,
   OpenPullRequestInput,
   PostPullRequestCommentInput,
+  PullRequestMergeState,
+  SubmitPullRequestReviewInput,
+  SubmittedReview,
+  UpdatePullRequestBodyInput,
   UpdatePullRequestInput,
 } from "../../ports/git-host.js";
 import type { GhExec } from "../issue-tracker/github.js";
@@ -171,4 +179,297 @@ export class GitHubGitHost implements GitHostPort {
       return null;
     }
   }
+
+  // ---------- Phase 1 additive surface (cli-spicy-anchor.md §1 step 2) ----------
+  //
+  // Phase 1 is additive: callers (lead-invoker / reviewer-invoker / outbox)
+  // are wired in Phase 2/3. The implementations below shell out to `gh`
+  // using the smallest set of flags that matches the documented behavior.
+  // No existing callers reach these paths in Phase 1.
+
+  async submitPullRequestReview(
+    input: SubmitPullRequestReviewInput,
+  ): Promise<SubmittedReview> {
+    // `gh pr review <num>` supports `--approve | --request-changes | --comment`
+    // plus `--body <md>`. There is no native flag to pin a review id, so we
+    // rely on the caller-side machine-block + last-match dedup probe to
+    // recover after crashes (cli-spicy-anchor.md §7-2).
+    const args = ["pr", "review", input.prRef.id, "--repo", this.opts.repo];
+    if (input.intent === "approve") args.push("--approve");
+    else if (input.intent === "request_changes") args.push("--request-changes");
+    else args.push("--comment");
+    args.push("--body", input.body);
+    await this.opts.exec.run(args);
+
+    // Read back the most recent review id matching the body's idempotency_key.
+    const reviews = await this.listPullRequestReviews(input.prRef);
+    const matched = reviews.find((r) =>
+      r.body.includes(`idempotency_key: ${input.idempotencyKey}`),
+    );
+    if (matched == null) {
+      throw new Error(
+        `gh pr review: posted review not visible after submit (key=${input.idempotencyKey})`,
+      );
+    }
+    return { externalReviewId: matched.externalReviewId };
+  }
+
+  async listPullRequestReviews(
+    prRef: ExternalRefHandle,
+  ): Promise<ListedReview[]> {
+    const res = await this.opts.exec.run([
+      "pr",
+      "view",
+      prRef.id,
+      "--repo",
+      this.opts.repo,
+      "--json",
+      "reviews",
+    ]);
+    const parsed = JSON.parse(res.stdout) as {
+      reviews?: {
+        id?: string;
+        databaseId?: number;
+        author?: { login?: string };
+        state?: string;
+        body?: string;
+        submittedAt?: string | null;
+      }[];
+    };
+    return (parsed.reviews ?? []).map((r) => ({
+      externalReviewId:
+        r.id ?? (r.databaseId != null ? String(r.databaseId) : ""),
+      author: r.author?.login ?? "",
+      state: mapReviewState(r.state ?? ""),
+      body: r.body ?? "",
+      submittedAt: r.submittedAt ?? null,
+    }));
+  }
+
+  async updatePullRequestBody(
+    input: UpdatePullRequestBodyInput,
+  ): Promise<ExternalRefHandle> {
+    return this.updatePullRequest({
+      prRef: input.prRef,
+      body: input.body,
+    });
+  }
+
+  async getPullRequestDiff(prRef: ExternalRefHandle): Promise<string> {
+    const res = await this.opts.exec.run([
+      "pr",
+      "diff",
+      prRef.id,
+      "--repo",
+      this.opts.repo,
+    ]);
+    return res.stdout;
+  }
+
+  async mergePullRequest(
+    input: MergePullRequestInput,
+  ): Promise<MergePullRequestResult> {
+    const args = [
+      "pr",
+      "merge",
+      input.prRef.id,
+      "--repo",
+      this.opts.repo,
+    ];
+    if (input.strategy === "squash") args.push("--squash");
+    else if (input.strategy === "merge") args.push("--merge");
+    else args.push("--rebase");
+    if (input.commitTitle != null) args.push("--subject", input.commitTitle);
+    if (input.commitMessage != null) args.push("--body", input.commitMessage);
+    await this.opts.exec.run(args);
+    const state = await this.getPullRequestMergeState(input.prRef);
+    if (state.mergeCommitSha == null) {
+      throw new Error(
+        `gh pr merge: merge commit sha not available for pr=${input.prRef.id}`,
+      );
+    }
+    return { mergeCommitSha: state.mergeCommitSha };
+  }
+
+  async addLabel(
+    prRef: ExternalRefHandle,
+    label: string,
+  ): Promise<ExternalRefHandle> {
+    await this.opts.exec.run([
+      "pr",
+      "edit",
+      prRef.id,
+      "--repo",
+      this.opts.repo,
+      "--add-label",
+      this.prefix(label),
+    ]);
+    return prRef;
+  }
+
+  async removeLabel(
+    prRef: ExternalRefHandle,
+    label: string,
+  ): Promise<ExternalRefHandle> {
+    await this.opts.exec.run([
+      "pr",
+      "edit",
+      prRef.id,
+      "--repo",
+      this.opts.repo,
+      "--remove-label",
+      this.prefix(label),
+    ]);
+    return prRef;
+  }
+
+  async dismissReview(input: DismissReviewInput): Promise<void> {
+    // gh exposes review dismissal only via the GraphQL API.
+    const message = input.message ?? "Dismissed by Caller";
+    await this.opts.exec.run([
+      "api",
+      "graphql",
+      "-F",
+      `reviewId=${input.externalReviewId}`,
+      "-F",
+      `message=${message}`,
+      "-f",
+      "query=mutation($reviewId:ID!,$message:String!){dismissPullRequestReview(input:{pullRequestReviewId:$reviewId,message:$message}){clientMutationId}}",
+    ]);
+  }
+
+  // ---------- dedup probes ----------
+
+  async findOpenPullRequestByMachineKey(
+    headBranch: string,
+    idempotencyKey: string,
+  ): Promise<ExternalRefHandle | null> {
+    const res = await this.opts.exec.run([
+      "pr",
+      "list",
+      "--repo",
+      this.opts.repo,
+      "--head",
+      headBranch,
+      "--state",
+      "open",
+      "--json",
+      "number,body,url",
+    ]);
+    const list = JSON.parse(res.stdout) as {
+      number: number;
+      body?: string;
+      url?: string;
+    }[];
+    for (const pr of list) {
+      if (
+        pr.body &&
+        bodyContainsMachineKey(pr.body, "pr", idempotencyKey)
+      ) {
+        return {
+          provider: PROVIDER,
+          id: String(pr.number),
+          url: pr.url,
+        };
+      }
+    }
+    return null;
+  }
+
+  async findPullRequestByBodyMachineKey(
+    prRef: ExternalRefHandle,
+    idempotencyKey: string,
+  ): Promise<ExternalRefHandle | null> {
+    const cur = await this.fetchPullRequest(prRef);
+    if (cur == null) return null;
+    if (bodyContainsMachineKey(cur.body, "pr", idempotencyKey)) return prRef;
+    return null;
+  }
+
+  async findReviewByMachineKey(
+    prRef: ExternalRefHandle,
+    idempotencyKey: string,
+  ): Promise<ListedReview | null> {
+    const reviews = await this.listPullRequestReviews(prRef);
+    for (const r of reviews) {
+      if (bodyContainsMachineKey(r.body, "review", idempotencyKey)) return r;
+    }
+    return null;
+  }
+
+  async getPullRequestMergeState(
+    prRef: ExternalRefHandle,
+  ): Promise<PullRequestMergeState> {
+    const res = await this.opts.exec.run([
+      "pr",
+      "view",
+      prRef.id,
+      "--repo",
+      this.opts.repo,
+      "--json",
+      "state,mergeCommit",
+    ]);
+    const parsed = JSON.parse(res.stdout) as {
+      state?: string;
+      mergeCommit?: { oid?: string } | null;
+    };
+    const mapped =
+      parsed.state === "OPEN"
+        ? "open"
+        : parsed.state === "MERGED"
+          ? "merged"
+          : "closed";
+    return {
+      state: mapped,
+      mergeCommitSha: parsed.mergeCommit?.oid ?? null,
+    };
+  }
+
+  async listLabels(prRef: ExternalRefHandle): Promise<string[]> {
+    const cur = await this.fetchPullRequest(prRef);
+    return cur?.labels ?? [];
+  }
+
+  async getReview(
+    prRef: ExternalRefHandle,
+    externalReviewId: string,
+  ): Promise<ListedReview | null> {
+    const reviews = await this.listPullRequestReviews(prRef);
+    return reviews.find((r) => r.externalReviewId === externalReviewId) ?? null;
+  }
+}
+
+function mapReviewState(state: string): ListedReview["state"] {
+  switch (state.toUpperCase()) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes_requested";
+    case "DISMISSED":
+      return "dismissed";
+    case "PENDING":
+      return "pending";
+    default:
+      return "commented";
+  }
+}
+
+function bodyContainsMachineKey(
+  body: string,
+  blockKind: "pr" | "review",
+  idempotencyKey: string,
+): boolean {
+  const re = new RegExp(
+    `<!--\\s*llm-team:${blockKind}-machine\\b([\\s\\S]*?)-->`,
+    "g",
+  );
+  let last: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) last = m;
+  if (last == null) return false;
+  const inner = last[1] ?? "";
+  const keyRe = /^idempotency_key:\s*(.+)$/m;
+  const km = keyRe.exec(inner);
+  if (km == null) return false;
+  return km[1]?.trim() === idempotencyKey;
 }

--- a/src/adapters/llm-runner/claude-code.ts
+++ b/src/adapters/llm-runner/claude-code.ts
@@ -1,3 +1,7 @@
+import {
+  applyCapabilityEnvStrip,
+  claudeCodeCapabilityFlags,
+} from "./common/capability.js";
 import { resolveSpawnEnv, spawnWithTimeout } from "./common/spawn.js";
 import type {
   LlmAdapterInput,
@@ -22,11 +26,15 @@ export class ClaudeCodeAdapter implements LlmRunnerAdapter {
   constructor(private readonly cfg: ClaudeCodeAdapterCfg = {}) {}
 
   async run(input: LlmAdapterInput): Promise<LlmAdapterResult> {
-    const { cmd, args } = this.buildArgv();
-    const env = resolveSpawnEnv({
+    const { cmd, args } = this.buildArgv(input);
+    // L3 — always apply the capability secret strip on top of allowlist /
+    // override; secrets like LLM_TEAM_MACHINE_BLOCK_SECRET must never reach
+    // the agent process even if the operator set them via envOverride.
+    const baseEnv = resolveSpawnEnv({
       allowlist: this.cfg.envAllowlist,
       override: this.cfg.envOverride,
     });
+    const env = applyCapabilityEnvStrip(baseEnv, input.capabilityPolicy);
     const r = await spawnWithTimeout({
       cmd,
       args,
@@ -39,12 +47,15 @@ export class ClaudeCodeAdapter implements LlmRunnerAdapter {
     return { ...r, spawnEnv: env };
   }
 
-  buildArgv(): { cmd: string; args: string[] } {
+  buildArgv(input?: LlmAdapterInput): { cmd: string; args: string[] } {
     const tokens = (this.cfg.command ?? "claude").split(/\s+/).filter(Boolean);
     const cmd = tokens[0] ?? "claude";
     const baseArgs = tokens.slice(1);
     const flags: string[] = ["-p", "--output-format", "text"];
     if (this.cfg.model) flags.push("--model", this.cfg.model);
+    if (input?.capabilityPolicy) {
+      flags.push(...claudeCodeCapabilityFlags(input.capabilityPolicy));
+    }
     if (this.cfg.extraArgs) flags.push(...this.cfg.extraArgs);
     return { cmd, args: [...baseArgs, ...flags] };
   }

--- a/src/adapters/llm-runner/codex-cli.ts
+++ b/src/adapters/llm-runner/codex-cli.ts
@@ -1,3 +1,7 @@
+import {
+  applyCapabilityEnvStrip,
+  codexCliCapabilityFlags,
+} from "./common/capability.js";
 import { resolveSpawnEnv, spawnWithTimeout } from "./common/spawn.js";
 import type {
   LlmAdapterInput,
@@ -29,10 +33,11 @@ export class CodexCliAdapter implements LlmRunnerAdapter {
 
   async run(input: LlmAdapterInput): Promise<LlmAdapterResult> {
     const { cmd, args } = this.buildArgv(input);
-    const env = resolveSpawnEnv({
+    const baseEnv = resolveSpawnEnv({
       allowlist: this.cfg.envAllowlist,
       override: this.cfg.envOverride,
     });
+    const env = applyCapabilityEnvStrip(baseEnv, input.capabilityPolicy);
     const r = await spawnWithTimeout({
       cmd,
       args,
@@ -59,6 +64,9 @@ export class CodexCliAdapter implements LlmRunnerAdapter {
     ];
     if (this.cfg.model) flags.push("--model", this.cfg.model);
     if (this.cfg.profile) flags.push("--profile", this.cfg.profile);
+    if (input.capabilityPolicy) {
+      flags.push(...codexCliCapabilityFlags(input.capabilityPolicy));
+    }
     if (this.cfg.extraArgs) flags.push(...this.cfg.extraArgs);
     return { cmd, args: [...baseArgs, ...flags] };
   }

--- a/src/adapters/llm-runner/common/capability.ts
+++ b/src/adapters/llm-runner/common/capability.ts
@@ -1,0 +1,112 @@
+/**
+ * Phase 1 capability-policy enforcement helpers shared by LLM runner adapters.
+ *
+ * Authority: `cli-spicy-anchor.md` §1.
+ *
+ * - `claudeCodeCapabilityFlags(policy)` → CLI args for L1 (claude-code).
+ * - `codexCliCapabilityFlags(policy)` → CLI args for L1 (codex-cli).
+ * - `applyCapabilityEnvStrip(env, policy)` → L3 env allowlist filter.
+ *
+ * L2 (cwd jail) is satisfied by the adapter passing `input.agentCwd` to
+ * `spawnWithTimeout` unchanged. L4 (post-call tracked diff allowlist) is a
+ * separate helper in `application/post-call-diff-allowlist.ts` invoked by
+ * lead/reviewer-invoker (Phase 2/3).
+ */
+
+import {
+  AgentCapabilityPolicy,
+  CAPABILITY_L3_STRIP_KEYS,
+  CAPABILITY_L3_STRIP_PREFIXES,
+  CAPABILITY_L3_STRIP_SUFFIXES,
+  isCapabilityStrippedEnvKey,
+} from "../../../domain/schema/agent-capability-policy.js";
+
+/** L1 — translate the policy into claude-code `--allowed-tools` / `--disallowed-tools`. */
+export function claudeCodeCapabilityFlags(
+  policy: AgentCapabilityPolicy,
+): string[] {
+  const allowed: string[] = [];
+  const disallowed: string[] = [];
+
+  // Read tool — claude-code's `Read` tool. Policy.read.mode=deny → disallow.
+  if (policy.read.mode === "deny") disallowed.push("Read");
+  else allowed.push("Read");
+
+  // Edit tool covers `Edit` + `Write`.
+  if (policy.edit.mode === "deny") disallowed.push("Edit", "Write");
+  else allowed.push("Edit", "Write");
+
+  // Bash. allow → unrestricted; allowlist → claude-code lacks per-pattern flag,
+  // so 1회전 maps to `Bash` allowed (relies on L4 / L5 for true allowlisting).
+  if (policy.bash.mode === "deny") disallowed.push("Bash");
+  else allowed.push("Bash");
+
+  // Network — WebFetch / WebSearch.
+  if (policy.network === "deny") disallowed.push("WebFetch", "WebSearch");
+  else allowed.push("WebFetch", "WebSearch");
+
+  const flags: string[] = [];
+  if (allowed.length > 0) {
+    flags.push("--allowed-tools", allowed.join(","));
+  }
+  if (disallowed.length > 0) {
+    flags.push("--disallowed-tools", disallowed.join(","));
+  }
+  return flags;
+}
+
+/** L1 — translate the policy into codex-cli `--sandbox` / network flags. */
+export function codexCliCapabilityFlags(
+  policy: AgentCapabilityPolicy,
+): string[] {
+  const flags: string[] = [];
+  // Default codex sandbox is `workspace-write` when edit is permitted.
+  // read-only when edit=deny but read != deny.
+  if (policy.edit.mode === "deny" && policy.read.mode !== "deny") {
+    flags.push("--sandbox", "read-only");
+  } else if (policy.edit.mode !== "deny") {
+    flags.push("--sandbox", "workspace-write");
+  } else {
+    // Both denied → fall back to read-only for self-consistency.
+    flags.push("--sandbox", "read-only");
+  }
+  if (policy.network === "deny") {
+    // codex-cli accepts `--no-network` per cli-spicy-anchor.md §1 L1.
+    flags.push("--no-network");
+  }
+  return flags;
+}
+
+/**
+ * L3 — strip secret env keys from the spawn env. Always removes the
+ * baseline secret family from `agent-capability-policy.ts`. When `policy`
+ * is provided we additionally apply `read.mode==="deny"` → drop `HOME` /
+ * `XDG_*` (best-effort; many CLIs require HOME to start).
+ */
+export function applyCapabilityEnvStrip(
+  env: NodeJS.ProcessEnv,
+  policy?: AgentCapabilityPolicy,
+): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) continue;
+    if (isCapabilityStrippedEnvKey(k)) continue;
+    out[k] = v;
+  }
+  // Network deny → drop common proxy env vars so the agent can't tunnel.
+  if (policy && policy.network === "deny") {
+    delete out.HTTP_PROXY;
+    delete out.HTTPS_PROXY;
+    delete out.http_proxy;
+    delete out.https_proxy;
+    delete out.ALL_PROXY;
+    delete out.all_proxy;
+  }
+  return out;
+}
+
+export const CAPABILITY_STRIP_BASELINE = {
+  keys: CAPABILITY_L3_STRIP_KEYS,
+  prefixes: CAPABILITY_L3_STRIP_PREFIXES,
+  suffixes: CAPABILITY_L3_STRIP_SUFFIXES,
+} as const;

--- a/src/adapters/llm-runner/types.ts
+++ b/src/adapters/llm-runner/types.ts
@@ -2,10 +2,18 @@
 // The contract-shaped LlmRunnerPort is implemented by the executor (runInvoke),
 // which composes stdin from prompt_ref/session_context_ref and dispatches here.
 
+import type { AgentCapabilityPolicy } from "../../domain/schema/agent-capability-policy.js";
+
 export interface LlmAdapterInput {
   stdin: string;
   agentCwd: string;
   timeoutSec: number;
+  /**
+   * Phase 1 (cli-spicy-anchor.md §1) — optional capability policy applied
+   * via L1 (CLI flags), L2 (cwd jail), L3 (env strip). Adapters that
+   * don't recognise the policy fall back to default behavior.
+   */
+  capabilityPolicy?: AgentCapabilityPolicy;
 }
 
 export interface LlmAdapterResult {

--- a/src/adapters/workspace/fake.ts
+++ b/src/adapters/workspace/fake.ts
@@ -139,6 +139,73 @@ export class FakeWorkspace implements WorkspacePort {
     return this.knownRefs.has(ref);
   }
 
+  // ---------- Phase 1 additive surface (cli-spicy-anchor.md §7-2) ----------
+
+  /** Test-only registry of trailers seeded by the fake or by `commit`. */
+  private readonly commitTrailers = new Map<
+    string,
+    { sha: string; trailers: Map<string, string> }[]
+  >();
+
+  /** Test-only registry of remote heads keyed by `<remote>/<branch>`. */
+  private readonly remoteHeads = new Map<string, string>();
+
+  /** Counts of resetHard / cleanForce calls (test introspection). */
+  resetHardCount = 0;
+  cleanForceCount = 0;
+
+  /** Test seeder — appends a fake commit log entry with trailers. */
+  seedCommitTrailer(branch: string, sha: string, trailers: Record<string, string>): void {
+    const list = this.commitTrailers.get(branch) ?? [];
+    list.push({ sha, trailers: new Map(Object.entries(trailers)) });
+    this.commitTrailers.set(branch, list);
+  }
+
+  /** Test seeder — sets a remote head for `<remote>/<branch>`. */
+  seedRemoteHead(remote: string, branch: string, sha: string | null): void {
+    if (sha == null) this.remoteHeads.delete(`${remote}/${branch}`);
+    else this.remoteHeads.set(`${remote}/${branch}`, sha);
+  }
+
+  async findCommitByTrailer(input: {
+    branch: string;
+    trailerKey: string;
+    value: string;
+    depth?: number;
+  }): Promise<string | null> {
+    const list = this.commitTrailers.get(input.branch);
+    if (list == null || list.length === 0) return null;
+    const depth = input.depth ?? 50;
+    const slice = list.slice(-depth).reverse();
+    for (const entry of slice) {
+      if (entry.trailers.get(input.trailerKey) === input.value) {
+        return entry.sha;
+      }
+    }
+    return null;
+  }
+
+  async getRemoteHeadSha(input: {
+    remote: string;
+    branch: string;
+  }): Promise<string | null> {
+    return this.remoteHeads.get(`${input.remote}/${input.branch}`) ?? null;
+  }
+
+  async resetHard(input: { sliceId: string; sha: string }): Promise<void> {
+    this.resetHardCount += 1;
+    const cur = this.state.get(input.sliceId);
+    if (cur == null)
+      throw new Error(
+        `resetHard on un-prepared workspace for slice_id=${input.sliceId}`,
+      );
+    this.state.set(input.sliceId, { head: input.sha, commits: cur.commits });
+  }
+
+  async cleanForce(_input: { sliceId: string }): Promise<void> {
+    this.cleanForceCount += 1;
+  }
+
   async rebaseOntoTrunk(input: {
     sliceId: string;
     trunkRevision: string;

--- a/src/adapters/workspace/git-worktree.ts
+++ b/src/adapters/workspace/git-worktree.ts
@@ -172,6 +172,74 @@ export class GitWorktreeWorkspace implements WorkspacePort {
     }
   }
 
+  // ---------- Phase 1 additive surface (cli-spicy-anchor.md §7-2) ----------
+
+  async findCommitByTrailer(input: {
+    branch: string;
+    trailerKey: string;
+    value: string;
+    depth?: number;
+  }): Promise<string | null> {
+    const depth = input.depth ?? 50;
+    // `git log -n <depth> --format=%H%x00%B%x00%x01` — split on \x01 then \x00.
+    let res: GitResult;
+    try {
+      res = await git(this.cfg.repoRoot, [
+        "log",
+        "-n",
+        String(depth),
+        "--format=%H%x00%B%x01",
+        input.branch,
+      ]);
+    } catch {
+      return null;
+    }
+    const records = res.stdout.split("\x01").filter((s) => s.length > 0);
+    const trailerRe = new RegExp(
+      `^${escapeRegExp(input.trailerKey)}:\\s*(.+)$`,
+      "m",
+    );
+    for (const rec of records) {
+      const idx = rec.indexOf("\x00");
+      if (idx < 0) continue;
+      const sha = rec.slice(0, idx).trim();
+      const body = rec.slice(idx + 1);
+      const m = trailerRe.exec(body);
+      if (m && m[1]?.trim() === input.value) return sha;
+    }
+    return null;
+  }
+
+  async getRemoteHeadSha(input: {
+    remote: string;
+    branch: string;
+  }): Promise<string | null> {
+    try {
+      const res = await git(this.cfg.repoRoot, [
+        "ls-remote",
+        "--heads",
+        input.remote,
+        input.branch,
+      ]);
+      const line = res.stdout.split("\n").find((l) => l.length > 0);
+      if (line == null) return null;
+      const sha = line.split(/\s+/)[0]?.trim();
+      return sha && sha.length > 0 ? sha : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async resetHard(input: { sliceId: string; sha: string }): Promise<void> {
+    const wt = this.worktreePath(input.sliceId);
+    await git(wt, ["reset", "--hard", input.sha]);
+  }
+
+  async cleanForce(input: { sliceId: string }): Promise<void> {
+    const wt = this.worktreePath(input.sliceId);
+    await git(wt, ["clean", "-fdx"]);
+  }
+
   private worktreePath(sliceId: string): string {
     return resolve(this.cfg.workspacesDir, sliceId);
   }
@@ -239,6 +307,10 @@ async function pathExists(p: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function assertSafeRel(rel: string): void {

--- a/src/application/machine-block.ts
+++ b/src/application/machine-block.ts
@@ -1,0 +1,235 @@
+import { createHmac } from "node:crypto";
+
+/**
+ * PR / review machine-block module.
+ *
+ * Authority: `cli-spicy-anchor.md` §11 (sanitize / last-match / nonce).
+ *
+ * Responsibilities:
+ *   - `sanitizeMarkdown(body)`: strip any agent-authored
+ *     `<!-- llm-team:... -->` blocks before the Caller inlines agent text
+ *     into PR/review bodies (defense against block-injection spoofing).
+ *   - `parseLastMatch(body, blockKind)`: only the **last** machine block of
+ *     the requested kind is authoritative.
+ *   - `buildCanonicalString` / `computeNonce` / `verifyNonce` /
+ *     `renderBlock`: HMAC-SHA256 (prefix-16 hex) signing of the block's
+ *     canonical fields.
+ *
+ * `secret` for HMAC is read from the env var named by
+ * `target.governance.machine_block_secret_env_name` (default
+ * `LLM_TEAM_MACHINE_BLOCK_SECRET`). The daemon must fail-loud at startup if
+ * the env var is unset (`requireMachineBlockSecret`).
+ */
+
+export type MachineBlockKind = "pr" | "review";
+
+const KIND_NAMES = new Set<string>(["pr", "review"]);
+
+const PR_FIELDS = [
+  "review_surface_id",
+  "parent_kind",
+  "parent_id",
+  "parent_phase",
+  "head_sha",
+  "review_round",
+  "last_verification_result",
+  "idempotency_key",
+] as const;
+
+const REVIEW_FIELDS = [
+  "review_surface_id",
+  "parent_kind",
+  "parent_id",
+  "parent_phase",
+  "review_round",
+  "session_id",
+  "turn_index",
+  "agent_profile_id",
+  "idempotency_key",
+] as const;
+
+export type PrCanonicalFields = Record<(typeof PR_FIELDS)[number], string>;
+export type ReviewCanonicalFields = Record<(typeof REVIEW_FIELDS)[number], string>;
+export type CanonicalFieldsFor<K extends MachineBlockKind> = K extends "pr"
+  ? PrCanonicalFields
+  : ReviewCanonicalFields;
+
+export const MACHINE_BLOCK_SECRET_ENV_DEFAULT =
+  "LLM_TEAM_MACHINE_BLOCK_SECRET";
+
+/**
+ * Read & assert the machine-block HMAC secret from process.env. Throws an
+ * Error if the variable is unset or empty so the daemon boots fail-loud
+ * (cli-spicy-anchor.md §11-3 secret 위치).
+ */
+export function requireMachineBlockSecret(
+  envName: string = MACHINE_BLOCK_SECRET_ENV_DEFAULT,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const v = env[envName];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new Error(
+      `machine-block secret env var ${envName} is not set; refusing to start`,
+    );
+  }
+  return v;
+}
+
+/**
+ * Strip any `<!-- llm-team:... -->` HTML comment block. Used to sanitize
+ * agent-authored markdown before inlining.
+ */
+export function sanitizeMarkdown(body: string): string {
+  return body.replace(/<!--\s*llm-team:[\s\S]*?-->/g, "");
+}
+
+export function fieldsForKind(
+  kind: MachineBlockKind,
+): readonly string[] {
+  return kind === "pr" ? PR_FIELDS : REVIEW_FIELDS;
+}
+
+/**
+ * Build the canonical string the HMAC is computed over. Field order is
+ * fixed and must match `cli-spicy-anchor.md §11-3`.
+ */
+export function buildCanonicalString<K extends MachineBlockKind>(
+  blockKind: K,
+  fields: CanonicalFieldsFor<K>,
+): string {
+  const parts: string[] = [`block_kind=${blockKind}`];
+  const order = fieldsForKind(blockKind);
+  for (const k of order) {
+    const v = (fields as Record<string, string>)[k];
+    if (typeof v !== "string" || v.length === 0) {
+      throw new Error(`canonical field "${k}" is missing or empty`);
+    }
+    parts.push(`${k}=${v}`);
+  }
+  return parts.join("|");
+}
+
+/** HMAC-SHA256 hex prefix 16. */
+export function computeNonce<K extends MachineBlockKind>(
+  secret: string,
+  blockKind: K,
+  fields: CanonicalFieldsFor<K>,
+): string {
+  if (typeof secret !== "string" || secret.length === 0) {
+    throw new Error("computeNonce: secret must be a non-empty string");
+  }
+  const canonical = buildCanonicalString(blockKind, fields);
+  return createHmac("sha256", secret)
+    .update(canonical)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function verifyNonce<K extends MachineBlockKind>(
+  secret: string,
+  blockKind: K,
+  fields: CanonicalFieldsFor<K>,
+  nonce: string,
+): boolean {
+  try {
+    const expected = computeNonce(secret, blockKind, fields);
+    return constantTimeEqual(expected, nonce);
+  } catch {
+    return false;
+  }
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let acc = 0;
+  for (let i = 0; i < a.length; i++) {
+    acc |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return acc === 0;
+}
+
+/**
+ * Serialize a machine block (canonical fields + nonce) into the wire
+ * format. The block is meant to be appended to the PR/review body's tail
+ * — the parser uses last-match semantics.
+ */
+export function renderBlock<K extends MachineBlockKind>(
+  blockKind: K,
+  fields: CanonicalFieldsFor<K>,
+  nonce: string,
+): string {
+  const order = fieldsForKind(blockKind);
+  const lines: string[] = [`<!-- llm-team:${blockKind}-machine`];
+  for (const k of order) {
+    const v = (fields as Record<string, string>)[k];
+    if (typeof v !== "string" || v.length === 0) {
+      throw new Error(`renderBlock: field "${k}" missing or empty`);
+    }
+    lines.push(`${k}: ${v}`);
+  }
+  lines.push(`nonce: ${nonce}`);
+  lines.push("-->");
+  return lines.join("\n");
+}
+
+export interface ParsedMachineBlock<K extends MachineBlockKind> {
+  blockKind: K;
+  fields: CanonicalFieldsFor<K>;
+  nonce: string;
+  /** Substring offset where the parsed block starts, for diagnostics. */
+  startOffset: number;
+}
+
+/**
+ * Locate the **last** machine block of `blockKind` in `body`. Returns null
+ * when no block is present or when the block is malformed (unknown field /
+ * missing nonce).
+ *
+ * Last-match policy: cli-spicy-anchor.md §11-2 — Caller appends its own
+ * block to the body's end so any earlier (agent-injected) block is
+ * shadowed.
+ */
+export function parseLastMatch<K extends MachineBlockKind>(
+  body: string,
+  blockKind: K,
+): ParsedMachineBlock<K> | null {
+  if (!KIND_NAMES.has(blockKind)) return null;
+  const re = new RegExp(
+    `<!--\\s*llm-team:${blockKind}-machine\\b([\\s\\S]*?)-->`,
+    "g",
+  );
+  let lastMatch: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) lastMatch = m;
+  if (lastMatch == null) return null;
+
+  const inner = lastMatch[1] ?? "";
+  const order = fieldsForKind(blockKind);
+  const knownKeys = new Set([...order, "nonce"]);
+  const fields: Record<string, string> = {};
+  let nonce: string | null = null;
+
+  for (const rawLine of inner.split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    const idx = line.indexOf(":");
+    if (idx < 0) return null;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (!knownKeys.has(key)) return null; // forward-compat-strict
+    if (key === "nonce") nonce = value;
+    else fields[key] = value;
+  }
+
+  for (const k of order) {
+    if (!(k in fields)) return null;
+  }
+  if (nonce == null || nonce.length === 0) return null;
+
+  return {
+    blockKind,
+    fields: fields as CanonicalFieldsFor<K>,
+    nonce,
+    startOffset: lastMatch.index,
+  };
+}

--- a/src/application/outbox.ts
+++ b/src/application/outbox.ts
@@ -1,0 +1,600 @@
+/**
+ * Phase 1 outbox 2-phase + dedup probe coordinator.
+ *
+ * Authority: `cli-spicy-anchor.md` §7 (외부 write outbox).
+ *
+ * The outbox itself manages only the (op_kind, idempotency_key) lifecycle
+ * via append-only ledger events. Receipt / SessionTurn backfill is the
+ * caller's (lead-invoker / reviewer-invoker / recovery-coordinator)
+ * responsibility — see plan §7-3.
+ *
+ * Phase 1 ships the module wiring; actual call-sites (lead-invoker,
+ * reviewer-invoker, pr-watcher) land in Phase 2/3/4.
+ */
+
+import { newId } from "../domain/ids.js";
+import type {
+  LedgerActionKind,
+  LedgerRow,
+} from "../domain/schema/ledger.js";
+import type { GitHostPort } from "../ports/git-host.js";
+import type { ExternalRefHandle } from "../ports/issue-tracker.js";
+import type { StorePort } from "../ports/store.js";
+import type { WorkspacePort } from "../ports/workspace.js";
+import type { LedgerAppender } from "./ledger.js";
+import { LEDGER_TRANSITIONS_PATH } from "./persistence-layout.js";
+
+export type OutboxOpKind =
+  | "commit_op"
+  | "push_op"
+  | "pr_open_op"
+  | "pr_update_op"
+  | "submit_review_op"
+  | "merge_op"
+  | "add_label_op"
+  | "remove_label_op"
+  | "dismiss_review_op";
+
+export type OutboxStatus = "posted" | "failed";
+
+export type OutboxRecoveryMode =
+  | "pending_without_posted"
+  | "posted_without_receipt";
+
+export interface OutboxBeginInput {
+  opKind: OutboxOpKind;
+  /** Caller-issued idempotency key (typically a ULID). */
+  idempotencyKey: string;
+  /** Free-form payload — opaque to outbox; persisted via ledger result_detail. */
+  payload?: Record<string, unknown>;
+  /** Caller id required by the LedgerRow schema. */
+  callerId: string;
+  /** Object identity for the ledger row (e.g. surface_ref or slice id). */
+  targetId: string;
+  objectId: string;
+  manifestId: string | null;
+  surfaceRef?: string;
+}
+
+export interface OutboxCompleteInput {
+  opKind: OutboxOpKind;
+  idempotencyKey: string;
+  status: OutboxStatus;
+  /** Provider-local id captured from the external write (PR#, review id, sha). */
+  externalId?: string;
+  callerId: string;
+  targetId: string;
+  objectId: string;
+  manifestId: string | null;
+  surfaceRef?: string;
+  externalReviewId?: string;
+}
+
+export interface OutboxRecoverInput<P = unknown> {
+  opKind: OutboxOpKind;
+  idempotencyKey: string;
+  mode: OutboxRecoveryMode;
+  /** Probe payload; required fields depend on op_kind (see probe table). */
+  probe: ProbeContextFor<OutboxOpKind, P>;
+  callerId: string;
+  targetId: string;
+  objectId: string;
+  manifestId: string | null;
+  surfaceRef?: string;
+}
+
+/** Per-op probe context. The router below is structurally typed. */
+export interface ProbeContextCommitOp {
+  workspace: WorkspacePort;
+  branch: string;
+  trailerKey: string;
+  value: string;
+  depth?: number;
+}
+export interface ProbeContextPushOp {
+  workspace: WorkspacePort;
+  remote: string;
+  branch: string;
+  expectedSha: string;
+}
+export interface ProbeContextPrOpenOp {
+  gitHost: GitHostPort;
+  headBranch: string;
+}
+export interface ProbeContextPrUpdateOp {
+  gitHost: GitHostPort;
+  prRef: ExternalRefHandle;
+}
+export interface ProbeContextSubmitReviewOp {
+  gitHost: GitHostPort;
+  prRef: ExternalRefHandle;
+}
+export interface ProbeContextMergeOp {
+  gitHost: GitHostPort;
+  prRef: ExternalRefHandle;
+}
+export interface ProbeContextLabelOp {
+  gitHost: GitHostPort;
+  prRef: ExternalRefHandle;
+  label: string;
+  /** "add" → expect label present; "remove" → expect absent. */
+  expect: "present" | "absent";
+}
+export interface ProbeContextDismissReviewOp {
+  gitHost: GitHostPort;
+  prRef: ExternalRefHandle;
+  externalReviewId: string;
+}
+
+export type ProbeContext =
+  | ({ opKind: "commit_op" } & ProbeContextCommitOp)
+  | ({ opKind: "push_op" } & ProbeContextPushOp)
+  | ({ opKind: "pr_open_op" } & ProbeContextPrOpenOp)
+  | ({ opKind: "pr_update_op" } & ProbeContextPrUpdateOp)
+  | ({ opKind: "submit_review_op" } & ProbeContextSubmitReviewOp)
+  | ({ opKind: "merge_op" } & ProbeContextMergeOp)
+  | ({ opKind: "add_label_op" } & ProbeContextLabelOp)
+  | ({ opKind: "remove_label_op" } & ProbeContextLabelOp)
+  | ({ opKind: "dismiss_review_op" } & ProbeContextDismissReviewOp);
+
+// Helper: keep TS happy when we let callers pass any ProbeContext shape.
+type ProbeContextFor<K extends OutboxOpKind, _P> = ProbeContext;
+
+export interface OutboxRecoveryResult {
+  recovered: boolean;
+  externalId: string | null;
+  externalState: Record<string, unknown> | null;
+}
+
+export interface OutboxRecoveryCandidate {
+  opKind: OutboxOpKind;
+  idempotencyKey: string;
+  mode: OutboxRecoveryMode;
+}
+
+export interface OutboxScanInput {
+  /**
+   * `(idempotencyKey) → boolean` predicate the caller uses to decide
+   * whether a matching AgentRunReceipt exists. Outbox doesn't know
+   * receipt schema; receipt knowledge stays in the caller (plan §7-3).
+   */
+  hasMatchingReceipt: (idempotencyKey: string) => Promise<boolean>;
+}
+
+export interface OutboxDeps {
+  store: StorePort;
+  ledger: LedgerAppender;
+}
+
+/**
+ * Run a port probe for the given op_kind. Returns `recovered=true` plus
+ * an `externalId` whenever the external surface confirms the write
+ * happened.
+ */
+export async function runOutboxProbe(
+  ctx: ProbeContext,
+): Promise<OutboxRecoveryResult> {
+  switch (ctx.opKind) {
+    case "commit_op": {
+      const sha = await ctx.workspace.findCommitByTrailer({
+        branch: ctx.branch,
+        trailerKey: ctx.trailerKey,
+        value: ctx.value,
+        depth: ctx.depth,
+      });
+      return sha == null
+        ? { recovered: false, externalId: null, externalState: null }
+        : {
+            recovered: true,
+            externalId: sha,
+            externalState: { commit_sha: sha },
+          };
+    }
+    case "push_op": {
+      const sha = await ctx.workspace.getRemoteHeadSha({
+        remote: ctx.remote,
+        branch: ctx.branch,
+      });
+      const ok = sha === ctx.expectedSha;
+      return ok
+        ? {
+            recovered: true,
+            externalId: sha,
+            externalState: { remote_sha: sha },
+          }
+        : { recovered: false, externalId: sha, externalState: null };
+    }
+    case "pr_open_op": {
+      // The idempotency key sits in the canonical machine block; this probe
+      // path is fed via the outer recovery coordinator which passes the key
+      // explicitly into `outbox.recover`. We rely on the caller to embed
+      // the same key in the PR body so this probe matches.
+      const handle = await ctx.gitHost.findOpenPullRequestByMachineKey(
+        ctx.headBranch,
+        // The shared idempotency_key lives in the outer recover() input.
+        // Encoded into ProbeContext via the structurally-typed wrapper
+        // below — see `recoverWithProbeKey`.
+        (ctx as unknown as { idempotencyKey: string }).idempotencyKey,
+      );
+      return handle == null
+        ? { recovered: false, externalId: null, externalState: null }
+        : {
+            recovered: true,
+            externalId: handle.id,
+            externalState: { pr_ref: handle },
+          };
+    }
+    case "pr_update_op": {
+      const handle = await ctx.gitHost.findPullRequestByBodyMachineKey(
+        ctx.prRef,
+        (ctx as unknown as { idempotencyKey: string }).idempotencyKey,
+      );
+      return handle == null
+        ? { recovered: false, externalId: null, externalState: null }
+        : {
+            recovered: true,
+            externalId: handle.id,
+            externalState: { pr_ref: handle },
+          };
+    }
+    case "submit_review_op": {
+      const review = await ctx.gitHost.findReviewByMachineKey(
+        ctx.prRef,
+        (ctx as unknown as { idempotencyKey: string }).idempotencyKey,
+      );
+      return review == null
+        ? { recovered: false, externalId: null, externalState: null }
+        : {
+            recovered: true,
+            externalId: review.externalReviewId,
+            externalState: { review_state: review.state },
+          };
+    }
+    case "merge_op": {
+      const state = await ctx.gitHost.getPullRequestMergeState(ctx.prRef);
+      const ok = state.state === "merged" && state.mergeCommitSha != null;
+      return ok
+        ? {
+            recovered: true,
+            externalId: state.mergeCommitSha,
+            externalState: { merge_commit_sha: state.mergeCommitSha },
+          }
+        : { recovered: false, externalId: null, externalState: null };
+    }
+    case "add_label_op":
+    case "remove_label_op": {
+      const labels = await ctx.gitHost.listLabels(ctx.prRef);
+      const present = labels.includes(ctx.label);
+      const ok = ctx.expect === "present" ? present : !present;
+      return ok
+        ? {
+            recovered: true,
+            externalId: ctx.label,
+            externalState: { labels },
+          }
+        : { recovered: false, externalId: null, externalState: { labels } };
+    }
+    case "dismiss_review_op": {
+      const review = await ctx.gitHost.getReview(
+        ctx.prRef,
+        ctx.externalReviewId,
+      );
+      const ok = review != null && review.state === "dismissed";
+      return ok
+        ? {
+            recovered: true,
+            externalId: ctx.externalReviewId,
+            externalState: { review_state: review.state },
+          }
+        : { recovered: false, externalId: null, externalState: null };
+    }
+    default: {
+      const _exhaustive: never = ctx;
+      void _exhaustive;
+      return { recovered: false, externalId: null, externalState: null };
+    }
+  }
+}
+
+/**
+ * Outbox — minimal coordinator. Each call appends ledger events; no
+ * Receipt/SessionTurn knowledge. The caller is responsible for using
+ * scoped idempotency keys (`outbox/<op_kind>/<key>`) so the ledger's
+ * applied-keys cache treats different ops independently.
+ */
+export class Outbox {
+  constructor(private readonly deps: OutboxDeps) {}
+
+  private outboxKey(opKind: OutboxOpKind, key: string, suffix: string): string {
+    return `outbox/${opKind}/${key}/${suffix}`;
+  }
+
+  async begin(input: OutboxBeginInput): Promise<{ result: "applied" | "duplicate" }> {
+    return appendOutboxRow(this.deps.ledger, {
+      action: "outbox_pending",
+      result: "applied",
+      callerId: input.callerId,
+      targetId: input.targetId,
+      objectId: input.objectId,
+      manifestId: input.manifestId,
+      idempotencyKey: this.outboxKey(input.opKind, input.idempotencyKey, "begin"),
+      opKind: input.opKind,
+      surfaceRef: input.surfaceRef,
+      detail: input.payload ? safeJson(input.payload) : null,
+    });
+  }
+
+  async complete(
+    input: OutboxCompleteInput,
+  ): Promise<{ result: "applied" | "duplicate" }> {
+    const action: LedgerActionKind =
+      input.status === "posted" ? "outbox_posted" : "outbox_failed";
+    const result = input.status === "posted" ? "applied" : "error";
+    return appendOutboxRow(this.deps.ledger, {
+      action,
+      result,
+      callerId: input.callerId,
+      targetId: input.targetId,
+      objectId: input.objectId,
+      manifestId: input.manifestId,
+      idempotencyKey: this.outboxKey(
+        input.opKind,
+        input.idempotencyKey,
+        `complete:${input.status}`,
+      ),
+      opKind: input.opKind,
+      surfaceRef: input.surfaceRef,
+      externalReviewId: input.externalReviewId,
+      detail: input.externalId ?? null,
+    });
+  }
+
+  async recover(input: OutboxRecoverInput): Promise<OutboxRecoveryResult> {
+    // Inject idempotencyKey into the probe context so probes that need it
+    // (pr_open_op / pr_update_op / submit_review_op) can read it.
+    const probeWithKey = {
+      ...input.probe,
+      idempotencyKey: input.idempotencyKey,
+    } as unknown as ProbeContext;
+    const probeResult = await runOutboxProbe(probeWithKey);
+
+    if (!probeResult.recovered) {
+      return probeResult;
+    }
+
+    // Always emit `outbox_recovered`. For pending_without_posted we *also*
+    // emit `outbox_posted` so the canonical state matches a normal happy
+    // path. For posted_without_receipt the `outbox_posted` row already
+    // exists — recovery only needs the marker.
+    await appendOutboxRow(this.deps.ledger, {
+      action: "outbox_recovered",
+      result: "recovered",
+      callerId: input.callerId,
+      targetId: input.targetId,
+      objectId: input.objectId,
+      manifestId: input.manifestId,
+      idempotencyKey: this.outboxKey(
+        input.opKind,
+        input.idempotencyKey,
+        `recovered:${input.mode}`,
+      ),
+      opKind: input.opKind,
+      surfaceRef: input.surfaceRef,
+      detail: probeResult.externalId,
+    });
+
+    if (input.mode === "pending_without_posted") {
+      await appendOutboxRow(this.deps.ledger, {
+        action: "outbox_posted",
+        result: "applied",
+        callerId: input.callerId,
+        targetId: input.targetId,
+        objectId: input.objectId,
+        manifestId: input.manifestId,
+        idempotencyKey: this.outboxKey(
+          input.opKind,
+          input.idempotencyKey,
+          "complete:posted",
+        ),
+        opKind: input.opKind,
+        surfaceRef: input.surfaceRef,
+        detail: probeResult.externalId,
+      });
+    }
+
+    return probeResult;
+  }
+
+  /**
+   * Walks the ledger and returns recovery candidates. Two cases (cli-spicy-anchor.md
+   * §7-3):
+   *   (a) pending_without_posted: `outbox_pending` exists but no
+   *       `outbox_posted` / `outbox_failed` / `outbox_recovered` for the
+   *       same (op_kind, key) is present.
+   *   (b) posted_without_receipt: `outbox_posted` is present but the
+   *       caller's `hasMatchingReceipt(idempotencyKey)` returns false.
+   *
+   * Receipt-presence detection is delegated via the input callback; the
+   * outbox does not know AgentRunReceipt's storage path.
+   */
+  async scanRecoveryCandidatesFromLedger(
+    input: OutboxScanInput,
+  ): Promise<OutboxRecoveryCandidate[]> {
+    const rows = await readAllLedgerRows(this.deps.store);
+
+    /** key = `<op_kind>::<idempotency_key>` */
+    const status = new Map<
+      string,
+      {
+        opKind: OutboxOpKind;
+        key: string;
+        hasPending: boolean;
+        hasPosted: boolean;
+        hasFailed: boolean;
+        hasRecovered: boolean;
+      }
+    >();
+
+    for (const row of rows) {
+      const opKind = row.op_kind as OutboxOpKind | undefined;
+      if (opKind == null) continue;
+      // Outbox idempotency keys follow `outbox/<op>/<key>/<suffix>`. We need
+      // the original key to scan receipts. Decode here.
+      const decoded = decodeOutboxKey(row.idempotency_key);
+      if (decoded == null) continue;
+      if (decoded.opKind !== opKind) continue;
+      const mapKey = `${opKind}::${decoded.key}`;
+      const cur = status.get(mapKey) ?? {
+        opKind,
+        key: decoded.key,
+        hasPending: false,
+        hasPosted: false,
+        hasFailed: false,
+        hasRecovered: false,
+      };
+      switch (row.action_kind) {
+        case "outbox_pending":
+          cur.hasPending = true;
+          break;
+        case "outbox_posted":
+          cur.hasPosted = true;
+          break;
+        case "outbox_failed":
+          cur.hasFailed = true;
+          break;
+        case "outbox_recovered":
+          cur.hasRecovered = true;
+          break;
+        default:
+          break;
+      }
+      status.set(mapKey, cur);
+    }
+
+    const candidates: OutboxRecoveryCandidate[] = [];
+    for (const v of status.values()) {
+      if (
+        v.hasPending &&
+        !v.hasPosted &&
+        !v.hasFailed &&
+        !v.hasRecovered
+      ) {
+        candidates.push({
+          opKind: v.opKind,
+          idempotencyKey: v.key,
+          mode: "pending_without_posted",
+        });
+      } else if (v.hasPosted) {
+        const receiptOk = await input.hasMatchingReceipt(v.key);
+        if (!receiptOk) {
+          candidates.push({
+            opKind: v.opKind,
+            idempotencyKey: v.key,
+            mode: "posted_without_receipt",
+          });
+        }
+      }
+    }
+    return candidates;
+  }
+}
+
+interface AppendOutboxArgs {
+  action: LedgerActionKind;
+  result: LedgerRow["result"];
+  callerId: string;
+  targetId: string;
+  objectId: string;
+  manifestId: string | null;
+  idempotencyKey: string;
+  opKind: OutboxOpKind;
+  surfaceRef?: string;
+  externalReviewId?: string;
+  detail: string | null;
+}
+
+async function appendOutboxRow(
+  ledger: LedgerAppender,
+  args: AppendOutboxArgs,
+): Promise<{ result: "applied" | "duplicate" }> {
+  const r = await ledger.appendTransition({
+    transition_id: newId(),
+    target_id: args.targetId,
+    object_id: args.objectId,
+    object_kind: "system",
+    from_state: null,
+    to_state: args.action,
+    loop_kind: null,
+    phase: null,
+    slice_id: null,
+    slice_kind: null,
+    dod_revision: null,
+    session_id: null,
+    turn_index: null,
+    slot_kind: null,
+    agent_profile_id: null,
+    contribution_kind: null,
+    action_kind: args.action,
+    final_verdict: null,
+    caller_id: args.callerId,
+    manifest_id: args.manifestId,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: null,
+    metric_run_id: null,
+    idempotency_key: args.idempotencyKey,
+    lease_token: null,
+    lease_kind: null,
+    result: args.result,
+    result_detail: args.detail,
+    timestamp: new Date().toISOString(),
+    op_kind: args.opKind,
+    ...(args.surfaceRef ? { surface_ref: args.surfaceRef } : {}),
+    ...(args.externalReviewId
+      ? { external_review_id: args.externalReviewId }
+      : {}),
+  });
+  return { result: r.result };
+}
+
+function decodeOutboxKey(key: string): { opKind: OutboxOpKind; key: string } | null {
+  // outbox/<op>/<key>/<suffix>  — we want <op> and <key>.
+  if (!key.startsWith("outbox/")) return null;
+  const rest = key.slice("outbox/".length);
+  const firstSlash = rest.indexOf("/");
+  if (firstSlash < 0) return null;
+  const opKind = rest.slice(0, firstSlash) as OutboxOpKind;
+  const afterOp = rest.slice(firstSlash + 1);
+  const lastSlash = afterOp.lastIndexOf("/");
+  if (lastSlash < 0) return null;
+  const decoded = afterOp.slice(0, lastSlash);
+  return { opKind, key: decoded };
+}
+
+async function readAllLedgerRows(store: StorePort): Promise<LedgerRow[]> {
+  const body = await store.readText(LEDGER_TRANSITIONS_PATH);
+  if (body == null || body.length === 0) return [];
+  const out: LedgerRow[] = [];
+  for (const line of body.split("\n")) {
+    if (line.length === 0) continue;
+    try {
+      // Use a permissive parse: legacy rows lacking phase 1 optional fields
+      // round-trip through `JSON.parse` cleanly. We do not run zod here —
+      // the outbox scan only reads `action_kind`, `op_kind`, and
+      // `idempotency_key`, all of which exist on every row schema variant.
+      out.push(JSON.parse(line) as LedgerRow);
+    } catch {
+      // Skip malformed line — caller's ledger replay layer surfaces
+      // corruption separately.
+    }
+  }
+  return out;
+}
+
+function safeJson(payload: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(payload);
+  } catch {
+    return "<unserializable>";
+  }
+}

--- a/src/application/persistence-layout.ts
+++ b/src/application/persistence-layout.ts
@@ -124,4 +124,29 @@ export const layout = {
     if (rel.startsWith("archive/")) return rel;
     return `archive/${rel}`;
   },
+  // ---------- Phase 1 PR-first additions (cli-spicy-anchor.md §5, §7) ----------
+  reviewSurface(reviewSurfaceId: string): string {
+    return `review_surfaces/${requireUlid("review_surface_id", reviewSurfaceId)}.json`;
+  },
+  agentRunReceipt(sessionId: string, turnIndex: number): string {
+    return `intents/${requireUlid("session_id", sessionId)}-${requireTurnIndex(turnIndex)}.receipt.json`;
+  },
+  leadIntent(sessionId: string, turnIndex: number): string {
+    return `intents/${requireUlid("session_id", sessionId)}-${requireTurnIndex(turnIndex)}.lead.json`;
+  },
+  reviewerIntent(sessionId: string, turnIndex: number): string {
+    return `intents/${requireUlid("session_id", sessionId)}-${requireTurnIndex(turnIndex)}.review.json`;
+  },
+  /**
+   * Optional outbox payload mirror — the ledger is the authoritative
+   * record, so this directory is used only by adapters that want to
+   * persist large payloads keyed by (op_kind, idempotency_key).
+   */
+  outboxPayload(opKind: string, idempotencyKey: string): string {
+    if (!/^[a-z][a-z0-9_]*$/.test(opKind))
+      throw new Error("op_kind must be snake_case");
+    if (!/^[A-Za-z0-9._:\-]+$/.test(idempotencyKey))
+      throw new Error("idempotency_key must match [A-Za-z0-9._:-]+");
+    return `outbox/${opKind}-${idempotencyKey}.json`;
+  },
 } as const;

--- a/src/application/post-call-diff-allowlist.ts
+++ b/src/application/post-call-diff-allowlist.ts
@@ -1,0 +1,96 @@
+/**
+ * L4 post-call tracked-diff allowlist (cli-spicy-anchor.md §1).
+ *
+ * After the agent process exits, lead-invoker / reviewer-invoker compare
+ * the worktree's git-tracked diff (`git status --porcelain` +
+ * `git diff --name-only`) with the agent's declared `LeadIntent.changed_files`.
+ * Mismatches are surfaced as a `capability_violation_l4_*` reason for
+ * ledger logging.
+ *
+ * Phase 1 ships only the pure helper. Actual call-sites land in Phase 2/3.
+ */
+
+export interface DiffAllowlistInput {
+  /** Repo-relative paths the agent declared via LeadIntent.changed_files. */
+  declaredChangedFiles: readonly string[];
+  /**
+   * Repo-relative paths surfaced by `git status --porcelain` as modified
+   * (M / A / D / R). The caller is responsible for parsing `git status`
+   * and feeding this list — keeps the helper port-free for testability.
+   */
+  trackedChangedFiles: readonly string[];
+  /**
+   * When true (reviewer role), any tracked diff is treated as a violation
+   * even if it appears in `declaredChangedFiles` (reviewers must not
+   * modify the worktree at all).
+   */
+  reviewerReadOnly?: boolean;
+}
+
+export type DiffAllowlistViolationKind =
+  | "capability_violation_l4_undeclared"
+  | "capability_violation_l4_missing_declared"
+  | "capability_violation_l4_reviewer_modified";
+
+export interface DiffAllowlistViolation {
+  kind: DiffAllowlistViolationKind;
+  paths: string[];
+}
+
+export interface DiffAllowlistOutcome {
+  ok: boolean;
+  violations: DiffAllowlistViolation[];
+}
+
+/**
+ * Validate the worktree's tracked diff against the agent's declared file
+ * set. Returns `{ ok: true, violations: [] }` when:
+ *
+ *   - lead role: tracked diff ⊆ declared (every modified path was declared).
+ *     Declared-but-not-modified is allowed (agent may declare files it
+ *     intended to but skipped — caller decides whether that's an issue
+ *     elsewhere); we surface it as a separate `missing_declared` violation
+ *     so callers can choose strictness.
+ *   - reviewer role: tracked diff is empty.
+ */
+export function checkPostCallDiffAllowlist(
+  input: DiffAllowlistInput,
+): DiffAllowlistOutcome {
+  const violations: DiffAllowlistViolation[] = [];
+  const declared = new Set(input.declaredChangedFiles);
+  const tracked = new Set(input.trackedChangedFiles);
+
+  if (input.reviewerReadOnly) {
+    if (tracked.size > 0) {
+      violations.push({
+        kind: "capability_violation_l4_reviewer_modified",
+        paths: [...tracked].sort(),
+      });
+    }
+    return { ok: violations.length === 0, violations };
+  }
+
+  const undeclared: string[] = [];
+  for (const p of tracked) {
+    if (!declared.has(p)) undeclared.push(p);
+  }
+  if (undeclared.length > 0) {
+    violations.push({
+      kind: "capability_violation_l4_undeclared",
+      paths: undeclared.sort(),
+    });
+  }
+
+  const missing: string[] = [];
+  for (const p of declared) {
+    if (!tracked.has(p)) missing.push(p);
+  }
+  if (missing.length > 0) {
+    violations.push({
+      kind: "capability_violation_l4_missing_declared",
+      paths: missing.sort(),
+    });
+  }
+
+  return { ok: violations.length === 0, violations };
+}

--- a/src/domain/schema/agent-capability-policy.ts
+++ b/src/domain/schema/agent-capability-policy.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+
+/**
+ * AgentCapabilityPolicy — declarative tool / fs / network capability scope
+ * applied to a single agent invocation.
+ *
+ * Authority: `cli-spicy-anchor.md` §1 (다층 enforcement L1~L5).
+ *
+ * Phase 1 introduces the schema and L1~L3 wiring in claude-code / codex-cli
+ * adapters. L4 (post-call tracked diff allowlist) ships as a helper only;
+ * actual call-sites land in lead-invoker / reviewer-invoker (Phase 2/3).
+ * L5 (OS sandbox / provider tool proxy) is deferred.
+ */
+
+const PathPattern = z.string().min(1);
+
+export const CapabilityFsMode = z.enum(["allow", "deny", "scoped"]);
+export type CapabilityFsMode = z.infer<typeof CapabilityFsMode>;
+
+export const CapabilityFsScope = z
+  .object({
+    mode: CapabilityFsMode,
+    /** Glob patterns relative to jail_root. Empty when mode != "scoped". */
+    allowlist_paths: z.array(PathPattern).default(() => []),
+    /** Absolute path used as the cwd jail root. Required when mode="scoped". */
+    jail_root: z.string().min(1).nullable().default(null),
+  })
+  .strict();
+export type CapabilityFsScope = z.infer<typeof CapabilityFsScope>;
+
+export const CapabilityBashMode = z.enum(["allow", "deny", "allowlist"]);
+export type CapabilityBashMode = z.infer<typeof CapabilityBashMode>;
+
+export const CapabilityBashScope = z
+  .object({
+    mode: CapabilityBashMode,
+    allowlist: z.array(z.string().min(1)).default(() => []),
+    denylist: z.array(z.string().min(1)).default(() => []),
+  })
+  .strict();
+export type CapabilityBashScope = z.infer<typeof CapabilityBashScope>;
+
+export const CapabilityNetworkMode = z.enum(["allow", "deny"]);
+export type CapabilityNetworkMode = z.infer<typeof CapabilityNetworkMode>;
+
+export const AgentCapabilityPolicy = z
+  .object({
+    read: CapabilityFsScope,
+    edit: CapabilityFsScope,
+    bash: CapabilityBashScope,
+    network: CapabilityNetworkMode,
+    notes: z.string().default(""),
+  })
+  .strict();
+export type AgentCapabilityPolicy = z.infer<typeof AgentCapabilityPolicy>;
+
+/** Profile defaults from `cli-spicy-anchor.md` §1. */
+export function defaultLeadCapabilityPolicy(jailRoot: string | null = null): AgentCapabilityPolicy {
+  return {
+    read: { mode: "scoped", allowlist_paths: [], jail_root: jailRoot },
+    edit: { mode: "scoped", allowlist_paths: [], jail_root: jailRoot },
+    bash: { mode: "deny", allowlist: [], denylist: [] },
+    network: "deny",
+    notes: "",
+  };
+}
+
+export function defaultReviewerCapabilityPolicy(jailRoot: string | null = null): AgentCapabilityPolicy {
+  return {
+    read: { mode: "scoped", allowlist_paths: [], jail_root: jailRoot },
+    edit: { mode: "deny", allowlist_paths: [], jail_root: null },
+    bash: { mode: "deny", allowlist: [], denylist: [] },
+    network: "deny",
+    notes: "",
+  };
+}
+
+/**
+ * Env vars stripped from agent spawn under L3 enforcement (cli-spicy-anchor.md
+ * §1 L3). The list bundles GitHub / SSH / cloud provider / package registry
+ * tokens plus the daemon-only machine-block secret family.
+ */
+export const CAPABILITY_L3_STRIP_KEYS: readonly string[] = [
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "SSH_AUTH_SOCK",
+  "NPM_TOKEN",
+  "LLM_TEAM_MACHINE_BLOCK_SECRET",
+];
+
+/** Patterns whose names must be stripped via prefix/glob match (L3). */
+export const CAPABILITY_L3_STRIP_PREFIXES: readonly string[] = [
+  "AWS_",
+  "LLM_TEAM_",
+];
+
+/** Suffixes — any env var matching `*_SECRET` is stripped (L3). */
+export const CAPABILITY_L3_STRIP_SUFFIXES: readonly string[] = ["_SECRET"];
+
+export function isCapabilityStrippedEnvKey(key: string): boolean {
+  if (CAPABILITY_L3_STRIP_KEYS.includes(key)) return true;
+  for (const p of CAPABILITY_L3_STRIP_PREFIXES) {
+    if (key.startsWith(p)) return true;
+  }
+  for (const s of CAPABILITY_L3_STRIP_SUFFIXES) {
+    if (key.endsWith(s)) return true;
+  }
+  return false;
+}

--- a/src/domain/schema/agent-run-receipt.ts
+++ b/src/domain/schema/agent-run-receipt.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { UlidString } from "../ids.js";
+import { AgentProfileId, AgentRoleInSession, ParentLoop } from "./contribution.js";
+
+/**
+ * AgentRunReceipt — invocation receipt persisted alongside SessionTurn.
+ *
+ * Authority: `cli-spicy-anchor.md` §5.
+ *
+ * Each agent invocation produces exactly one receipt. The PR-watcher 5-gate
+ * full-tuple correlation references the `idempotency_key` and
+ * `external_review_id` fields here.
+ */
+
+export const AgentRunReceiptExitStatus = z.enum([
+  "ok",
+  "timeout",
+  "transport_error",
+  "adapter_unavailable",
+  "malformed_output",
+]);
+export type AgentRunReceiptExitStatus = z.infer<
+  typeof AgentRunReceiptExitStatus
+>;
+
+export const AgentRunReceipt = z
+  .object({
+    session_id: UlidString,
+    turn_index: z.number().int().nonnegative(),
+    parent_loop: ParentLoop,
+    agent_profile_id: AgentProfileId,
+    agent_role_in_session: AgentRoleInSession,
+    /** Caller-issued ULID; mirrored into PR / review machine block. */
+    idempotency_key: z.string().min(1),
+    /** Diagnostics blob ref (transcript, stderr, etc.). */
+    diagnostics_ref: z.string().min(1),
+    /** Provider-local review id once submit_review_op completes (reviewer only). */
+    external_review_id: z.string().min(1).nullable().default(null),
+    /** Provider-local PR id (lead/reviewer both reference). */
+    external_pr_id: z.string().min(1).nullable().default(null),
+    /** Commit SHA produced by lead.commit (lead only). */
+    commit_sha: z.string().min(1).nullable().default(null),
+    exit_status: AgentRunReceiptExitStatus,
+    /** Wall-clock ISO timestamp at receipt persistence. */
+    recorded_at: z.string().datetime(),
+  })
+  .strict();
+
+export type AgentRunReceipt = z.infer<typeof AgentRunReceipt>;

--- a/src/domain/schema/lead-intent.ts
+++ b/src/domain/schema/lead-intent.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+/**
+ * LeadIntent — narrow contract a lead agent emits as fenced JSON.
+ *
+ * Authority: `cli-spicy-anchor.md` §5, §8.
+ *
+ * `changed_files` is the post-call tracked-diff allowlist input (L4): the
+ * Caller compares the worktree's tracked diff with this list. Any tracked
+ * diff outside `changed_files` triggers `capability_violation_l4_diff`.
+ */
+
+export const LeadIntent = z
+  .object({
+    summary: z.string().min(1),
+    /** Repo-relative paths the lead claims to have written. */
+    changed_files: z.array(z.string().min(1)).default(() => []),
+    decision_needed: z.string().default(""),
+    verification_notes: z.string().default(""),
+    open_questions: z.string().default(""),
+  })
+  .strict();
+export type LeadIntent = z.infer<typeof LeadIntent>;

--- a/src/domain/schema/ledger.ts
+++ b/src/domain/schema/ledger.ts
@@ -43,6 +43,15 @@ export const LedgerActionKind = z.enum([
   "pause_resume",
   "signal_apply",
   "external_observation",
+  // Phase 1 (cli-spicy-anchor.md §7-1): outbox 2-phase + PRR signal events.
+  // Legacy readers must use union-read semantics (unknown action_kind →
+  // ignore the row) so older daemons keep functioning during rollout.
+  "outbox_pending",
+  "outbox_posted",
+  "outbox_failed",
+  "outbox_recovered",
+  "review_signal_applied",
+  "review_signal_dropped",
 ]);
 export type LedgerActionKind = z.infer<typeof LedgerActionKind>;
 
@@ -97,6 +106,17 @@ export const LedgerRow = z
     timestamp: z.string().datetime(),
     audit_hash: z.string().regex(/^[0-9a-f]{64}$/),
     audit_hash_prev: z.string().regex(/^[0-9a-f]{64}$/),
+    /**
+     * Phase 1 additive optional fields (cli-spicy-anchor.md §7-1, §6).
+     * Legacy rows omit these. Strict mode + .optional() makes legacy parses
+     * pass while new outbox / PRR rows can carry the extra correlation.
+     */
+    surface_ref: z.string().min(1).optional(),
+    external_review_id: z.string().min(1).optional(),
+    diagnostics_ref: z.string().min(1).optional(),
+    op_kind: z.string().min(1).optional(),
+    drop_reason: z.string().min(1).optional(),
+    nonce: z.string().min(1).optional(),
   })
   .strict();
 

--- a/src/domain/schema/milestone.ts
+++ b/src/domain/schema/milestone.ts
@@ -32,6 +32,21 @@ export const Milestone = z
     spec_revision_pin: z.string().min(1).nullable(),
     context_summary_id: UlidString.nullable(),
     external_refs: z.array(ExternalRef).default(() => []),
+    /**
+     * Phase 1 (cli-spicy-anchor.md §2, §5): optional per-phase ReviewSurface
+     * pointers. Discovery/Specification share the same surface (same-PR
+     * continuation), so two of the four slots will frequently reference the
+     * same id. Caller paths only — Phase 2/3 wires the writers.
+     */
+    review_surface_ids: z
+      .object({
+        discovery: UlidString.optional(),
+        specification: UlidString.optional(),
+        planning: UlidString.optional(),
+        validation: UlidString.optional(),
+      })
+      .strict()
+      .optional(),
     created_at: z.string().datetime(),
     updated_at: z.string().datetime(),
   })

--- a/src/domain/schema/review-surface.ts
+++ b/src/domain/schema/review-surface.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import { UlidString } from "../ids.js";
+
+/**
+ * ReviewSurface — provider-agnostic, parent-agnostic surface backing a
+ * single PR for a slice / milestone / spec_doc.
+ *
+ * Authority: `cli-spicy-anchor.md` §2.
+ *
+ * Phase 1 introduces the schema only. Caller-side write paths (lead-invoker /
+ * reviewer-invoker, recovery-coordinator) land in Phase 2/3.
+ */
+
+export const ReviewSurfaceParentKind = z.enum([
+  "slice",
+  "milestone",
+  "spec_doc",
+]);
+export type ReviewSurfaceParentKind = z.infer<typeof ReviewSurfaceParentKind>;
+
+/**
+ * `parent_phase` is meaningful only when `parent_kind=milestone`. For
+ * slice / spec_doc the field is `null`.
+ */
+export const ReviewSurfaceParentPhase = z.enum([
+  "Discovery",
+  "Specification",
+  "Planning",
+  "Validation",
+]);
+export type ReviewSurfaceParentPhase = z.infer<
+  typeof ReviewSurfaceParentPhase
+>;
+
+export const ReviewSurfaceLifecycleState = z.enum([
+  "open",
+  "merged",
+  "closed",
+  "externally_closed",
+]);
+export type ReviewSurfaceLifecycleState = z.infer<
+  typeof ReviewSurfaceLifecycleState
+>;
+
+export const ReviewSurfaceReviewState = z.enum([
+  "pending_review",
+  "changes_requested",
+  "approved",
+]);
+export type ReviewSurfaceReviewState = z.infer<
+  typeof ReviewSurfaceReviewState
+>;
+
+export const ReviewSurfaceBuildState = z.enum([
+  "ready",
+  "rebuilding",
+  "stale",
+  "not_applicable",
+]);
+export type ReviewSurfaceBuildState = z.infer<typeof ReviewSurfaceBuildState>;
+
+export const ReviewSurfacePrRef = z
+  .object({
+    provider: z.enum(["github", "fs_mirror"]),
+    /** Provider-local execution identifier (GitHub: PR number string). */
+    id: z.string().min(1),
+    /** Optional GraphQL node id. */
+    node_id: z.string().min(1).nullable().default(null),
+    url: z.string().min(1),
+  })
+  .strict();
+export type ReviewSurfacePrRef = z.infer<typeof ReviewSurfacePrRef>;
+
+export const ReviewSurface = z
+  .object({
+    review_surface_id: UlidString,
+    parent_kind: ReviewSurfaceParentKind,
+    parent_id: UlidString,
+    /** Required only when parent_kind=milestone. Null otherwise. */
+    parent_phase: ReviewSurfaceParentPhase.nullable().default(null),
+    pr_ref: ReviewSurfacePrRef,
+    branch: z.string().min(1),
+    base_ref: z.string().min(1),
+    head_sha: z.string().min(1),
+    review_round: z.number().int().nonnegative(),
+    lifecycle_state: ReviewSurfaceLifecycleState,
+    review_state: ReviewSurfaceReviewState,
+    /** Meaningful only when parent_kind=slice. */
+    build_state: ReviewSurfaceBuildState,
+    latest_verification_run_id: UlidString.nullable().default(null),
+    last_synced_external_revision: z
+      .string()
+      .min(1)
+      .nullable()
+      .default(null),
+    created_at: z.string().datetime(),
+    updated_at: z.string().datetime(),
+  })
+  .strict()
+  .refine(
+    (s) => (s.parent_kind === "milestone" ? s.parent_phase != null : true),
+    {
+      message: "parent_phase required when parent_kind=milestone",
+      path: ["parent_phase"],
+    },
+  )
+  .refine(
+    (s) => (s.parent_kind !== "milestone" ? s.parent_phase == null : true),
+    {
+      message:
+        "parent_phase must be null when parent_kind != milestone",
+      path: ["parent_phase"],
+    },
+  );
+
+export type ReviewSurface = z.infer<typeof ReviewSurface>;

--- a/src/domain/schema/reviewer-intent.ts
+++ b/src/domain/schema/reviewer-intent.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+/**
+ * ReviewerIntent — narrow contract a reviewer agent emits as fenced JSON.
+ *
+ * Authority: `cli-spicy-anchor.md` §5, §8.
+ */
+
+export const ReviewerIntentVerdict = z.enum(["approve", "request_changes"]);
+export type ReviewerIntentVerdict = z.infer<typeof ReviewerIntentVerdict>;
+
+export const ReviewerFileComment = z
+  .object({
+    /** Repo-relative path. */
+    path: z.string().min(1),
+    /** Line number on the right-side diff (1-indexed). */
+    line: z.number().int().positive(),
+    /** Optional starting line for multi-line comments. */
+    start_line: z.number().int().positive().nullable().default(null),
+    body: z.string().min(1),
+  })
+  .strict();
+export type ReviewerFileComment = z.infer<typeof ReviewerFileComment>;
+
+export const ReviewerIntent = z
+  .object({
+    intent: ReviewerIntentVerdict,
+    body: z.string().default(""),
+    file_comments: z.array(ReviewerFileComment).default(() => []),
+  })
+  .strict();
+export type ReviewerIntent = z.infer<typeof ReviewerIntent>;

--- a/src/domain/schema/session-turn.ts
+++ b/src/domain/schema/session-turn.ts
@@ -57,6 +57,13 @@ export const SessionTurn = z
     caller_routing_decision: CallerRoutingDecision.nullable().default(null),
     workspace_commit: z.string().min(1).nullable().default(null),
     verification_result_ref: UlidString.nullable().default(null),
+    /**
+     * Phase 1 (cli-spicy-anchor.md §5): additive pointers introduced for the
+     * PR-first surface. Both fields are optional; legacy turns leave them
+     * absent and existing readers ignore unknown fields harmlessly.
+     */
+    output_receipt_ref: z.string().min(1).optional(),
+    output_intent_ref: z.string().min(1).optional(),
     recorded_at: z.string().datetime(),
   })
   .strict();

--- a/src/domain/schema/slice.ts
+++ b/src/domain/schema/slice.ts
@@ -63,6 +63,13 @@ export const Slice = z
     spawning_proposal_id: UlidString.nullable().default(null),
     abandoned_reason: z.string().min(1).nullable().default(null),
     external_refs: z.array(ExternalRef).default(() => []),
+    /**
+     * Phase 1 (cli-spicy-anchor.md §5): optional pointer to the active
+     * ReviewSurface backing this slice's PR. Caller paths only — agent
+     * envelopes never set this field. Phase 2/3 wires the writers; until
+     * then, callers leave it absent.
+     */
+    review_surface_id: UlidString.optional(),
     created_at: z.string().datetime(),
     updated_at: z.string().datetime(),
   })

--- a/src/ports/git-host.ts
+++ b/src/ports/git-host.ts
@@ -38,6 +38,78 @@ export interface PostPullRequestCommentInput {
   body: string;
 }
 
+/**
+ * Phase 1 PR-first additive extensions (cli-spicy-anchor.md §1 step 2).
+ *
+ * The new methods are GitHub-specific PR / review / merge / label ops that
+ * the lead-invoker / reviewer-invoker (Phase 2/3) and outbox dedup probes
+ * (`cli-spicy-anchor.md §7-2`) call into. local/remote git state stays on
+ * `WorkspacePort`.
+ *
+ * Adapters that have not yet implemented a method may throw
+ * `NotImplementedError` — callers are gated on Phase 2/3 wiring. The
+ * fs-mirror adapter implements the full surface for tests.
+ */
+
+export type ReviewIntent = "approve" | "request_changes" | "comment";
+
+export interface ReviewFileComment {
+  path: string;
+  line: number;
+  startLine?: number | null;
+  body: string;
+}
+
+export interface SubmitPullRequestReviewInput {
+  prRef: ExternalRefHandle;
+  intent: ReviewIntent;
+  body: string;
+  fileComments?: ReviewFileComment[];
+  /** Caller-issued ULID — mirrored into review-machine block. */
+  idempotencyKey: string;
+}
+
+export interface SubmittedReview {
+  /** Provider-local review id (GitHub: review id). */
+  externalReviewId: string;
+}
+
+export interface ListedReview {
+  externalReviewId: string;
+  author: string;
+  state: "approved" | "changes_requested" | "commented" | "dismissed" | "pending";
+  body: string;
+  submittedAt: string | null;
+}
+
+export interface UpdatePullRequestBodyInput {
+  prRef: ExternalRefHandle;
+  body: string;
+}
+
+export interface MergePullRequestInput {
+  prRef: ExternalRefHandle;
+  /** Squash | merge | rebase. fs-mirror ignores this. */
+  strategy: "squash" | "merge" | "rebase";
+  commitTitle?: string;
+  commitMessage?: string;
+}
+
+export interface MergePullRequestResult {
+  mergeCommitSha: string;
+}
+
+export interface PullRequestMergeState {
+  state: "merged" | "open" | "closed";
+  mergeCommitSha: string | null;
+}
+
+export interface DismissReviewInput {
+  prRef: ExternalRefHandle;
+  externalReviewId: string;
+  message?: string;
+}
+
 export interface GitHostPort {
   openPullRequest(input: OpenPullRequestInput): Promise<ExternalRefHandle>;
   updatePullRequest(
@@ -56,4 +128,79 @@ export interface GitHostPort {
     body: string;
     revision: string;
   } | null>;
+
+  // ---------- Phase 1 additive surface (§ above) ----------
+
+  /** Submit a review (approve / request_changes / comment). */
+  submitPullRequestReview(
+    input: SubmitPullRequestReviewInput,
+  ): Promise<SubmittedReview>;
+
+  listPullRequestReviews(prRef: ExternalRefHandle): Promise<ListedReview[]>;
+
+  updatePullRequestBody(
+    input: UpdatePullRequestBodyInput,
+  ): Promise<ExternalRefHandle>;
+
+  /** Returns unified diff for the PR head against base (UTF-8 text). */
+  getPullRequestDiff(prRef: ExternalRefHandle): Promise<string>;
+
+  mergePullRequest(
+    input: MergePullRequestInput,
+  ): Promise<MergePullRequestResult>;
+
+  addLabel(
+    prRef: ExternalRefHandle,
+    label: string,
+  ): Promise<ExternalRefHandle>;
+
+  removeLabel(
+    prRef: ExternalRefHandle,
+    label: string,
+  ): Promise<ExternalRefHandle>;
+
+  dismissReview(input: DismissReviewInput): Promise<void>;
+
+  // ---------- Phase 1 dedup probes (cli-spicy-anchor.md §7-2) ----------
+
+  /**
+   * Find an open PR whose body machine-block carries the given
+   * idempotency_key. Used by `pr_open_op` recovery probe.
+   */
+  findOpenPullRequestByMachineKey(
+    headBranch: string,
+    idempotencyKey: string,
+  ): Promise<ExternalRefHandle | null>;
+
+  /**
+   * Verify the PR's current body machine-block idempotency_key matches.
+   * Used by `pr_update_op` recovery probe.
+   */
+  findPullRequestByBodyMachineKey(
+    prRef: ExternalRefHandle,
+    idempotencyKey: string,
+  ): Promise<ExternalRefHandle | null>;
+
+  /**
+   * Find a review on the PR whose body machine-block carries the given
+   * idempotency_key. Used by `submit_review_op` recovery probe.
+   */
+  findReviewByMachineKey(
+    prRef: ExternalRefHandle,
+    idempotencyKey: string,
+  ): Promise<ListedReview | null>;
+
+  /** Used by `merge_op` recovery probe. */
+  getPullRequestMergeState(
+    prRef: ExternalRefHandle,
+  ): Promise<PullRequestMergeState>;
+
+  /** Used by `add_label_op` / `remove_label_op` recovery probes. */
+  listLabels(prRef: ExternalRefHandle): Promise<string[]>;
+
+  /** Used by `dismiss_review_op` recovery probe. */
+  getReview(
+    prRef: ExternalRefHandle,
+    externalReviewId: string,
+  ): Promise<ListedReview | null>;
 }

--- a/src/ports/workspace.ts
+++ b/src/ports/workspace.ts
@@ -97,4 +97,38 @@ export interface WorkspacePort {
    * slice is persisted.
    */
   verifyRef(ref: string): Promise<boolean>;
+
+  // ---------- Phase 1 additive surface (cli-spicy-anchor.md §7-2) ----------
+
+  /**
+   * Walk back at most `depth` commits on `branch` looking for a commit whose
+   * message contains a trailer line `<trailerKey>: <value>`. Returns the
+   * commit SHA if found, null otherwise. Used by `commit_op` outbox probe.
+   */
+  findCommitByTrailer(input: {
+    branch: string;
+    trailerKey: string;
+    value: string;
+    depth?: number;
+  }): Promise<string | null>;
+
+  /**
+   * Returns the SHA at `<remote>/<branch>` (best-effort). Used by `push_op`
+   * outbox probe to confirm a push that may have succeeded server-side
+   * before the daemon crashed.
+   */
+  getRemoteHeadSha(input: { remote: string; branch: string }): Promise<string | null>;
+
+  /**
+   * Reset the slice worktree to `sha` (`git reset --hard <sha>`). Used by
+   * lead-invoker to recover a dirty worktree before retrying parse/call.
+   * The supplied sha must already be reachable from the worktree.
+   */
+  resetHard(input: { sliceId: string; sha: string }): Promise<void>;
+
+  /**
+   * `git clean -fdx` inside the slice worktree. Pairs with `resetHard` for
+   * dirty-worktree retry recovery (cli-spicy-anchor.md §8 retry cap).
+   */
+  cleanForce(input: { sliceId: string }): Promise<void>;
 }

--- a/tests/adapters/capability-policy.test.ts
+++ b/tests/adapters/capability-policy.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { ClaudeCodeAdapter } from "../../src/adapters/llm-runner/claude-code.js";
+import { CodexCliAdapter } from "../../src/adapters/llm-runner/codex-cli.js";
+import {
+  applyCapabilityEnvStrip,
+  claudeCodeCapabilityFlags,
+  codexCliCapabilityFlags,
+} from "../../src/adapters/llm-runner/common/capability.js";
+import {
+  defaultLeadCapabilityPolicy,
+  defaultReviewerCapabilityPolicy,
+} from "../../src/domain/schema/agent-capability-policy.js";
+
+const baseInput = {
+  stdin: "",
+  agentCwd: "/tmp/agent",
+  timeoutSec: 0,
+};
+
+describe("L1 — claude-code capability flags", () => {
+  it("lead default → allowed Read,Edit,Write disallowed Bash,WebFetch,WebSearch", () => {
+    const flags = claudeCodeCapabilityFlags(defaultLeadCapabilityPolicy());
+    expect(flags).toContain("--allowed-tools");
+    const allowed = flags[flags.indexOf("--allowed-tools") + 1];
+    expect(allowed).toContain("Read");
+    expect(allowed).toContain("Edit");
+    expect(allowed).toContain("Write");
+    expect(flags).toContain("--disallowed-tools");
+    const disallowed = flags[flags.indexOf("--disallowed-tools") + 1];
+    expect(disallowed).toContain("Bash");
+    expect(disallowed).toContain("WebFetch");
+  });
+
+  it("reviewer default → Edit/Write disallowed", () => {
+    const flags = claudeCodeCapabilityFlags(defaultReviewerCapabilityPolicy());
+    const disallowed = flags[flags.indexOf("--disallowed-tools") + 1];
+    expect(disallowed).toContain("Edit");
+    expect(disallowed).toContain("Write");
+  });
+
+  it("ClaudeCodeAdapter argv injects flags when policy supplied", () => {
+    const a = new ClaudeCodeAdapter();
+    const { args } = a.buildArgv({
+      ...baseInput,
+      capabilityPolicy: defaultReviewerCapabilityPolicy(),
+    });
+    expect(args).toContain("--allowed-tools");
+    expect(args).toContain("--disallowed-tools");
+  });
+
+  it("ClaudeCodeAdapter argv stays unchanged when no policy", () => {
+    const a = new ClaudeCodeAdapter();
+    const { args } = a.buildArgv();
+    expect(args).not.toContain("--allowed-tools");
+  });
+});
+
+describe("L1 — codex-cli capability flags", () => {
+  it("lead default → workspace-write + --no-network", () => {
+    const flags = codexCliCapabilityFlags(defaultLeadCapabilityPolicy());
+    expect(flags).toContain("--sandbox");
+    expect(flags[flags.indexOf("--sandbox") + 1]).toBe("workspace-write");
+    expect(flags).toContain("--no-network");
+  });
+
+  it("reviewer default → read-only sandbox", () => {
+    const flags = codexCliCapabilityFlags(defaultReviewerCapabilityPolicy());
+    expect(flags[flags.indexOf("--sandbox") + 1]).toBe("read-only");
+    expect(flags).toContain("--no-network");
+  });
+
+  it("CodexCliAdapter argv injects flags when policy supplied", () => {
+    const a = new CodexCliAdapter();
+    const { args } = a.buildArgv({
+      ...baseInput,
+      capabilityPolicy: defaultLeadCapabilityPolicy(),
+    });
+    expect(args).toContain("--sandbox");
+    expect(args).toContain("--no-network");
+  });
+});
+
+describe("L3 — applyCapabilityEnvStrip", () => {
+  it("removes baseline secret env keys", () => {
+    const env = {
+      PATH: "/usr/bin",
+      GITHUB_TOKEN: "ghp_xxx",
+      GH_TOKEN: "gho_yyy",
+      AWS_ACCESS_KEY_ID: "AKIA",
+      LLM_TEAM_MACHINE_BLOCK_SECRET: "shhh",
+      LLM_TEAM_OTHER_SECRET: "shh2",
+      MY_API_SECRET: "shh3",
+      NPM_TOKEN: "ntoken",
+    };
+    const stripped = applyCapabilityEnvStrip(env);
+    expect(stripped.PATH).toBe("/usr/bin");
+    expect(stripped.GITHUB_TOKEN).toBeUndefined();
+    expect(stripped.GH_TOKEN).toBeUndefined();
+    expect(stripped.AWS_ACCESS_KEY_ID).toBeUndefined();
+    expect(stripped.LLM_TEAM_MACHINE_BLOCK_SECRET).toBeUndefined();
+    expect(stripped.LLM_TEAM_OTHER_SECRET).toBeUndefined();
+    expect(stripped.MY_API_SECRET).toBeUndefined();
+    expect(stripped.NPM_TOKEN).toBeUndefined();
+  });
+
+  it("network=deny additionally strips proxy env vars", () => {
+    const env = { HTTP_PROXY: "http://x", HTTPS_PROXY: "http://y", PATH: "/" };
+    const stripped = applyCapabilityEnvStrip(env, defaultLeadCapabilityPolicy());
+    expect(stripped.HTTP_PROXY).toBeUndefined();
+    expect(stripped.HTTPS_PROXY).toBeUndefined();
+    expect(stripped.PATH).toBe("/");
+  });
+});

--- a/tests/adapters/git-host-fs-mirror-phase1.test.ts
+++ b/tests/adapters/git-host-fs-mirror-phase1.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { FsMirrorGitHost } from "../../src/adapters/git-host/fs-mirror.js";
+import { MemoryStore } from "../../src/adapters/store/memory.js";
+
+function makeHost(): { host: FsMirrorGitHost; store: MemoryStore } {
+  const store = new MemoryStore();
+  return { host: new FsMirrorGitHost(store), store };
+}
+
+describe("FsMirrorGitHost — Phase 1 review surface", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+  afterEach(async () => {
+    if (cleanup) await cleanup();
+    cleanup = null;
+  });
+
+  it("submitPullRequestReview persists + listPullRequestReviews returns it", async () => {
+    const { host } = makeHost();
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "B",
+      headBranch: "feat/x",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const submit = await host.submitPullRequestReview({
+      prRef: pr,
+      intent: "approve",
+      body: "lgtm\n<!-- llm-team:review-machine\nidempotency_key: K1\n-->",
+      idempotencyKey: "K1",
+    });
+    expect(submit.externalReviewId).toBe("1");
+    const reviews = await host.listPullRequestReviews(pr);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]?.state).toBe("approved");
+  });
+
+  it("findReviewByMachineKey returns the matching review (last-match probe)", async () => {
+    const { host } = makeHost();
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "B",
+      headBranch: "feat/x",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await host.submitPullRequestReview({
+      prRef: pr,
+      intent: "request_changes",
+      body: "needs work\n<!-- llm-team:review-machine\nidempotency_key: K1\n-->",
+      idempotencyKey: "K1",
+    });
+    const probe = await host.findReviewByMachineKey(pr, "K1");
+    expect(probe).not.toBeNull();
+    expect(probe!.state).toBe("changes_requested");
+    expect(await host.findReviewByMachineKey(pr, "MISS")).toBeNull();
+  });
+
+  it("findOpenPullRequestByMachineKey + findPullRequestByBodyMachineKey", async () => {
+    const { host } = makeHost();
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "intro\n<!-- llm-team:pr-machine\nidempotency_key: PR-1\n-->",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const found = await host.findOpenPullRequestByMachineKey("slice/abc", "PR-1");
+    expect(found?.id).toBe(pr.id);
+    expect(await host.findOpenPullRequestByMachineKey("slice/abc", "OTHER")).toBeNull();
+    const direct = await host.findPullRequestByBodyMachineKey(pr, "PR-1");
+    expect(direct?.id).toBe(pr.id);
+  });
+
+  it("getPullRequestMergeState reflects mergePullRequest", async () => {
+    const { host } = makeHost();
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    expect((await host.getPullRequestMergeState(pr)).state).toBe("open");
+    const merged = await host.mergePullRequest({
+      prRef: pr,
+      strategy: "squash",
+    });
+    expect(merged.mergeCommitSha).toContain("merge-");
+    const state = await host.getPullRequestMergeState(pr);
+    expect(state.state).toBe("merged");
+    expect(state.mergeCommitSha).toBe(merged.mergeCommitSha);
+  });
+
+  it("addLabel / removeLabel / listLabels probe", async () => {
+    const { host } = makeHost();
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: ["pre"],
+    });
+    expect(await host.listLabels(pr)).toEqual(["pre"]);
+    await host.addLabel(pr, "review/needs-changes");
+    expect((await host.listLabels(pr)).sort()).toEqual([
+      "pre",
+      "review/needs-changes",
+    ]);
+    await host.removeLabel(pr, "pre");
+    expect(await host.listLabels(pr)).toEqual(["review/needs-changes"]);
+  });
+
+  it("dismissReview transitions review state", async () => {
+    const { host } = makeHost();
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const submit = await host.submitPullRequestReview({
+      prRef: pr,
+      intent: "approve",
+      body: "k",
+      idempotencyKey: "RKEY",
+    });
+    await host.dismissReview({
+      prRef: pr,
+      externalReviewId: submit.externalReviewId,
+      message: "bye",
+    });
+    const review = await host.getReview(pr, submit.externalReviewId);
+    expect(review?.state).toBe("dismissed");
+  });
+
+  it("getPullRequestDiff returns seeded diff", async () => {
+    const { host } = makeHost();
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await host.seedDiff(pr, "diff --git a b");
+    expect(await host.getPullRequestDiff(pr)).toBe("diff --git a b");
+  });
+});

--- a/tests/adapters/workspace-fake-phase1.test.ts
+++ b/tests/adapters/workspace-fake-phase1.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+
+function freshFake(): FakeWorkspace {
+  const root = mkdtempSync(join(tmpdir(), "fake-ws-phase1-"));
+  return new FakeWorkspace(root);
+}
+
+const SLICE_ID = "01HZS00000000000000000000A";
+
+describe("FakeWorkspace — Phase 1 additive surface", () => {
+  it("findCommitByTrailer matches seeded trailer", async () => {
+    const ws = freshFake();
+    ws.seedCommitTrailer("slice/abc", "sha-1", { "Idempotency-Key": "K1" });
+    ws.seedCommitTrailer("slice/abc", "sha-2", { "Idempotency-Key": "K2" });
+    const sha = await ws.findCommitByTrailer({
+      branch: "slice/abc",
+      trailerKey: "Idempotency-Key",
+      value: "K1",
+    });
+    expect(sha).toBe("sha-1");
+    expect(
+      await ws.findCommitByTrailer({
+        branch: "slice/abc",
+        trailerKey: "Idempotency-Key",
+        value: "MISS",
+      }),
+    ).toBeNull();
+  });
+
+  it("getRemoteHeadSha returns seeded value", async () => {
+    const ws = freshFake();
+    ws.seedRemoteHead("origin", "slice/abc", "deadbeef");
+    expect(
+      await ws.getRemoteHeadSha({ remote: "origin", branch: "slice/abc" }),
+    ).toBe("deadbeef");
+    expect(
+      await ws.getRemoteHeadSha({ remote: "origin", branch: "missing" }),
+    ).toBeNull();
+  });
+
+  it("resetHard updates head + counts call", async () => {
+    const ws = freshFake();
+    await ws.prepareInnerWorkspace({
+      sliceId: SLICE_ID,
+      trunkBaseRevision: "trunk-1",
+    });
+    await ws.commit({
+      sliceId: SLICE_ID,
+      message: "wip",
+      files: [{ path: "a.txt", content: "x" }],
+    });
+    expect(ws.resetHardCount).toBe(0);
+    await ws.resetHard({ sliceId: SLICE_ID, sha: "trunk-1" });
+    expect(ws.resetHardCount).toBe(1);
+    expect(await ws.head(SLICE_ID)).toBe("trunk-1");
+  });
+
+  it("cleanForce increments counter", async () => {
+    const ws = freshFake();
+    expect(ws.cleanForceCount).toBe(0);
+    await ws.cleanForce({ sliceId: SLICE_ID });
+    expect(ws.cleanForceCount).toBe(1);
+  });
+});

--- a/tests/application/machine-block.test.ts
+++ b/tests/application/machine-block.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCanonicalString,
+  computeNonce,
+  MACHINE_BLOCK_SECRET_ENV_DEFAULT,
+  parseLastMatch,
+  renderBlock,
+  requireMachineBlockSecret,
+  sanitizeMarkdown,
+  verifyNonce,
+} from "../../src/application/machine-block.js";
+
+const PR_FIELDS = {
+  review_surface_id: "01HZA00000000000000000000A",
+  parent_kind: "slice",
+  parent_id: "01HZS00000000000000000000A",
+  parent_phase: "n/a",
+  head_sha: "deadbeef",
+  review_round: "0",
+  last_verification_result: "pass",
+  idempotency_key: "01HZK00000000000000000000A",
+} as const;
+
+const REVIEW_FIELDS = {
+  review_surface_id: "01HZA00000000000000000000A",
+  parent_kind: "milestone",
+  parent_id: "01HZM00000000000000000000A",
+  parent_phase: "Discovery",
+  review_round: "1",
+  session_id: "01HZSE0000000000000000000A",
+  turn_index: "2",
+  agent_profile_id: "atlas",
+  idempotency_key: "01HZK00000000000000000000A",
+} as const;
+
+const SECRET = "super-secret-test-only";
+
+describe("requireMachineBlockSecret", () => {
+  it("throws when env var is unset", () => {
+    expect(() =>
+      requireMachineBlockSecret(MACHINE_BLOCK_SECRET_ENV_DEFAULT, {}),
+    ).toThrow(/refusing to start/);
+  });
+
+  it("throws when env var is empty", () => {
+    expect(() =>
+      requireMachineBlockSecret(MACHINE_BLOCK_SECRET_ENV_DEFAULT, {
+        [MACHINE_BLOCK_SECRET_ENV_DEFAULT]: "",
+      }),
+    ).toThrow();
+  });
+
+  it("returns the secret when set", () => {
+    expect(
+      requireMachineBlockSecret(MACHINE_BLOCK_SECRET_ENV_DEFAULT, {
+        [MACHINE_BLOCK_SECRET_ENV_DEFAULT]: "abc",
+      }),
+    ).toBe("abc");
+  });
+});
+
+describe("sanitizeMarkdown", () => {
+  it("strips agent-authored llm-team blocks", () => {
+    const body = "hello\n<!-- llm-team:pr-machine\nidempotency_key: spoof\n-->\nworld";
+    expect(sanitizeMarkdown(body)).toBe("hello\n\nworld");
+  });
+
+  it("leaves non-llm-team html comments untouched", () => {
+    const body = "x <!-- regular comment --> y";
+    expect(sanitizeMarkdown(body)).toBe(body);
+  });
+
+  it("strips multiple blocks", () => {
+    const body = "a<!-- llm-team:review-machine\nx: 1\n-->b<!-- llm-team:pr-machine\ny:2\n-->c";
+    expect(sanitizeMarkdown(body)).toBe("abc");
+  });
+});
+
+describe("buildCanonicalString / computeNonce / verifyNonce", () => {
+  it("HMAC-SHA256 hex prefix 16 is deterministic", () => {
+    const a = computeNonce(SECRET, "pr", PR_FIELDS);
+    const b = computeNonce(SECRET, "pr", PR_FIELDS);
+    expect(a).toEqual(b);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("verifyNonce passes when fields & secret match", () => {
+    const nonce = computeNonce(SECRET, "pr", PR_FIELDS);
+    expect(verifyNonce(SECRET, "pr", PR_FIELDS, nonce)).toBe(true);
+  });
+
+  it("verifyNonce fails when ANY single field is altered", () => {
+    const nonce = computeNonce(SECRET, "pr", PR_FIELDS);
+    for (const k of Object.keys(PR_FIELDS) as (keyof typeof PR_FIELDS)[]) {
+      const tampered = { ...PR_FIELDS, [k]: PR_FIELDS[k] + "x" };
+      expect(verifyNonce(SECRET, "pr", tampered, nonce)).toBe(false);
+    }
+  });
+
+  it("verifyNonce fails when secret is wrong", () => {
+    const nonce = computeNonce(SECRET, "pr", PR_FIELDS);
+    expect(verifyNonce("other-secret", "pr", PR_FIELDS, nonce)).toBe(false);
+  });
+
+  it("review-machine block omits PR-only fields and vice versa", () => {
+    // canonical string for pr should NOT contain session_id/turn_index/agent_profile_id
+    const prCanon = buildCanonicalString("pr", PR_FIELDS);
+    expect(prCanon).not.toContain("session_id");
+    expect(prCanon).not.toContain("turn_index");
+    expect(prCanon).not.toContain("agent_profile_id");
+    // canonical string for review should NOT contain head_sha / last_verification_result
+    const revCanon = buildCanonicalString("review", REVIEW_FIELDS);
+    expect(revCanon).not.toContain("head_sha");
+    expect(revCanon).not.toContain("last_verification_result");
+    expect(revCanon).toContain("session_id=");
+    expect(revCanon).toContain("agent_profile_id=");
+  });
+
+  it("PR-machine block includes parent_phase explicitly", () => {
+    const canon = buildCanonicalString("pr", PR_FIELDS);
+    expect(canon).toContain("|parent_phase=n/a|");
+  });
+});
+
+describe("renderBlock + parseLastMatch round-trip", () => {
+  it("PR block round-trips through render → parse", () => {
+    const nonce = computeNonce(SECRET, "pr", PR_FIELDS);
+    const block = renderBlock("pr", PR_FIELDS, nonce);
+    const parsed = parseLastMatch(block, "pr");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields).toEqual(PR_FIELDS);
+    expect(parsed!.nonce).toEqual(nonce);
+    expect(verifyNonce(SECRET, "pr", parsed!.fields, parsed!.nonce)).toBe(true);
+  });
+
+  it("review block round-trips through render → parse", () => {
+    const nonce = computeNonce(SECRET, "review", REVIEW_FIELDS);
+    const block = renderBlock("review", REVIEW_FIELDS, nonce);
+    const parsed = parseLastMatch(block, "review");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields).toEqual(REVIEW_FIELDS);
+    expect(verifyNonce(SECRET, "review", parsed!.fields, parsed!.nonce)).toBe(true);
+  });
+
+  it("last-match policy: a Caller-appended block overrides an earlier injected one", () => {
+    const callerNonce = computeNonce(SECRET, "review", REVIEW_FIELDS);
+    const callerBlock = renderBlock("review", REVIEW_FIELDS, callerNonce);
+    // attacker injected a fake block earlier in the body
+    const fake = renderBlock(
+      "review",
+      { ...REVIEW_FIELDS, idempotency_key: "FAKE" },
+      "0123456789abcdef",
+    );
+    const body = `Some review body…\n${fake}\nmore prose\n${callerBlock}`;
+    const parsed = parseLastMatch(body, "review");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.fields.idempotency_key).toBe(REVIEW_FIELDS.idempotency_key);
+    expect(verifyNonce(SECRET, "review", parsed!.fields, parsed!.nonce)).toBe(true);
+  });
+
+  it("returns null when block is missing", () => {
+    expect(parseLastMatch("plain text", "pr")).toBeNull();
+  });
+
+  it("returns null when an unknown field is present (forward-compat-strict)", () => {
+    const nonce = computeNonce(SECRET, "pr", PR_FIELDS);
+    const block = renderBlock("pr", PR_FIELDS, nonce);
+    const tampered = block.replace(
+      "-->",
+      "extra_field: xxx\n-->",
+    );
+    expect(parseLastMatch(tampered, "pr")).toBeNull();
+  });
+});

--- a/tests/application/outbox.test.ts
+++ b/tests/application/outbox.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "../../src/adapters/store/memory.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { FsMirrorGitHost } from "../../src/adapters/git-host/fs-mirror.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import {
+  Outbox,
+  type OutboxOpKind,
+  type ProbeContext,
+  runOutboxProbe,
+} from "../../src/application/outbox.js";
+import { LEDGER_TRANSITIONS_PATH } from "../../src/application/persistence-layout.js";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TARGET = "demo";
+const OBJ_ID = "01HZSO0000000000000000000A";
+const MANIFEST_ID = "01HZMN0000000000000000000A";
+
+function newOutbox(): { outbox: Outbox; store: MemoryStore; ledger: FileLedger } {
+  const store = new MemoryStore();
+  const ledger = new FileLedger({ store });
+  const outbox = new Outbox({ store, ledger });
+  return { outbox, store, ledger };
+}
+
+describe("Outbox 2-phase begin/complete", () => {
+  it("begin → complete posts emit ledger rows with op_kind", async () => {
+    const { outbox, store } = newOutbox();
+    const r1 = await outbox.begin({
+      opKind: "commit_op",
+      idempotencyKey: "K1",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    expect(r1.result).toBe("applied");
+    const r2 = await outbox.complete({
+      opKind: "commit_op",
+      idempotencyKey: "K1",
+      status: "posted",
+      externalId: "abc123",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    expect(r2.result).toBe("applied");
+    const ndjson = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+    const rows = ndjson.split("\n").filter((s) => s.length > 0).map((s) => JSON.parse(s));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].action_kind).toBe("outbox_pending");
+    expect(rows[0].op_kind).toBe("commit_op");
+    expect(rows[1].action_kind).toBe("outbox_posted");
+  });
+
+  it("complete is idempotent (same key+status → duplicate)", async () => {
+    const { outbox } = newOutbox();
+    await outbox.begin({
+      opKind: "commit_op",
+      idempotencyKey: "K1",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    const a = await outbox.complete({
+      opKind: "commit_op",
+      idempotencyKey: "K1",
+      status: "posted",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    const b = await outbox.complete({
+      opKind: "commit_op",
+      idempotencyKey: "K1",
+      status: "posted",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    expect(a.result).toBe("applied");
+    expect(b.result).toBe("duplicate");
+  });
+});
+
+describe("runOutboxProbe — 8 op_kind probes", () => {
+  it("commit_op uses WorkspacePort.findCommitByTrailer", async () => {
+    const ws = new FakeWorkspace(mkdtempSync(join(tmpdir(), "ob-")));
+    ws.seedCommitTrailer("slice/abc", "sha-1", { "Idempotency-Key": "K1" });
+    const ctx: ProbeContext = {
+      opKind: "commit_op",
+      workspace: ws,
+      branch: "slice/abc",
+      trailerKey: "Idempotency-Key",
+      value: "K1",
+    };
+    const r = await runOutboxProbe(ctx);
+    expect(r.recovered).toBe(true);
+    expect(r.externalId).toBe("sha-1");
+  });
+
+  it("push_op uses WorkspacePort.getRemoteHeadSha and matches expectedSha", async () => {
+    const ws = new FakeWorkspace(mkdtempSync(join(tmpdir(), "ob-")));
+    ws.seedRemoteHead("origin", "slice/abc", "deadbeef");
+    const ok = await runOutboxProbe({
+      opKind: "push_op",
+      workspace: ws,
+      remote: "origin",
+      branch: "slice/abc",
+      expectedSha: "deadbeef",
+    });
+    expect(ok.recovered).toBe(true);
+    const fail = await runOutboxProbe({
+      opKind: "push_op",
+      workspace: ws,
+      remote: "origin",
+      branch: "slice/abc",
+      expectedSha: "OTHER",
+    });
+    expect(fail.recovered).toBe(false);
+  });
+
+  it("pr_open_op uses GitHostPort.findOpenPullRequestByMachineKey", async () => {
+    const store = new MemoryStore();
+    const host = new FsMirrorGitHost(store);
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x\n<!-- llm-team:pr-machine\nidempotency_key: PR-1\n-->",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const r = await runOutboxProbe({
+      opKind: "pr_open_op",
+      gitHost: host,
+      headBranch: "slice/abc",
+      // Outbox.recover injects idempotencyKey; here we mimic that path.
+      ...({ idempotencyKey: "PR-1" } as object),
+    } as unknown as ProbeContext);
+    expect(r.recovered).toBe(true);
+    expect(r.externalId).toBe(pr.id);
+  });
+
+  it("submit_review_op uses GitHostPort.findReviewByMachineKey", async () => {
+    const store = new MemoryStore();
+    const host = new FsMirrorGitHost(store);
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await host.submitPullRequestReview({
+      prRef: pr,
+      intent: "approve",
+      body: "ok\n<!-- llm-team:review-machine\nidempotency_key: RKEY\n-->",
+      idempotencyKey: "RKEY",
+    });
+    const r = await runOutboxProbe({
+      opKind: "submit_review_op",
+      gitHost: host,
+      prRef: pr,
+      ...({ idempotencyKey: "RKEY" } as object),
+    } as unknown as ProbeContext);
+    expect(r.recovered).toBe(true);
+  });
+
+  it("merge_op uses GitHostPort.getPullRequestMergeState", async () => {
+    const store = new MemoryStore();
+    const host = new FsMirrorGitHost(store);
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const beforeMerge = await runOutboxProbe({
+      opKind: "merge_op",
+      gitHost: host,
+      prRef: pr,
+    });
+    expect(beforeMerge.recovered).toBe(false);
+    await host.mergePullRequest({ prRef: pr, strategy: "squash" });
+    const afterMerge = await runOutboxProbe({
+      opKind: "merge_op",
+      gitHost: host,
+      prRef: pr,
+    });
+    expect(afterMerge.recovered).toBe(true);
+  });
+
+  it("add_label_op / remove_label_op use GitHostPort.listLabels", async () => {
+    const store = new MemoryStore();
+    const host = new FsMirrorGitHost(store);
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await host.addLabel(pr, "needs-review");
+    expect(
+      (
+        await runOutboxProbe({
+          opKind: "add_label_op",
+          gitHost: host,
+          prRef: pr,
+          label: "needs-review",
+          expect: "present",
+        })
+      ).recovered,
+    ).toBe(true);
+    expect(
+      (
+        await runOutboxProbe({
+          opKind: "remove_label_op",
+          gitHost: host,
+          prRef: pr,
+          label: "absent-label",
+          expect: "absent",
+        })
+      ).recovered,
+    ).toBe(true);
+  });
+
+  it("dismiss_review_op uses GitHostPort.getReview", async () => {
+    const store = new MemoryStore();
+    const host = new FsMirrorGitHost(store);
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const submit = await host.submitPullRequestReview({
+      prRef: pr,
+      intent: "approve",
+      body: "ok",
+      idempotencyKey: "RK",
+    });
+    await host.dismissReview({
+      prRef: pr,
+      externalReviewId: submit.externalReviewId,
+    });
+    const r = await runOutboxProbe({
+      opKind: "dismiss_review_op",
+      gitHost: host,
+      prRef: pr,
+      externalReviewId: submit.externalReviewId,
+    });
+    expect(r.recovered).toBe(true);
+  });
+});
+
+describe("Outbox.recover crash-recovery", () => {
+  it("pending_without_posted → emits outbox_recovered + outbox_posted", async () => {
+    const { outbox, store, ledger } = newOutbox();
+    await outbox.begin({
+      opKind: "commit_op",
+      idempotencyKey: "K1",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    // simulate crash before complete is called → restart → probe
+    const ws = new FakeWorkspace(mkdtempSync(join(tmpdir(), "ob-")));
+    ws.seedCommitTrailer("slice/abc", "sha-RECOVER", {
+      "Idempotency-Key": "K1",
+    });
+    const recovered = await outbox.recover({
+      opKind: "commit_op",
+      idempotencyKey: "K1",
+      mode: "pending_without_posted",
+      probe: {
+        opKind: "commit_op",
+        workspace: ws,
+        branch: "slice/abc",
+        trailerKey: "Idempotency-Key",
+        value: "K1",
+      },
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    expect(recovered.recovered).toBe(true);
+    expect(recovered.externalId).toBe("sha-RECOVER");
+    const rows = (
+      (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? ""
+    )
+      .split("\n")
+      .filter((s) => s.length > 0)
+      .map((s) => JSON.parse(s));
+    const kinds = rows.map((r) => r.action_kind);
+    expect(kinds).toEqual([
+      "outbox_pending",
+      "outbox_recovered",
+      "outbox_posted",
+    ]);
+    void ledger; // silence unused
+  });
+
+  it("posted_without_receipt → emits only outbox_recovered (no duplicate posted)", async () => {
+    const { outbox, store } = newOutbox();
+    await outbox.begin({
+      opKind: "submit_review_op",
+      idempotencyKey: "K2",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    await outbox.complete({
+      opKind: "submit_review_op",
+      idempotencyKey: "K2",
+      status: "posted",
+      externalId: "rev-9",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    // simulate crash AFTER posted but before receipt write
+    const host = new FsMirrorGitHost(new MemoryStore());
+    const pr = await host.openPullRequest({
+      title: "T",
+      body: "x",
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await host.submitPullRequestReview({
+      prRef: pr,
+      intent: "approve",
+      body: "ok\n<!-- llm-team:review-machine\nidempotency_key: K2\n-->",
+      idempotencyKey: "K2",
+    });
+    const recovered = await outbox.recover({
+      opKind: "submit_review_op",
+      idempotencyKey: "K2",
+      mode: "posted_without_receipt",
+      probe: {
+        opKind: "submit_review_op",
+        gitHost: host,
+        prRef: pr,
+      },
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    expect(recovered.recovered).toBe(true);
+    const rows = (
+      (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? ""
+    )
+      .split("\n")
+      .filter((s) => s.length > 0)
+      .map((s) => JSON.parse(s));
+    const kinds = rows.map((r) => r.action_kind);
+    expect(kinds).toEqual([
+      "outbox_pending",
+      "outbox_posted",
+      "outbox_recovered",
+    ]);
+    // no duplicate posted row
+    expect(kinds.filter((k) => k === "outbox_posted")).toHaveLength(1);
+  });
+
+  it("recover with negative probe → no extra rows", async () => {
+    const { outbox, store } = newOutbox();
+    await outbox.begin({
+      opKind: "commit_op",
+      idempotencyKey: "GHOST",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    const ws = new FakeWorkspace(mkdtempSync(join(tmpdir(), "ob-")));
+    const r = await outbox.recover({
+      opKind: "commit_op",
+      idempotencyKey: "GHOST",
+      mode: "pending_without_posted",
+      probe: {
+        opKind: "commit_op",
+        workspace: ws,
+        branch: "slice/abc",
+        trailerKey: "Idempotency-Key",
+        value: "GHOST",
+      },
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    expect(r.recovered).toBe(false);
+    const rows = (
+      (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? ""
+    )
+      .split("\n")
+      .filter((s) => s.length > 0);
+    // Only the pending row; no recovered/posted appended.
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("Outbox.scanRecoveryCandidatesFromLedger — both cases", () => {
+  it("returns pending_without_posted + posted_without_receipt candidates", async () => {
+    const { outbox, store } = newOutbox();
+    // op A: pending only (crash before complete)
+    await outbox.begin({
+      opKind: "commit_op",
+      idempotencyKey: "A",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    // op B: pending + posted (crash before receipt)
+    await outbox.begin({
+      opKind: "submit_review_op",
+      idempotencyKey: "B",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    await outbox.complete({
+      opKind: "submit_review_op",
+      idempotencyKey: "B",
+      status: "posted",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    // op C: pending + posted + receipt (no recovery needed)
+    await outbox.begin({
+      opKind: "merge_op",
+      idempotencyKey: "C",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    await outbox.complete({
+      opKind: "merge_op",
+      idempotencyKey: "C",
+      status: "posted",
+      callerId: "caller",
+      targetId: TARGET,
+      objectId: OBJ_ID,
+      manifestId: MANIFEST_ID,
+    });
+    const receipts = new Set<string>(["C"]);
+    const candidates = await outbox.scanRecoveryCandidatesFromLedger({
+      hasMatchingReceipt: async (k) => receipts.has(k),
+    });
+    const sorted = candidates
+      .map(
+        (c): [OutboxOpKind, string, string] => [c.opKind, c.idempotencyKey, c.mode],
+      )
+      .sort();
+    expect(sorted).toEqual([
+      ["commit_op", "A", "pending_without_posted"],
+      ["submit_review_op", "B", "posted_without_receipt"],
+    ]);
+    void store;
+  });
+});

--- a/tests/application/persistence-layout.test.ts
+++ b/tests/application/persistence-layout.test.ts
@@ -107,4 +107,24 @@ describe("persistence-layout", () => {
     expect(() => layout.humanSignal("a/b")).toThrow();
     expect(() => layout.humanSignal("")).toThrow();
   });
+
+  it("phase 1 PR-first paths (review_surfaces, intents, outbox)", () => {
+    const RS_ID = "01HZRS0000000000000000000A";
+    expect(layout.reviewSurface(RS_ID)).toBe(`review_surfaces/${RS_ID}.json`);
+    expect(layout.agentRunReceipt(SESS_ID, 0)).toBe(
+      `intents/${SESS_ID}-0.receipt.json`,
+    );
+    expect(layout.leadIntent(SESS_ID, 1)).toBe(
+      `intents/${SESS_ID}-1.lead.json`,
+    );
+    expect(layout.reviewerIntent(SESS_ID, 2)).toBe(
+      `intents/${SESS_ID}-2.review.json`,
+    );
+    expect(layout.outboxPayload("commit_op", "01HZK00000000000000000000A")).toBe(
+      `outbox/commit_op-01HZK00000000000000000000A.json`,
+    );
+    expect(() => layout.reviewSurface("not-a-ulid")).toThrow(/ULID/);
+    expect(() => layout.outboxPayload("BAD-Op", "k")).toThrow(/snake_case/);
+    expect(() => layout.outboxPayload("commit_op", "../bad")).toThrow();
+  });
 });

--- a/tests/application/post-call-diff-allowlist.test.ts
+++ b/tests/application/post-call-diff-allowlist.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { checkPostCallDiffAllowlist } from "../../src/application/post-call-diff-allowlist.js";
+
+describe("checkPostCallDiffAllowlist (L4)", () => {
+  it("ok when tracked == declared", () => {
+    const out = checkPostCallDiffAllowlist({
+      declaredChangedFiles: ["a.ts", "b.ts"],
+      trackedChangedFiles: ["a.ts", "b.ts"],
+    });
+    expect(out.ok).toBe(true);
+    expect(out.violations).toEqual([]);
+  });
+
+  it("flags undeclared tracked changes", () => {
+    const out = checkPostCallDiffAllowlist({
+      declaredChangedFiles: ["a.ts"],
+      trackedChangedFiles: ["a.ts", "rogue.ts"],
+    });
+    expect(out.ok).toBe(false);
+    expect(out.violations.find((v) => v.kind === "capability_violation_l4_undeclared")).toBeTruthy();
+    expect(
+      out.violations.find((v) => v.kind === "capability_violation_l4_undeclared")!.paths,
+    ).toEqual(["rogue.ts"]);
+  });
+
+  it("flags declared-but-missing as separate violation", () => {
+    const out = checkPostCallDiffAllowlist({
+      declaredChangedFiles: ["a.ts", "b.ts"],
+      trackedChangedFiles: ["a.ts"],
+    });
+    expect(out.ok).toBe(false);
+    expect(
+      out.violations.find((v) => v.kind === "capability_violation_l4_missing_declared"),
+    ).toBeTruthy();
+  });
+
+  it("reviewer role: ok only when worktree diff is empty", () => {
+    const ok = checkPostCallDiffAllowlist({
+      declaredChangedFiles: [],
+      trackedChangedFiles: [],
+      reviewerReadOnly: true,
+    });
+    expect(ok.ok).toBe(true);
+
+    const bad = checkPostCallDiffAllowlist({
+      declaredChangedFiles: [],
+      trackedChangedFiles: ["x.ts"],
+      reviewerReadOnly: true,
+    });
+    expect(bad.ok).toBe(false);
+    expect(bad.violations[0]?.kind).toBe(
+      "capability_violation_l4_reviewer_modified",
+    );
+  });
+});

--- a/tests/domain/schema-phase-1.test.ts
+++ b/tests/domain/schema-phase-1.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentCapabilityPolicy,
+  defaultLeadCapabilityPolicy,
+  defaultReviewerCapabilityPolicy,
+  isCapabilityStrippedEnvKey,
+} from "../../src/domain/schema/agent-capability-policy.js";
+import { AgentRunReceipt } from "../../src/domain/schema/agent-run-receipt.js";
+import { LeadIntent } from "../../src/domain/schema/lead-intent.js";
+import {
+  LedgerActionKind,
+  LedgerRow,
+} from "../../src/domain/schema/ledger.js";
+import { Milestone } from "../../src/domain/schema/milestone.js";
+import { ReviewSurface } from "../../src/domain/schema/review-surface.js";
+import { ReviewerIntent } from "../../src/domain/schema/reviewer-intent.js";
+import { SessionTurn } from "../../src/domain/schema/session-turn.js";
+import { Slice } from "../../src/domain/schema/slice.js";
+
+const ULID_A = "01HZA00000000000000000000A";
+const ULID_B = "01HZB00000000000000000000A";
+const ULID_C = "01HZC00000000000000000000A";
+const ULID_D = "01HZD00000000000000000000A";
+const ULID_M = "01HZM00000000000000000000A";
+const ULID_S = "01HZS00000000000000000000A";
+const ULID_SE = "01HZSE0000000000000000000A";
+const ULID_MAN = "01HZMN0000000000000000000A";
+const ISO = "2026-05-10T00:00:00.000Z";
+const HASH = "0".repeat(64);
+
+describe("AgentCapabilityPolicy", () => {
+  it("parses lead default policy", () => {
+    const p = defaultLeadCapabilityPolicy("/tmp/jail");
+    const parsed = AgentCapabilityPolicy.parse(p);
+    expect(parsed.read.mode).toBe("scoped");
+    expect(parsed.edit.mode).toBe("scoped");
+    expect(parsed.bash.mode).toBe("deny");
+    expect(parsed.network).toBe("deny");
+  });
+
+  it("parses reviewer default policy with edit=deny", () => {
+    const p = defaultReviewerCapabilityPolicy("/tmp/jail");
+    const parsed = AgentCapabilityPolicy.parse(p);
+    expect(parsed.edit.mode).toBe("deny");
+    expect(parsed.read.mode).toBe("scoped");
+  });
+
+  it("identifies L3 stripped env keys", () => {
+    expect(isCapabilityStrippedEnvKey("GITHUB_TOKEN")).toBe(true);
+    expect(isCapabilityStrippedEnvKey("GH_TOKEN")).toBe(true);
+    expect(isCapabilityStrippedEnvKey("AWS_ACCESS_KEY_ID")).toBe(true);
+    expect(isCapabilityStrippedEnvKey("LLM_TEAM_MACHINE_BLOCK_SECRET")).toBe(true);
+    expect(isCapabilityStrippedEnvKey("LLM_TEAM_FOO_SECRET")).toBe(true);
+    expect(isCapabilityStrippedEnvKey("MY_API_SECRET")).toBe(true);
+    expect(isCapabilityStrippedEnvKey("PATH")).toBe(false);
+    expect(isCapabilityStrippedEnvKey("HOME")).toBe(false);
+  });
+});
+
+describe("ReviewSurface schema", () => {
+  const baseSurface = {
+    review_surface_id: ULID_A,
+    parent_kind: "slice" as const,
+    parent_id: ULID_S,
+    parent_phase: null,
+    pr_ref: {
+      provider: "fs_mirror" as const,
+      id: "1",
+      node_id: null,
+      url: "https://example/pr/1",
+    },
+    branch: "slice/abc",
+    base_ref: "main",
+    head_sha: "deadbeef",
+    review_round: 0,
+    lifecycle_state: "open" as const,
+    review_state: "pending_review" as const,
+    build_state: "ready" as const,
+    latest_verification_run_id: null,
+    last_synced_external_revision: null,
+    created_at: ISO,
+    updated_at: ISO,
+  };
+
+  it("parses each parent_kind (slice/milestone/spec_doc) round-trip", () => {
+    expect(ReviewSurface.parse(baseSurface).parent_kind).toBe("slice");
+    expect(
+      ReviewSurface.parse({
+        ...baseSurface,
+        parent_kind: "milestone",
+        parent_id: ULID_M,
+        parent_phase: "Discovery",
+      }).parent_kind,
+    ).toBe("milestone");
+    expect(
+      ReviewSurface.parse({
+        ...baseSurface,
+        parent_kind: "spec_doc",
+        parent_id: ULID_B,
+        parent_phase: null,
+      }).parent_kind,
+    ).toBe("spec_doc");
+  });
+
+  it("requires parent_phase when parent_kind=milestone", () => {
+    expect(() =>
+      ReviewSurface.parse({
+        ...baseSurface,
+        parent_kind: "milestone",
+        parent_id: ULID_M,
+        parent_phase: null,
+      }),
+    ).toThrow(/parent_phase required/);
+  });
+
+  it("rejects parent_phase when parent_kind != milestone", () => {
+    expect(() =>
+      ReviewSurface.parse({
+        ...baseSurface,
+        parent_kind: "slice",
+        parent_phase: "Discovery",
+      }),
+    ).toThrow(/parent_phase must be null/);
+  });
+});
+
+describe("AgentRunReceipt schema", () => {
+  it("parses a lead receipt", () => {
+    const r = AgentRunReceipt.parse({
+      session_id: ULID_SE,
+      turn_index: 0,
+      parent_loop: "outer",
+      agent_profile_id: "atlas",
+      agent_role_in_session: "lead",
+      idempotency_key: ULID_A,
+      diagnostics_ref: "diag/1",
+      external_review_id: null,
+      external_pr_id: "42",
+      commit_sha: "abc123",
+      exit_status: "ok",
+      recorded_at: ISO,
+    });
+    expect(r.agent_profile_id).toBe("atlas");
+  });
+
+  it("rejects unknown exit_status", () => {
+    expect(() =>
+      AgentRunReceipt.parse({
+        session_id: ULID_SE,
+        turn_index: 0,
+        parent_loop: "outer",
+        agent_profile_id: "atlas",
+        agent_role_in_session: "lead",
+        idempotency_key: ULID_A,
+        diagnostics_ref: "diag/1",
+        exit_status: "weird",
+        recorded_at: ISO,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("LeadIntent schema", () => {
+  it("parses minimum + defaults", () => {
+    const i = LeadIntent.parse({ summary: "hello" });
+    expect(i.changed_files).toEqual([]);
+    expect(i.decision_needed).toBe("");
+  });
+
+  it("rejects empty summary", () => {
+    expect(() => LeadIntent.parse({ summary: "" })).toThrow();
+  });
+});
+
+describe("ReviewerIntent schema", () => {
+  it("parses approve with file comments", () => {
+    const i = ReviewerIntent.parse({
+      intent: "approve",
+      body: "lgtm",
+      file_comments: [{ path: "x.ts", line: 3, body: "nit" }],
+    });
+    expect(i.intent).toBe("approve");
+    expect(i.file_comments).toHaveLength(1);
+  });
+
+  it("rejects intent=comment", () => {
+    expect(() =>
+      ReviewerIntent.parse({ intent: "comment", body: "x" }),
+    ).toThrow();
+  });
+});
+
+describe("SessionTurn additive optional refs", () => {
+  // Build a minimal valid Envelope per the existing schema (envelope.ts §138).
+  const envelope = {
+    session_id: ULID_SE,
+    turn_index: 0,
+    parent_loop: "outer" as const,
+    phase_or_purpose: "spec_proposal",
+    slice_id: null,
+    slice_kind: null,
+    tdd_phase: null,
+    agent_profile_id: "atlas" as const,
+    agent_role_in_session: "lead" as const,
+    contribution_kind: "lead_draft" as const,
+    parent_review_verdict_id: null,
+    output_kind: "spec_proposal" as const,
+    object_id: ULID_M,
+    manifest_id: ULID_MAN,
+    input_revision_pins: ["rev-1"],
+    summary: "x",
+    artifacts: null,
+    verdict: null,
+    next_action_request: null,
+    failure: null,
+    idempotency_key: "key-1",
+    runtime_metadata: {},
+  };
+
+  it("accepts output_receipt_ref / output_intent_ref optional", () => {
+    const t = SessionTurn.parse({
+      session_id: ULID_SE,
+      turn_index: 0,
+      agent_profile_id: "atlas",
+      input_manifest_id: ULID_MAN,
+      input_turn_log_snapshot_ref: null,
+      output_envelope: envelope,
+      next_action_request: null,
+      caller_routing_decision: null,
+      workspace_commit: null,
+      verification_result_ref: null,
+      output_receipt_ref: "intents/x.receipt.json",
+      output_intent_ref: "intents/x.lead.json",
+      recorded_at: ISO,
+    });
+    expect(t.output_receipt_ref).toBe("intents/x.receipt.json");
+    expect(t.output_intent_ref).toBe("intents/x.lead.json");
+  });
+
+  it("legacy turns parse without the new fields", () => {
+    const t = SessionTurn.parse({
+      session_id: ULID_SE,
+      turn_index: 0,
+      agent_profile_id: "atlas",
+      input_manifest_id: ULID_MAN,
+      input_turn_log_snapshot_ref: null,
+      output_envelope: envelope,
+      next_action_request: null,
+      caller_routing_decision: null,
+      workspace_commit: null,
+      verification_result_ref: null,
+      recorded_at: ISO,
+    });
+    expect(t.output_receipt_ref).toBeUndefined();
+  });
+});
+
+describe("Slice / Milestone additive review_surface fields", () => {
+  it("Slice.review_surface_id is optional", () => {
+    const s = Slice.parse({
+      slice_id: ULID_S,
+      milestone_id: ULID_M,
+      slice_kind: "feature",
+      value_statement: "x",
+      ac_ids: [],
+      acceptance_tests: [],
+      declared_scope: [],
+      declared_metric_threshold: null,
+      interface_break: false,
+      dependencies: [],
+      trunk_base_revision: "deadbeef",
+      dod_revision_pin: "rev-1",
+      state: "SLICE_PENDING",
+      current_session_id: null,
+      spawning_proposal_id: null,
+      abandoned_reason: null,
+      external_refs: [],
+      review_surface_id: ULID_A,
+      created_at: ISO,
+      updated_at: ISO,
+    });
+    expect(s.review_surface_id).toBe(ULID_A);
+  });
+
+  it("Milestone.review_surface_ids per phase is optional", () => {
+    const m = Milestone.parse({
+      milestone_id: ULID_M,
+      target_id: "demo",
+      title: "t",
+      state: "M_INTAKE_QUEUED",
+      slot_kind: null,
+      intake_source_kind: "human_seed",
+      intake_source_id: "issue:1",
+      spec_revision_pin: null,
+      context_summary_id: null,
+      external_refs: [],
+      review_surface_ids: { discovery: ULID_A, planning: ULID_B },
+      created_at: ISO,
+      updated_at: ISO,
+    });
+    expect(m.review_surface_ids?.discovery).toBe(ULID_A);
+    expect(m.review_surface_ids?.specification).toBeUndefined();
+  });
+});
+
+describe("LedgerRow phase-1 action_kind union-read", () => {
+  const baseRow = {
+    transition_id: ULID_A,
+    target_id: "demo",
+    object_id: ULID_S,
+    object_kind: "system" as const,
+    from_state: null,
+    to_state: "outbox_pending",
+    loop_kind: null,
+    phase: null,
+    slice_id: null,
+    slice_kind: null,
+    dod_revision: null,
+    session_id: null,
+    turn_index: null,
+    slot_kind: null,
+    agent_profile_id: null,
+    contribution_kind: null,
+    final_verdict: null,
+    caller_id: "caller",
+    manifest_id: null,
+    input_revision_pins: [] as string[],
+    output_hash: null,
+    verification_run_id: null,
+    metric_run_id: null,
+    idempotency_key: "outbox/commit_op/k1/begin",
+    lease_token: null,
+    lease_kind: null,
+    result_detail: null,
+    timestamp: ISO,
+    audit_hash: HASH,
+    audit_hash_prev: HASH,
+  };
+
+  it("parses each new outbox / review_signal action_kind", () => {
+    const new_kinds: (typeof LedgerActionKind)["options"][number][] = [
+      "outbox_pending",
+      "outbox_posted",
+      "outbox_failed",
+      "outbox_recovered",
+      "review_signal_applied",
+      "review_signal_dropped",
+    ];
+    for (const k of new_kinds) {
+      const r = LedgerRow.parse({
+        ...baseRow,
+        action_kind: k,
+        result: k === "outbox_failed" ? "error" : "applied",
+      });
+      expect(r.action_kind).toBe(k);
+    }
+  });
+
+  it("legacy action_kind still parses (union-read)", () => {
+    const r = LedgerRow.parse({
+      ...baseRow,
+      action_kind: "session_progress",
+      result: "applied",
+    });
+    expect(r.action_kind).toBe("session_progress");
+  });
+
+  it("accepts the new optional correlation fields", () => {
+    const r = LedgerRow.parse({
+      ...baseRow,
+      action_kind: "outbox_posted",
+      result: "applied",
+      surface_ref: "review_surfaces/abc.json",
+      external_review_id: "rev-99",
+      diagnostics_ref: "diag/x",
+      op_kind: "submit_review_op",
+      drop_reason: "five_gate_3_round_mismatch",
+      nonce: "deadbeef12345678",
+    });
+    expect(r.op_kind).toBe("submit_review_op");
+    expect(r.surface_ref).toBe("review_surfaces/abc.json");
+  });
+
+  it("rejects unknown action_kind (strict)", () => {
+    expect(() =>
+      LedgerRow.parse({
+        ...baseRow,
+        action_kind: "nonsense_kind",
+        result: "applied",
+      }),
+    ).toThrow();
+  });
+});
+
+// suppress unused-import warning for ULIDs that aren't used elsewhere
+void [ULID_C, ULID_D];


### PR DESCRIPTION
## Summary
- PR-first 신규 시스템 인프라 additive 도입 (cli-spicy-anchor.md "Phase 1")
- AgentCapabilityPolicy + 다층 enforcement L1-L3 (L4 helper 만, lead/reviewer-invoker 호출은 Phase 2/3)
- GitHostPort/WorkspacePort 확장 (review API 8 + dedup probe 6 + workspace 4)
- outbox 모듈 (begin/complete/recover/scanRecoveryCandidatesFromLedger, 8 op probe — port 분기)
- machine-block 모듈 (sanitize/parseLastMatch/canonical HMAC nonce + fail-loud secret env)
- 4 신규 schema (review-surface, agent-run-receipt, lead-intent, reviewer-intent)
- 기존 schema additive (slice/milestone/session-turn/ledger-row)
- Persistence layout (review_surfaces/intents/outbox)

근거: cli-spicy-anchor.md "Phase 1 — additive 신규 도입". 기존 envelope/manifest path 변경 0, caller (turn-worker / dialogue-coordinator / outer-turn / cli) 동작 변경 0.

### 변경 내용
| Module | Artifact | Notes |
|---|---|---|
| schema | `agent-capability-policy.ts` | L1~L3 enum + L3 strip key/prefix/suffix helpers + lead/reviewer profile defaults |
| schema | `review-surface.ts` | parent_kind {slice,milestone,spec_doc} + parent_phase 강제(milestone 만) refine |
| schema | `agent-run-receipt.ts` / `lead-intent.ts` / `reviewer-intent.ts` | invoker 결과 contract |
| schema additive | `slice.review_surface_id?`, `milestone.review_surface_ids?`, `session-turn.{output_receipt_ref,output_intent_ref}?`, `ledger.action_kind` +6 + 6 optional fields | union-read 회귀 |
| port | `GitHostPort` | submitPullRequestReview / listPullRequestReviews / updatePullRequestBody / getPullRequestDiff / mergePullRequest / addLabel / removeLabel / dismissReview + 6 dedup probe |
| port | `WorkspacePort` | findCommitByTrailer / getRemoteHeadSha / resetHard / cleanForce |
| adapter | `git-host/{github,fs-mirror}.ts` | gh CLI / in-memory mirror 양쪽 + machine-block 기반 dedup probe |
| adapter | `workspace/{git-worktree,fake}.ts` | git log / ls-remote / reset / clean + fake 의 seed API |
| adapter | `llm-runner/{claude-code,codex-cli}.ts` | LlmAdapterInput.capabilityPolicy? → L1 CLI flag + L3 env strip |
| application | `outbox.ts` | Outbox(begin/complete/recover/scanRecoveryCandidatesFromLedger) + runOutboxProbe (8 op_kind, port 분기) |
| application | `machine-block.ts` | sanitize/parseLastMatch/buildCanonicalString/computeNonce(HMAC-SHA256 prefix 16)/verifyNonce/renderBlock/requireMachineBlockSecret |
| application | `post-call-diff-allowlist.ts` | L4 helper (lead/reviewer 분기, declared vs tracked, reviewer read-only) |
| application | `persistence-layout.ts` | reviewSurface/agentRunReceipt/leadIntent/reviewerIntent/outboxPayload |

## Test plan
- [x] **단위**: ReviewSurface CRUD (3 parent_kind), 4 신규 schema parse, outbox 2-phase + 8 op probe, machine-block sanitize/last-match/HMAC nonce 단일 필드 변조 회귀, L1 (claude/codex CLI flag), L3 (env strip GITHUB_TOKEN/GH_TOKEN/AWS_*/NPM_TOKEN/LLM_TEAM_*_SECRET/LLM_TEAM_MACHINE_BLOCK_SECRET), L4 helper (declared/tracked mismatch + reviewer read-only)
- [x] **fail-loud**: `LLM_TEAM_MACHINE_BLOCK_SECRET` env 부재 → `requireMachineBlockSecret` throw
- [x] **outbox crash recovery**: pending_without_posted (kill 직후) + posted_without_receipt (receipt 작성 전 kill) 두 case 모두 `scanRecoveryCandidatesFromLedger` 가 회수, recover 가 멱등 (중복 outbox_posted 0)
- [x] **LedgerRow union-read**: legacy action_kind round-trip, 신규 6 종 round-trip, unknown action_kind 거부
- [x] **machine-block last-match policy**: 본문 안 가짜 block + 끝에 진짜 block → 끝의 진짜만 권위
- [x] **PR-machine block parent_phase 필드**: canonical_string 에 포함, review-machine 과 core 4 필드 정합
- [x] **회귀**: 기존 1009 tests 0 regression (총 1084 passing)
- [x] **typecheck / build clean**

추가 wire-up (lead-invoker / reviewer-invoker / pr-watcher / recovery-coordinator) 은 Phase 2/3/4 에서 진행. 본 PR 의 신규 모듈은 export 만 하고 caller 호출 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)