### PR TITLE
feat(wiring): phase-5-0a daemon/runner PR-first activation wiring

### DIFF
--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -64,6 +64,12 @@ import { runRecoverySweep } from "../application/recovery.js";
 import { runScoutScannerSweep } from "../application/scout-observer.js";
 import { runOneInnerTurn } from "../application/turn-worker.js";
 import { SystemClock } from "../ports/clock.js";
+import {
+  buildPrFirstWiring,
+  requireMachineBlockSecretFromCfg,
+  resolvePrFirstSettings,
+} from "./pr-first-wiring.js";
+import { runPrWatcherCyclePrelude } from "./pr-watcher-cycle.js";
 
 type DaemonRole =
   | "turn-worker"
@@ -190,6 +196,15 @@ async function main(argv: readonly string[]): Promise<number> {
   const args = parseArgs(argv);
   const targetRaw = JSON.parse(await readFile(args.targetPath, "utf8"));
   const cfg = validateOrThrow(targetRaw);
+
+  // Phase 5 (audit §5-D): fail-loud machine-block secret check at startup.
+  // Throws when the configured env var (default
+  // `LLM_TEAM_MACHINE_BLOCK_SECRET`) is unset so PR-first signing/verify is
+  // never silently bypassed in production. The secret is held in this scope
+  // only — never logged, persisted, or threaded into prompts/ledger.
+  const machineBlockSecret = requireMachineBlockSecretFromCfg(cfg);
+  const prFirstSettings = resolvePrFirstSettings(cfg);
+
   const workdir = resolve(
     args.workdir ?? cfg.identity.workdir_path ?? process.cwd(),
   );
@@ -293,6 +308,26 @@ async function main(argv: readonly string[]): Promise<number> {
       "actor_team_membership_unreachable",
     );
 
+    // Phase 5 (audit §5-D, P0-1): build the PR-first invoker/dispatcher/
+    // watcher graph. Default `experiments.{lead,reviewer}_pr_first === false`
+    // keeps the legacy envelope path active until operators opt in. The
+    // `FsMirrorGitHost` adapter is wired here too — production GitHub-API
+    // adapter selection is a separate concern (Phase 6+).
+    const gitHost = new FsMirrorGitHost(store);
+    const prFirstWiring = buildPrFirstWiring({
+      store,
+      clock,
+      ledger,
+      llmRunner,
+      workspace,
+      gitHost,
+      verification,
+      callerId: args.callerId,
+      targetId: cfg.identity.target_id,
+      machineBlockSecret,
+      settings: prFirstSettings,
+    });
+
     do {
       // Every cycle starts with a recovery sweep (RGC-RECOVERY).
       const sweep = await runRecoverySweep({
@@ -388,6 +423,44 @@ async function main(argv: readonly string[]): Promise<number> {
           await new Promise((r) => setTimeout(r, args.cycleIntervalMs));
         continue;
       }
+
+      // Phase 5 (audit §5-D): cycle prelude — PrWatcher polls every open
+      // ReviewSurface and routes 5-gate passing reviews through
+      // PrFirstDispatcher. Gated on `reviewer_pr_first` so the envelope path
+      // does not pay the per-cycle scan cost. Only roles that progress an
+      // object run the prelude (recovery / drift / scout do their own work).
+      if (
+        prFirstSettings.reviewerPrFirst &&
+        (args.role === "turn-worker" ||
+          args.role === "dialogue-coordinator" ||
+          args.role === "outer-coordinator")
+      ) {
+        const summary = await runPrWatcherCyclePrelude({
+          store,
+          prWatcher: prFirstWiring.prWatcher,
+          prFirstDispatcher: prFirstWiring.prFirstDispatcher,
+          // Production wiring resolves the trunk via the workspace adapter;
+          // for cycle-prelude purposes any branch name slot works since
+          // `PrFirstDispatcher.dispatchSlice` only reads it for reverify.
+          trunkRevision: "trunk",
+          reverifyTestCommands: testCommands,
+          environmentFingerprint: `node${process.version}`,
+        });
+        if (summary.dispatches > 0 || summary.reviewsDropped > 0) {
+          logger.log({
+            level: "info",
+            event: "pr_watcher.cycle",
+            fields: {
+              role: args.role,
+              surfaces: summary.surfacesPolled,
+              applied: summary.reviewsApplied,
+              dropped: summary.reviewsDropped,
+              duplicate: summary.reviewsDuplicate,
+              dispatches: summary.dispatches,
+            },
+          });
+        }
+      }
       let outcomeJson: string;
       switch (args.role) {
         case "turn-worker": {
@@ -407,12 +480,22 @@ async function main(argv: readonly string[]): Promise<number> {
               // incident-10: per-phase timeout overrides + lr_invoke retry cap.
               contextBudget: cfg.context_budget,
               failurePolicy: cfg.failure_policy,
+              // Phase 5 (audit §5-D): toggle the PR-first lead path.
+              // Default `experiments.lead_pr_first === false` keeps the
+              // legacy envelope path active.
+              leadPath: prFirstSettings.leadPrFirst ? "pr_first" : "envelope",
             },
             lease,
             leaseConfig: cfg.lease,
             // phase-0-stabilization C: persist composed prompts under
             // `<workdir>/prompts/<session>/<turn>.md` instead of OS-tmp.
             workdirRoot: workdir,
+            // Wire the LeadInvoker only when PR-first is active so the
+            // legacy envelope path stays untouched. `prFirstWiring.leadInvoker`
+            // is non-null for any role that supplies `llmRunner`.
+            ...(prFirstSettings.leadPrFirst && prFirstWiring.leadInvoker != null
+              ? { leadInvoker: prFirstWiring.leadInvoker }
+              : {}),
           });
           outcomeJson = JSON.stringify({ role: args.role, outcome });
           break;
@@ -437,6 +520,14 @@ async function main(argv: readonly string[]): Promise<number> {
             // phase-0-stabilization C: persist composed prompts under
             // `<workdir>/prompts/<session>/<turn>.md` instead of OS-tmp.
             workdirRoot: workdir,
+            // Phase 5 (audit §5-D): toggle the PR-first reviewer path.
+            reviewerPath: prFirstSettings.reviewerPrFirst
+              ? "pr_first"
+              : "envelope",
+            ...(prFirstSettings.reviewerPrFirst &&
+            prFirstWiring.reviewerInvoker != null
+              ? { reviewerInvoker: prFirstWiring.reviewerInvoker }
+              : {}),
           });
           outcomeJson = JSON.stringify({ role: args.role, outcome });
           break;
@@ -462,6 +553,12 @@ async function main(argv: readonly string[]): Promise<number> {
             // phase-0-stabilization C: persist composed prompts under
             // `<workdir>/prompts/<session>/<turn>.md` instead of OS-tmp.
             workdirRoot: workdir,
+            // Phase 5 (audit §5-D): toggle the PR-first lead path for outer
+            // phases (Discovery / Specification / Planning / Validation).
+            leadPath: prFirstSettings.leadPrFirst ? "pr_first" : "envelope",
+            ...(prFirstSettings.leadPrFirst && prFirstWiring.leadInvoker != null
+              ? { leadInvoker: prFirstWiring.leadInvoker }
+              : {}),
           });
           outcomeJson = JSON.stringify({ role: args.role, outcome });
           break;
@@ -485,8 +582,22 @@ async function main(argv: readonly string[]): Promise<number> {
           break;
         }
         case "recovery": {
-          // Recovery sweep already ran above — emit a noop outcome.
-          outcomeJson = JSON.stringify({ role: args.role, outcome: { kind: "swept" } });
+          // Phase 4 lease-sweep already ran above. Phase 5 audit P0-1
+          // additionally invokes the PR-first `RecoveryCoordinator` so
+          // outbox crash-recovery (Case A pending_without_posted, Case B
+          // posted_without_receipt) ledger rows are surfaced. The default
+          // `buildProbe` returns null (no provider-specific probe is wired
+          // here yet) so candidates report `recovered_skipped: no_probe`
+          // until a probe builder lands — but the sweep itself runs.
+          const recoveryResult = await prFirstWiring.recoveryCoordinator.runOnce();
+          outcomeJson = JSON.stringify({
+            role: args.role,
+            outcome: {
+              kind: "swept",
+              pr_first_scanned: recoveryResult.scanned,
+              pr_first_items: recoveryResult.items.length,
+            },
+          });
           break;
         }
         case "scout-scanner": {

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -66,7 +66,7 @@ import { runOneInnerTurn } from "../application/turn-worker.js";
 import { SystemClock } from "../ports/clock.js";
 import {
   buildPrFirstWiring,
-  requireMachineBlockSecretFromCfg,
+  resolveMachineBlockSecretIfPrFirstEnabled,
   resolvePrFirstSettings,
 } from "./pr-first-wiring.js";
 import { runPrWatcherCyclePrelude } from "./pr-watcher-cycle.js";
@@ -202,7 +202,14 @@ async function main(argv: readonly string[]): Promise<number> {
   // `LLM_TEAM_MACHINE_BLOCK_SECRET`) is unset so PR-first signing/verify is
   // never silently bypassed in production. The secret is held in this scope
   // only — never logged, persisted, or threaded into prompts/ledger.
-  const machineBlockSecret = requireMachineBlockSecretFromCfg(cfg);
+  //
+  // PR #125 self-review P1-1: toggle-gated. Envelope-only deployments
+  // (both `experiments.lead_pr_first` and `experiments.reviewer_pr_first`
+  // = false) skip the secret check — PR-first signing is inactive so the
+  // fail-loud requirement does not apply. Operators flipping a toggle on
+  // MUST provide the secret env var; otherwise startup aborts at the next
+  // boot (matching the audit §5-D DoD for active PR-first deployments).
+  const machineBlockSecret = resolveMachineBlockSecretIfPrFirstEnabled(cfg);
   const prFirstSettings = resolvePrFirstSettings(cfg);
 
   const workdir = resolve(

--- a/src/cli/pr-first-wiring.ts
+++ b/src/cli/pr-first-wiring.ts
@@ -99,6 +99,30 @@ export function requireMachineBlockSecretFromCfg(
   return requireMachineBlockSecret(settings.machineBlockSecretEnvName, env);
 }
 
+/**
+ * PR #125 self-review P1-1: toggle-gated fail-loud secret resolution.
+ *
+ * The audit §5-D DoD requires fail-loud when PR-first signing is active.
+ * Calling `requireMachineBlockSecretFromCfg` unconditionally at daemon boot
+ * caused a migration hazard: existing deployments running the legacy
+ * envelope path (both `experiments.lead_pr_first` and
+ * `experiments.reviewer_pr_first` = false, default) would abort on the next
+ * deploy if they had not pre-seeded `LLM_TEAM_MACHINE_BLOCK_SECRET`.
+ *
+ * This helper preserves the fail-loud intent for PR-first-enabled
+ * deployments while keeping envelope-only deployments operable without the
+ * secret. Returns `null` when both PR-first toggles are off — the wiring
+ * then skips invoker construction (which is the only consumer that signs).
+ */
+export function resolveMachineBlockSecretIfPrFirstEnabled(
+  cfg: TargetConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const settings = resolvePrFirstSettings(cfg);
+  if (!settings.leadPrFirst && !settings.reviewerPrFirst) return null;
+  return requireMachineBlockSecret(settings.machineBlockSecretEnvName, env);
+}
+
 export interface PrFirstWiringDeps {
   store: StorePort;
   clock: ClockPort;
@@ -109,7 +133,16 @@ export interface PrFirstWiringDeps {
   verification: VerificationPort;
   callerId: string;
   targetId: string;
-  machineBlockSecret: string;
+  /**
+   * Machine-block HMAC secret. Required when invokers are constructed
+   * (lead/reviewer PR-first signing). Pass `null` when both
+   * `experiments.{lead,reviewer}_pr_first` toggles are off — the wiring
+   * skips invoker construction and PR-watcher signature verification falls
+   * back to a never-matching key (verifyMachineBlock will reject any signed
+   * input, which is the safe default when the deployment opted out of
+   * PR-first). See PR #125 self-review P1-1.
+   */
+  machineBlockSecret: string | null;
   settings: PrFirstSettings;
   /** Trunk branch for lead PR open. */
   baseBranch?: string;
@@ -135,8 +168,14 @@ export function buildPrFirstWiring(deps: PrFirstWiringDeps): PrFirstWiring {
 
   // `llmRunner` is required for the invokers; recovery / watcher / dispatcher
   // do not need it. The recovery role omits llmRunner entirely (Phase 7a).
+  //
+  // PR #125 self-review P1-1: when `machineBlockSecret` is null (envelope-
+  // only deployment with both PR-first toggles off) the invokers + watcher
+  // are not constructed. The daemon/runner already gates invoker
+  // consumption on the same toggle state, so callers see `null` and fall
+  // back to the legacy envelope path.
   const leadInvoker =
-    deps.llmRunner != null
+    deps.llmRunner != null && deps.machineBlockSecret != null
       ? new LeadInvoker(
           {
             callerId: deps.callerId,
@@ -157,7 +196,7 @@ export function buildPrFirstWiring(deps: PrFirstWiringDeps): PrFirstWiring {
       : null;
 
   const reviewerInvoker =
-    deps.llmRunner != null
+    deps.llmRunner != null && deps.machineBlockSecret != null
       ? new ReviewerInvoker(
           {
             callerId: deps.callerId,
@@ -176,11 +215,18 @@ export function buildPrFirstWiring(deps: PrFirstWiringDeps): PrFirstWiring {
         )
       : null;
 
+  // PrWatcher signature verification requires the secret. When the secret
+  // is null (PR-first toggles off) the daemon/runner does not invoke the
+  // cycle prelude, but a non-null secret is still required by the watcher
+  // type. Pass an empty string sentinel so any accidental verify call
+  // rejects every signature (machine-block.verify uses constant-time
+  // compare against the supplied key — empty key never matches a real HMAC).
+  const watcherSecret = deps.machineBlockSecret ?? "";
   const prWatcher = new PrWatcher(
     {
       callerId: deps.callerId,
       targetId: deps.targetId,
-      machineBlockSecret: deps.machineBlockSecret,
+      machineBlockSecret: watcherSecret,
       ...(deps.settings.expectedBotAccount != null
         ? { expectedBotAccount: deps.settings.expectedBotAccount }
         : {}),

--- a/src/cli/pr-first-wiring.ts
+++ b/src/cli/pr-first-wiring.ts
@@ -1,0 +1,241 @@
+/**
+ * Phase 5 PR-first wiring (cli-spicy-anchor.md §1, audit §5-D).
+ *
+ * Audit P0-1 fixed here: the daemon entries used to construct zero
+ * PR-first invokers/dispatchers/watchers; Phase 1-4 code therefore never
+ * executed in production no matter how `target.json` was configured. This
+ * module is a single seam where the daemon and runner CLI build the
+ * invokers + helpers from a parsed `TargetConfig` so the wiring is testable
+ * in isolation.
+ *
+ * Authority:
+ *   - cli-spicy-anchor.md §1 (capability) + §11 (machine-block secret)
+ *   - audit `docs/history/2026-05-12-pr-first-audit.md` §5-D
+ *
+ * Contract (kept narrow on purpose):
+ *   - `resolvePrFirstSettings(cfg, env)` reads `experiments.*` toggles and
+ *     `governance.*` wiring fields. The secret env var name defaults to
+ *     `LLM_TEAM_MACHINE_BLOCK_SECRET`.
+ *   - `requireMachineBlockSecretFromCfg(cfg, env)` is a thin wrapper that
+ *     fails loud at daemon boot when the named env var is unset.
+ *   - `buildPrFirstWiring(deps)` constructs `LeadInvoker`, `ReviewerInvoker`,
+ *     `PrWatcher`, `PrFirstDispatcher`, `RecoveryCoordinator` from already-
+ *     resolved deps. Only invokers the role consumes are instantiated by the
+ *     caller (the helpers themselves are cheap, but selecting at the call-
+ *     site keeps each daemon role focused).
+ *
+ * Default `experiments.{lead,reviewer}_pr_first === false` keeps the legacy
+ * envelope path active until operators opt in.
+ */
+import { LeadInvoker } from "../application/lead-invoker.js";
+import {
+  MACHINE_BLOCK_SECRET_ENV_DEFAULT,
+  requireMachineBlockSecret,
+} from "../application/machine-block.js";
+import { Outbox } from "../application/outbox.js";
+import { PrFirstDispatcher } from "../application/caller-dispatch-prfirst.js";
+import { PrWatcher } from "../application/pr-watcher.js";
+import { RecoveryCoordinator } from "../application/recovery-coordinator.js";
+import { ReviewerInvoker } from "../application/reviewer-invoker.js";
+import { DroppedReviewSignalCache } from "../application/drift-observer.js";
+import type { TargetConfig } from "../config/target-schema.js";
+import type { ClockPort } from "../ports/clock.js";
+import type { GitHostPort } from "../ports/git-host.js";
+import type { LlmRunnerPort } from "../ports/llm-runner.js";
+import type { StorePort } from "../ports/store.js";
+import type { VerificationPort } from "../ports/verification.js";
+import type { WorkspacePort } from "../ports/workspace.js";
+import type { LedgerAppender } from "../application/ledger.js";
+
+const DEFAULT_KNOWN_AGENT_PROFILE_IDS: readonly string[] = [
+  "atlas",
+  "forge",
+  "sentinel",
+  "scout",
+];
+
+export interface PrFirstSettings {
+  /** target.experiments.lead_pr_first ?? false. */
+  leadPrFirst: boolean;
+  /** target.experiments.reviewer_pr_first ?? false. */
+  reviewerPrFirst: boolean;
+  /** Env var name for the HMAC secret. Defaults to LLM_TEAM_MACHINE_BLOCK_SECRET. */
+  machineBlockSecretEnvName: string;
+  /** PR-watcher gate ④(a). When undefined the watcher only requires a non-empty author. */
+  expectedBotAccount: string | undefined;
+  /** PR-watcher gate ④(b). Defaults to the four built-in profiles. */
+  knownAgentProfileIds: readonly string[];
+}
+
+/**
+ * Read PR-first settings from `target.json`. Pure — no I/O, no env read.
+ */
+export function resolvePrFirstSettings(cfg: TargetConfig): PrFirstSettings {
+  const gov = cfg.governance;
+  const exp = cfg.experiments;
+  return {
+    leadPrFirst: exp?.lead_pr_first ?? false,
+    reviewerPrFirst: exp?.reviewer_pr_first ?? false,
+    machineBlockSecretEnvName:
+      gov?.machine_block_secret_env_name ?? MACHINE_BLOCK_SECRET_ENV_DEFAULT,
+    expectedBotAccount: gov?.bot_account,
+    knownAgentProfileIds:
+      gov?.known_agent_profile_ids ?? DEFAULT_KNOWN_AGENT_PROFILE_IDS,
+  };
+}
+
+/**
+ * Resolve + assert the machine-block HMAC secret. Thin wrapper around
+ * `requireMachineBlockSecret` that lets the daemon entry pass the cfg-
+ * derived env-var name.
+ *
+ * Throws when the env var is missing — fail-loud per audit §5-D DoD.
+ */
+export function requireMachineBlockSecretFromCfg(
+  cfg: TargetConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const settings = resolvePrFirstSettings(cfg);
+  return requireMachineBlockSecret(settings.machineBlockSecretEnvName, env);
+}
+
+export interface PrFirstWiringDeps {
+  store: StorePort;
+  clock: ClockPort;
+  ledger: LedgerAppender;
+  llmRunner: LlmRunnerPort | null;
+  workspace: WorkspacePort;
+  gitHost: GitHostPort;
+  verification: VerificationPort;
+  callerId: string;
+  targetId: string;
+  machineBlockSecret: string;
+  settings: PrFirstSettings;
+  /** Trunk branch for lead PR open. */
+  baseBranch?: string;
+}
+
+export interface PrFirstWiring {
+  outbox: Outbox;
+  leadInvoker: LeadInvoker | null;
+  reviewerInvoker: ReviewerInvoker | null;
+  prWatcher: PrWatcher;
+  prFirstDispatcher: PrFirstDispatcher;
+  recoveryCoordinator: RecoveryCoordinator;
+  droppedSignalCache: DroppedReviewSignalCache;
+}
+
+/**
+ * Construct the PR-first invoker/dispatcher/watcher graph from already-
+ * resolved deps. The caller chooses which fields to consume per role.
+ */
+export function buildPrFirstWiring(deps: PrFirstWiringDeps): PrFirstWiring {
+  const outbox = new Outbox({ store: deps.store, ledger: deps.ledger });
+  const droppedSignalCache = new DroppedReviewSignalCache();
+
+  // `llmRunner` is required for the invokers; recovery / watcher / dispatcher
+  // do not need it. The recovery role omits llmRunner entirely (Phase 7a).
+  const leadInvoker =
+    deps.llmRunner != null
+      ? new LeadInvoker(
+          {
+            callerId: deps.callerId,
+            targetId: deps.targetId,
+            baseBranch: deps.baseBranch ?? "main",
+          },
+          {
+            store: deps.store,
+            clock: deps.clock,
+            llmRunner: deps.llmRunner,
+            workspace: deps.workspace,
+            gitHost: deps.gitHost,
+            ledger: deps.ledger,
+            machineBlockSecret: deps.machineBlockSecret,
+            outbox,
+          },
+        )
+      : null;
+
+  const reviewerInvoker =
+    deps.llmRunner != null
+      ? new ReviewerInvoker(
+          {
+            callerId: deps.callerId,
+            targetId: deps.targetId,
+          },
+          {
+            store: deps.store,
+            clock: deps.clock,
+            llmRunner: deps.llmRunner,
+            workspace: deps.workspace,
+            gitHost: deps.gitHost,
+            ledger: deps.ledger,
+            machineBlockSecret: deps.machineBlockSecret,
+            outbox,
+          },
+        )
+      : null;
+
+  const prWatcher = new PrWatcher(
+    {
+      callerId: deps.callerId,
+      targetId: deps.targetId,
+      machineBlockSecret: deps.machineBlockSecret,
+      ...(deps.settings.expectedBotAccount != null
+        ? { expectedBotAccount: deps.settings.expectedBotAccount }
+        : {}),
+      knownAgentProfileIds: deps.settings.knownAgentProfileIds,
+    },
+    {
+      store: deps.store,
+      clock: deps.clock,
+      gitHost: deps.gitHost,
+      ledger: deps.ledger,
+      droppedSignalCache,
+    },
+  );
+
+  const prFirstDispatcher = new PrFirstDispatcher(
+    {
+      callerId: deps.callerId,
+      targetId: deps.targetId,
+    },
+    {
+      store: deps.store,
+      clock: deps.clock,
+      gitHost: deps.gitHost,
+      ledger: deps.ledger,
+      outbox,
+      workspace: deps.workspace,
+      verification: deps.verification,
+    },
+  );
+
+  // ProbeBuilder is wired by the recovery role after construction (the
+  // probe needs role-specific port resolution). For non-recovery roles the
+  // coordinator is built but unused; daemon roles that actually run a sweep
+  // overwrite the buildProbe before calling `runOnce`.
+  const recoveryCoordinator = new RecoveryCoordinator(
+    {
+      callerId: deps.callerId,
+      targetId: deps.targetId,
+    },
+    {
+      store: deps.store,
+      clock: deps.clock,
+      ledger: deps.ledger,
+      outbox,
+      buildProbe: async () => null,
+    },
+  );
+
+  return {
+    outbox,
+    leadInvoker,
+    reviewerInvoker,
+    prWatcher,
+    prFirstDispatcher,
+    recoveryCoordinator,
+    droppedSignalCache,
+  };
+}

--- a/src/cli/pr-watcher-cycle.ts
+++ b/src/cli/pr-watcher-cycle.ts
@@ -1,0 +1,266 @@
+/**
+ * Phase 5 cycle prelude — PrWatcher poll + caller-dispatch-prfirst routing.
+ *
+ * cli-spicy-anchor.md §1 step 4 calls for the daemon's cycle prelude to
+ * poll the active ReviewSurface set and route any 5-gate-passing review
+ * verdict through `PrFirstDispatcher`. This module is a thin orchestrator:
+ *
+ *   1. Enumerate open ReviewSurface objects under `<workdir>/review_surfaces/`.
+ *   2. For each, call `PrWatcher.pollReviewSurface`.
+ *   3. For every `applied` per-review outcome, route to `PrFirstDispatcher`
+ *      with the loaded slice / sliceMerge / milestone payload.
+ *
+ * The helper is intentionally read-mostly: it does not mutate ReviewSurface
+ * state itself; both the watcher (review_signal_applied / dropped ledger
+ * rows) and the dispatcher (review_state / build_state / merge transitions)
+ * own their own writes.
+ *
+ * Returns aggregated counts so the daemon can log a single summary line per
+ * cycle.
+ */
+import type { Milestone as MilestoneT } from "../domain/schema/milestone.js";
+import { Milestone } from "../domain/schema/milestone.js";
+import {
+  ReviewSurface,
+  type ReviewSurface as ReviewSurfaceT,
+} from "../domain/schema/review-surface.js";
+import { Slice, type Slice as SliceT } from "../domain/schema/slice.js";
+import {
+  SliceMerge,
+  type SliceMerge as SliceMergeT,
+} from "../domain/schema/slice-merge.js";
+import type { CommandSpec } from "../ports/verification.js";
+import type { StorePort } from "../ports/store.js";
+import {
+  PrFirstDispatcher,
+  type PrFirstDispatchResult,
+} from "../application/caller-dispatch-prfirst.js";
+import { PrWatcher } from "../application/pr-watcher.js";
+import { layout } from "../application/persistence-layout.js";
+
+export interface PrWatcherCycleDeps {
+  store: StorePort;
+  prWatcher: PrWatcher;
+  prFirstDispatcher: PrFirstDispatcher;
+  /** Trunk revision used for re-verification — typically the active branch base. */
+  trunkRevision: string;
+  /** Reverify command builder threaded into PrFirstDispatcher slice approve. */
+  reverifyTestCommands: (workspaceCwd: string) => CommandSpec[];
+  environmentFingerprint: string;
+}
+
+export interface PrWatcherCycleSummary {
+  surfacesPolled: number;
+  reviewsApplied: number;
+  reviewsDropped: number;
+  reviewsDuplicate: number;
+  dispatches: number;
+  /** Per-surface dispatch results (kept short — caller decides whether to log). */
+  results: PrFirstDispatchResult[];
+}
+
+const EMPTY_SUMMARY: PrWatcherCycleSummary = {
+  surfacesPolled: 0,
+  reviewsApplied: 0,
+  reviewsDropped: 0,
+  reviewsDuplicate: 0,
+  dispatches: 0,
+  results: [],
+};
+
+/**
+ * Run one cycle prelude pass: poll every open ReviewSurface, dispatch
+ * applied verdicts. Idempotent — repeated calls with no new reviews emit
+ * `duplicate_applied` (gate ⑤) and skip dispatch.
+ */
+export async function runPrWatcherCyclePrelude(
+  deps: PrWatcherCycleDeps,
+): Promise<PrWatcherCycleSummary> {
+  const surfaces = await listOpenReviewSurfaces(deps.store);
+  if (surfaces.length === 0) return { ...EMPTY_SUMMARY };
+
+  let reviewsApplied = 0;
+  let reviewsDropped = 0;
+  let reviewsDuplicate = 0;
+  const results: PrFirstDispatchResult[] = [];
+
+  for (const surface of surfaces) {
+    const poll = await deps.prWatcher.pollReviewSurface(surface);
+    for (const r of poll.reviews) {
+      switch (r.kind) {
+        case "applied":
+          reviewsApplied += 1;
+          break;
+        case "dropped":
+          reviewsDropped += 1;
+          break;
+        case "duplicate_applied":
+          reviewsDuplicate += 1;
+          break;
+      }
+    }
+
+    // Pick the latest applied review (last-match precedence aligns with
+    // §11 — the canonical signal is always the most recent passing review).
+    let applied: Extract<(typeof poll.reviews)[number], { kind: "applied" }> | null = null;
+    for (let i = poll.reviews.length - 1; i >= 0; i -= 1) {
+      const candidate = poll.reviews[i]!;
+      if (candidate.kind === "applied") {
+        applied = candidate;
+        break;
+      }
+    }
+    if (applied == null) continue;
+
+    const dispatched = await dispatchApplied(deps, surface, applied);
+    if (dispatched != null) results.push(dispatched);
+  }
+
+  return {
+    surfacesPolled: surfaces.length,
+    reviewsApplied,
+    reviewsDropped,
+    reviewsDuplicate,
+    dispatches: results.length,
+    results,
+  };
+}
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+async function listOpenReviewSurfaces(
+  store: StorePort,
+): Promise<ReviewSurfaceT[]> {
+  let names: string[];
+  try {
+    names = await store.list("review_surfaces");
+  } catch {
+    return [];
+  }
+  const out: ReviewSurfaceT[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const body = await store.readText(`review_surfaces/${name}`);
+    if (body == null || body.length === 0) continue;
+    let surface: ReviewSurfaceT;
+    try {
+      surface = ReviewSurface.parse(JSON.parse(body));
+    } catch {
+      continue;
+    }
+    // Only `open` surfaces accept new applied reviews; `merged` / `closed`
+    // surfaces are terminal and the watcher correctly emits
+    // `duplicate_applied` if revisited, but skipping early is cheaper.
+    if (surface.lifecycle_state !== "open") continue;
+    out.push(surface);
+  }
+  return out;
+}
+
+async function dispatchApplied(
+  deps: PrWatcherCycleDeps,
+  surface: ReviewSurfaceT,
+  applied: { verdict: "approve" | "request_changes" | "comment"; receipt: { session_id: string } },
+): Promise<PrFirstDispatchResult | null> {
+  // The watcher emits `verdict: "comment"` for review.state=commented; we
+  // do not dispatch those — they are recorded as `review_signal_applied`
+  // but produce no state change (cli-spicy-anchor.md §10).
+  if (applied.verdict === "comment") return null;
+  const verdict = applied.verdict;
+
+  if (surface.parent_kind === "slice") {
+    const slice = await loadSliceById(deps.store, surface.parent_id);
+    if (slice == null) return null;
+    const sliceMerge = await loadActiveSliceMerge(deps.store, slice.slice_id);
+    if (sliceMerge == null) return null;
+    return await deps.prFirstDispatcher.dispatch({
+      parent_kind: "slice",
+      reviewSurface: surface,
+      slice,
+      sliceMerge,
+      sessionId: applied.receipt.session_id,
+      verdict,
+      verificationRunId: surface.latest_verification_run_id,
+      trunkRevision: deps.trunkRevision,
+      testCommandsForReverify: deps.reverifyTestCommands,
+      environmentFingerprint: deps.environmentFingerprint,
+    });
+  }
+  if (surface.parent_kind === "milestone") {
+    const milestone = await loadMilestoneById(deps.store, surface.parent_id);
+    if (milestone == null || surface.parent_phase == null) return null;
+    return await deps.prFirstDispatcher.dispatch({
+      parent_kind: "milestone",
+      reviewSurface: surface,
+      milestone,
+      sessionId: applied.receipt.session_id,
+      verdict,
+      parentPhase: surface.parent_phase,
+    });
+  }
+  // spec_doc — dispatcher emits a fail-loud `review_signal_dropped` row.
+  return await deps.prFirstDispatcher.dispatch({
+    parent_kind: "spec_doc",
+    reviewSurface: surface,
+    sessionId: applied.receipt.session_id,
+    verdict,
+  });
+}
+
+async function loadSliceById(
+  store: StorePort,
+  sliceId: string,
+): Promise<SliceT | null> {
+  const body = await store.readText(layout.slice(sliceId));
+  if (body == null || body.length === 0) return null;
+  try {
+    return Slice.parse(JSON.parse(body));
+  } catch {
+    return null;
+  }
+}
+
+async function loadActiveSliceMerge(
+  store: StorePort,
+  sliceId: string,
+): Promise<SliceMergeT | null> {
+  let names: string[];
+  try {
+    names = await store.list("slice_merges");
+  } catch {
+    return null;
+  }
+  let candidate: SliceMergeT | null = null;
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const body = await store.readText(`slice_merges/${name}`);
+    if (body == null || body.length === 0) continue;
+    let sm: SliceMergeT;
+    try {
+      sm = SliceMerge.parse(JSON.parse(body));
+    } catch {
+      continue;
+    }
+    if (sm.slice_id !== sliceId) continue;
+    // Prefer the most recently updated active row.
+    if (candidate == null || sm.updated_at > candidate.updated_at) {
+      candidate = sm;
+    }
+  }
+  return candidate;
+}
+
+async function loadMilestoneById(
+  store: StorePort,
+  milestoneId: string,
+): Promise<MilestoneT | null> {
+  const body = await store.readText(layout.milestone(milestoneId));
+  if (body == null || body.length === 0) return null;
+  try {
+    return Milestone.parse(JSON.parse(body));
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -21,7 +21,7 @@ import { runOneMiddleReviewTurn } from "../application/dialogue-coordinator.js";
 import { SystemClock } from "../ports/clock.js";
 import {
   buildPrFirstWiring,
-  requireMachineBlockSecretFromCfg,
+  resolveMachineBlockSecretIfPrFirstEnabled,
   resolvePrFirstSettings,
 } from "./pr-first-wiring.js";
 
@@ -128,7 +128,12 @@ async function main(argv: readonly string[]): Promise<number> {
   // Throws when the configured env var (default
   // `LLM_TEAM_MACHINE_BLOCK_SECRET`) is unset so PR-first signing/verify is
   // never silently bypassed.
-  const machineBlockSecret = requireMachineBlockSecretFromCfg(cfg);
+  //
+  // PR #125 self-review P1-1: toggle-gated. Envelope-only deployments skip
+  // the secret check; deployments with either `experiments.lead_pr_first`
+  // or `experiments.reviewer_pr_first` = true MUST provide the secret env
+  // var or startup aborts.
+  const machineBlockSecret = resolveMachineBlockSecretIfPrFirstEnabled(cfg);
   const prFirstSettings = resolvePrFirstSettings(cfg);
 
   const workdir = resolve(

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -12,12 +12,18 @@ import { FakeVerification } from "../adapters/verification/fake.js";
 import { ShellVerification } from "../adapters/verification/shell.js";
 import { GitWorktreeWorkspace } from "../adapters/workspace/git-worktree.js";
 import { FakeWorkspace } from "../adapters/workspace/fake.js";
+import { FsMirrorGitHost } from "../adapters/git-host/fs-mirror.js";
 import { validateOrThrow } from "../application/config-validator.js";
 import { FileLedger } from "../application/ledger.js";
 import { LOG_DAEMON_PATH } from "../application/persistence-layout.js";
 import { runOneInnerTurn } from "../application/turn-worker.js";
 import { runOneMiddleReviewTurn } from "../application/dialogue-coordinator.js";
 import { SystemClock } from "../ports/clock.js";
+import {
+  buildPrFirstWiring,
+  requireMachineBlockSecretFromCfg,
+  resolvePrFirstSettings,
+} from "./pr-first-wiring.js";
 
 /**
  * CLI entrypoint — runs a single coordinator iteration and exits.
@@ -117,6 +123,14 @@ async function main(argv: readonly string[]): Promise<number> {
   const args = parseArgs(argv);
   const targetRaw = JSON.parse(await readFile(args.targetPath, "utf8"));
   const cfg = validateOrThrow(targetRaw);
+
+  // Phase 5 (audit §5-D): fail-loud machine-block secret check at startup.
+  // Throws when the configured env var (default
+  // `LLM_TEAM_MACHINE_BLOCK_SECRET`) is unset so PR-first signing/verify is
+  // never silently bypassed.
+  const machineBlockSecret = requireMachineBlockSecretFromCfg(cfg);
+  const prFirstSettings = resolvePrFirstSettings(cfg);
+
   const workdir = resolve(
     args.workdir ?? cfg.identity.workdir_path ?? process.cwd(),
   );
@@ -173,6 +187,24 @@ async function main(argv: readonly string[]): Promise<number> {
         : { argv: ["npm", "test"], cwd },
     ];
 
+    // Phase 5 (audit §5-D, P0-1): construct the PR-first wiring once per
+    // runner invocation. `experiments.{lead,reviewer}_pr_first` toggles in
+    // target.json decide whether the invokers are actually consumed.
+    const gitHost = new FsMirrorGitHost(store);
+    const prFirstWiring = buildPrFirstWiring({
+      store,
+      clock,
+      ledger,
+      llmRunner,
+      workspace,
+      gitHost,
+      verification,
+      callerId: args.callerId,
+      targetId: cfg.identity.target_id,
+      machineBlockSecret,
+      settings: prFirstSettings,
+    });
+
     if (args.dialogueCoordinator) {
       const outcome = await runOneMiddleReviewTurn({
         store,
@@ -188,6 +220,12 @@ async function main(argv: readonly string[]): Promise<number> {
         // phase-0-stabilization C: persist composed prompts under
         // `<workdir>/prompts/<session>/<turn>.md` instead of OS-tmp.
         workdirRoot: workdir,
+        // Phase 5 (audit §5-D): toggle the PR-first reviewer path.
+        reviewerPath: prFirstSettings.reviewerPrFirst ? "pr_first" : "envelope",
+        ...(prFirstSettings.reviewerPrFirst &&
+        prFirstWiring.reviewerInvoker != null
+          ? { reviewerInvoker: prFirstWiring.reviewerInvoker }
+          : {}),
       });
       process.stdout.write(`${JSON.stringify(outcome)}\n`);
       // P0-2 fix (PR #62 review): dispatch_no_match exits non-zero so CI
@@ -209,10 +247,15 @@ async function main(argv: readonly string[]): Promise<number> {
         targetId: cfg.identity.target_id,
         testCommands,
         environmentFingerprint: `node${process.version}`,
+        // Phase 5 (audit §5-D): toggle the PR-first lead path.
+        leadPath: prFirstSettings.leadPrFirst ? "pr_first" : "envelope",
       },
       // phase-0-stabilization C: persist composed prompts under
       // `<workdir>/prompts/<session>/<turn>.md` instead of OS-tmp.
       workdirRoot: workdir,
+      ...(prFirstSettings.leadPrFirst && prFirstWiring.leadInvoker != null
+        ? { leadInvoker: prFirstWiring.leadInvoker }
+        : {}),
     });
     process.stdout.write(`${JSON.stringify(outcome)}\n`);
     return outcome.kind === "noop" ||

--- a/src/config/target-schema.ts
+++ b/src/config/target-schema.ts
@@ -35,6 +35,26 @@ export const Governance = z
     human_team_cache_ttl_seconds: z.number().int().positive().default(300),
     human_team_provider: HumanTeamProvider.default("fs-mirror"),
     unauthorized_author_alert: z.boolean().default(false),
+    /**
+     * Phase 5 (cli-spicy-anchor.md §11-3 + audit §5-D): env var name from
+     * which `requireMachineBlockSecret` reads the HMAC secret used to sign
+     * and verify `<!-- llm-team:{pr,review}-machine ... -->` blocks. The
+     * daemon fails loud at startup if the named variable is unset. Default
+     * keeps the historical name `LLM_TEAM_MACHINE_BLOCK_SECRET`.
+     */
+    machine_block_secret_env_name: z.string().min(1).optional(),
+    /**
+     * Phase 5 PR-watcher gate ④(a): authorized GitHub bot account
+     * (review.author) for the orchestrator's reviewer surface. When set the
+     * watcher rejects reviews authored by anyone else.
+     */
+    bot_account: z.string().min(1).optional(),
+    /**
+     * Phase 5 PR-watcher gate ④(b): whitelist of `agent_profile_id` values
+     * that may author the canonical machine review. Defaults to the four
+     * built-in profiles (atlas / forge / sentinel / scout).
+     */
+    known_agent_profile_ids: z.array(z.string().min(1)).optional(),
   })
   .strict()
   .refine(
@@ -415,6 +435,23 @@ export const FailurePolicy = z
   .strict();
 export type FailurePolicy = z.infer<typeof FailurePolicy>;
 
+/**
+ * Phase 5 (cli-spicy-anchor.md §1 + audit §5-D): per-path PR-first
+ * activation toggles. Both default `false` so the legacy envelope path
+ * remains the production default until operators opt in. Toggling either
+ * field activates the corresponding invoker wire-up inside the daemon
+ * (turn-worker / outer-coordinator for lead, dialogue-coordinator for
+ * reviewer); the toggle has no effect when the daemon role does not
+ * consume it.
+ */
+export const Experiments = z
+  .object({
+    lead_pr_first: z.boolean().default(false),
+    reviewer_pr_first: z.boolean().default(false),
+  })
+  .strict();
+export type Experiments = z.infer<typeof Experiments>;
+
 export const TargetConfig = z
   .object({
     identity: Identity,
@@ -433,6 +470,7 @@ export const TargetConfig = z
     invariant_enforcement: InvariantEnforcement.optional(),
     context_budget: ContextBudget.optional(),
     failure_policy: FailurePolicy.optional(),
+    experiments: Experiments.optional(),
   })
   .strict();
 

--- a/tests/e2e/pr-first-wiring-mock.test.ts
+++ b/tests/e2e/pr-first-wiring-mock.test.ts
@@ -118,12 +118,17 @@ describe("Phase 5 — daemon PR-first wiring (audit P0-1)", () => {
     else process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = prevMachineSecret;
   });
 
-  it("(a) daemon boot fails loud when LLM_TEAM_MACHINE_BLOCK_SECRET is unset", async () => {
+  it("(a) daemon boot fails loud when LLM_TEAM_MACHINE_BLOCK_SECRET is unset AND a PR-first toggle is on", async () => {
+    // PR #125 self-review P1-1: fail-loud is gated on at least one
+    // `experiments.{lead,reviewer}_pr_first` being true. Envelope-only
+    // deployments tolerate a missing secret (see (g)).
     delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
     const workdir = mkdtempSync(join(tmpdir(), "phase5-secret-"));
     const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
     process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
-    const targetPath = writeTarget(workdir);
+    const targetPath = writeTarget(workdir, {
+      experiments: { lead_pr_first: true },
+    });
 
     await expect(
       daemonMain([
@@ -144,13 +149,14 @@ describe("Phase 5 — daemon PR-first wiring (audit P0-1)", () => {
     ).rejects.toThrow(/LLM_TEAM_MACHINE_BLOCK_SECRET/);
   });
 
-  it("(b) custom governance.machine_block_secret_env_name routes the fail-loud check", async () => {
+  it("(b) custom governance.machine_block_secret_env_name routes the fail-loud check (PR-first toggle on)", async () => {
     delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
     delete process.env.LLM_TEAM_CUSTOM_SECRET;
     const workdir = mkdtempSync(join(tmpdir(), "phase5-secret-custom-"));
     const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
     process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
     const targetPath = writeTarget(workdir, {
+      experiments: { reviewer_pr_first: true },
       governance: {
         machine_block_secret_env_name: "LLM_TEAM_CUSTOM_SECRET",
       } as TargetOverrides["governance"],
@@ -173,6 +179,49 @@ describe("Phase 5 — daemon PR-first wiring (audit P0-1)", () => {
         "phase5-custom-secret",
       ]),
     ).rejects.toThrow(/LLM_TEAM_CUSTOM_SECRET/);
+  });
+
+  it("(g) PR #125 P1-1 — envelope-only cfg (both toggles off) boots without the secret env", async () => {
+    // Migration safety: a deployment running the legacy envelope path
+    // (default `experiments.{lead,reviewer}_pr_first === false`) must NOT
+    // abort on the next deploy when `LLM_TEAM_MACHINE_BLOCK_SECRET` is
+    // unset. Fail-loud only kicks in once an operator opts into PR-first
+    // by flipping a toggle.
+    delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    const workdir = mkdtempSync(join(tmpdir(), "phase5-envelope-only-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir);
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase5-envelope-only",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: { kind: string };
+    };
+    expect(parsed.role).toBe("turn-worker");
+    expect(parsed.outcome.kind).toBe("noop");
   });
 
   it("(c) default cfg (no experiments) boots without invoking the PR-first path", async () => {

--- a/tests/e2e/pr-first-wiring-mock.test.ts
+++ b/tests/e2e/pr-first-wiring-mock.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Phase 5 (audit §5-D, P0-1) — daemon entry PR-first wiring smoke.
+ *
+ * The audit found that `daemon.ts` / `runner.ts` constructed zero PR-first
+ * invokers no matter how `target.json` was configured. Phase 1-4's
+ * ~3000 LOC of new code therefore never executed in production. This file
+ * pins the wiring contract with mock-port scenarios:
+ *
+ *   1. daemon fails loud at boot when `LLM_TEAM_MACHINE_BLOCK_SECRET` is
+ *      unset (audit §5-D DoD).
+ *   2. cfg-driven `experiments.lead_pr_first` toggle activates the lead
+ *      PR-first path — observed via the `lead_path_pr_first` outcome.
+ *   3. cfg-driven `experiments.reviewer_pr_first` toggle activates the
+ *      reviewer PR-first path — observed via `reviewer_path_pr_first`.
+ *   4. `governance.bot_account` / `governance.known_agent_profile_ids`
+ *      schema fields parse without rejection.
+ *   5. default `false` toggles preserve the legacy envelope path (no
+ *      `lead_path_pr_first` outcome is emitted).
+ *
+ * The recovery role + PrWatcher cycle prelude are exercised by the
+ * application-layer tests already (`recovery-coordinator.test.ts`,
+ * `pr-watcher.test.ts`) — this file's contribution is the daemon entry
+ * seam where the wiring lives in production.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { daemonMain } from "../../src/cli/daemon.js";
+
+const TARGET_ID = "demo-target";
+
+interface TargetOverrides {
+  experiments?: {
+    lead_pr_first?: boolean;
+    reviewer_pr_first?: boolean;
+  };
+  governance?: {
+    bot_account?: string;
+    known_agent_profile_ids?: string[];
+    machine_block_secret_env_name?: string;
+  };
+}
+
+function writeTarget(workdir: string, overrides: TargetOverrides = {}): string {
+  const target: Record<string, unknown> = {
+    identity: {
+      target_id: TARGET_ID,
+      workdir_path: workdir,
+      audit_hash_seed: "seed-phase5",
+    },
+    agent_profiles: {
+      atlas: { runner: "fake" },
+      forge: { runner: "fake" },
+      sentinel: { runner: "fake" },
+      scout: { runner: "fake" },
+    },
+  };
+  if (overrides.experiments) target.experiments = overrides.experiments;
+  if (overrides.governance) {
+    // governance is a `.strict()` object with three required fields
+    // (human_team / control_issue_number / contract_change_issue_number).
+    // Tests merge their PR-first-specific overrides on top of a complete
+    // baseline so the target.json validator accepts the input.
+    target.governance = {
+      human_team: "test-team",
+      control_issue_number: 1,
+      contract_change_issue_number: 2,
+      ...overrides.governance,
+    };
+  }
+  const path = join(workdir, "target.json");
+  writeFileSync(path, JSON.stringify(target), "utf8");
+  return path;
+}
+
+function captureStdout(): { restore: () => void; lines: () => string[] } {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  const spy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(((c: string | Uint8Array) => {
+      chunks.push(typeof c === "string" ? c : Buffer.from(c).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write);
+  return {
+    restore: () => {
+      spy.mockRestore();
+      void orig;
+    },
+    lines: () =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter((s) => s.length > 0),
+  };
+}
+
+describe("Phase 5 — daemon PR-first wiring (audit P0-1)", () => {
+  let prevAllowFake: string | undefined;
+  let prevFixtureDir: string | undefined;
+  let prevMachineSecret: string | undefined;
+
+  beforeEach(() => {
+    prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    prevFixtureDir = process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
+    prevMachineSecret = process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+  });
+
+  afterEach(() => {
+    if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+    if (prevFixtureDir == null) delete process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
+    else process.env.LLM_TEAM_FAKE_FIXTURE_DIR = prevFixtureDir;
+    if (prevMachineSecret == null)
+      delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    else process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = prevMachineSecret;
+  });
+
+  it("(a) daemon boot fails loud when LLM_TEAM_MACHINE_BLOCK_SECRET is unset", async () => {
+    delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    const workdir = mkdtempSync(join(tmpdir(), "phase5-secret-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir);
+
+    await expect(
+      daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase5-secret",
+      ]),
+    ).rejects.toThrow(/LLM_TEAM_MACHINE_BLOCK_SECRET/);
+  });
+
+  it("(b) custom governance.machine_block_secret_env_name routes the fail-loud check", async () => {
+    delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    delete process.env.LLM_TEAM_CUSTOM_SECRET;
+    const workdir = mkdtempSync(join(tmpdir(), "phase5-secret-custom-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir, {
+      governance: {
+        machine_block_secret_env_name: "LLM_TEAM_CUSTOM_SECRET",
+      } as TargetOverrides["governance"],
+    });
+
+    await expect(
+      daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase5-custom-secret",
+      ]),
+    ).rejects.toThrow(/LLM_TEAM_CUSTOM_SECRET/);
+  });
+
+  it("(c) default cfg (no experiments) boots without invoking the PR-first path", async () => {
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-secret";
+    const workdir = mkdtempSync(join(tmpdir(), "phase5-default-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir);
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "turn-worker",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase5-default",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: { kind: string };
+    };
+    expect(parsed.role).toBe("turn-worker");
+    // Empty store → noop. PR-first toggles default false so no
+    // `lead_path_pr_first` outcome is emitted on this empty pickup.
+    expect(parsed.outcome.kind).toBe("noop");
+  });
+
+  it("(d) experiments.lead_pr_first=true boots all three lead-consuming roles (turn-worker / outer-coordinator)", async () => {
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-secret";
+    for (const role of ["turn-worker", "outer-coordinator"] as const) {
+      const workdir = mkdtempSync(join(tmpdir(), `phase5-lead-${role}-`));
+      const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
+      process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+      const targetPath = writeTarget(workdir, {
+        experiments: { lead_pr_first: true },
+        governance: {
+          bot_account: "phase5-bot[bot]",
+          known_agent_profile_ids: ["atlas", "forge", "sentinel", "scout"],
+        } as TargetOverrides["governance"],
+      });
+
+      const cap = captureStdout();
+      let code: number;
+      try {
+        code = await daemonMain([
+          "--role",
+          role,
+          "--target",
+          targetPath,
+          "--workdir",
+          workdir,
+          "--once",
+          "--cycle-interval-ms",
+          "0",
+          "--fake-workspace",
+          "--fake-verification",
+          "--caller-id",
+          `phase5-lead-${role}`,
+        ]);
+      } finally {
+        cap.restore();
+      }
+      expect(code).toBe(0);
+      const last = cap.lines().at(-1) ?? "";
+      const parsed = JSON.parse(last) as {
+        role: string;
+        outcome: { kind: string };
+      };
+      expect(parsed.role).toBe(role);
+      // Empty store → noop. The wiring assertion is that the daemon
+      // reached the role's main body at all (the previous wiring threw
+      // because LeadInvoker requires a machineBlockSecret it could not
+      // resolve when secret env was unset and toggles were off).
+      expect(parsed.outcome.kind).toBe("noop");
+    }
+  });
+
+  it("(e) experiments.reviewer_pr_first=true boots dialogue-coordinator with reviewer wiring", async () => {
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-secret";
+    const workdir = mkdtempSync(join(tmpdir(), "phase5-reviewer-"));
+    const fixtureDir = mkdtempSync(join(tmpdir(), "phase5-fxt-"));
+    process.env.LLM_TEAM_FAKE_FIXTURE_DIR = fixtureDir;
+    const targetPath = writeTarget(workdir, {
+      experiments: { reviewer_pr_first: true },
+      governance: {
+        bot_account: "phase5-bot[bot]",
+      } as TargetOverrides["governance"],
+    });
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "dialogue-coordinator",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--fake-workspace",
+        "--fake-verification",
+        "--caller-id",
+        "phase5-reviewer",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: { kind: string };
+    };
+    expect(parsed.role).toBe("dialogue-coordinator");
+    expect(parsed.outcome.kind).toBe("noop");
+  });
+
+  it("(f) recovery role invokes PrFirst RecoveryCoordinator.runOnce", async () => {
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-secret";
+    const workdir = mkdtempSync(join(tmpdir(), "phase5-recovery-"));
+    mkdirSync(join(workdir, "log"), { recursive: true });
+    // recovery role omits llmRunner entirely (audit §5-D Phase 7a) — the
+    // wiring still constructs RecoveryCoordinator and calls runOnce.
+    const targetPath = writeTarget(workdir);
+
+    const cap = captureStdout();
+    let code: number;
+    try {
+      code = await daemonMain([
+        "--role",
+        "recovery",
+        "--target",
+        targetPath,
+        "--workdir",
+        workdir,
+        "--once",
+        "--cycle-interval-ms",
+        "0",
+        "--caller-id",
+        "phase5-recovery",
+      ]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+    const last = cap.lines().at(-1) ?? "";
+    const parsed = JSON.parse(last) as {
+      role: string;
+      outcome: {
+        kind: string;
+        pr_first_scanned?: number;
+        pr_first_items?: number;
+      };
+    };
+    expect(parsed.role).toBe("recovery");
+    expect(parsed.outcome.kind).toBe("swept");
+    // Empty ledger → zero candidates. The presence of these fields proves
+    // PrFirst RecoveryCoordinator.runOnce ran (audit P0-1 wire-up).
+    expect(parsed.outcome.pr_first_scanned).toBe(0);
+    expect(parsed.outcome.pr_first_items).toBe(0);
+  });
+});

--- a/tests/integration/daemon-control-state.test.ts
+++ b/tests/integration/daemon-control-state.test.ts
@@ -105,11 +105,16 @@ async function readLedgerRows(store: FsStore): Promise<LedgerRow[]> {
 describe("Phase 7b — daemon control-state prelude gate", () => {
   let prevAllowFake: string | undefined;
   let prevFixtureDir: string | undefined;
+  let prevMachineSecret: string | undefined;
 
   beforeEach(() => {
     prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
     prevFixtureDir = process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
+    prevMachineSecret = process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
     process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+    // Phase 5 (audit §5-D): daemon boots fail-loud without the machine-block
+    // secret. Tests opt in with a deterministic placeholder.
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-machine-block-secret";
   });
 
   afterEach(() => {
@@ -117,6 +122,9 @@ describe("Phase 7b — daemon control-state prelude gate", () => {
     else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
     if (prevFixtureDir == null) delete process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
     else process.env.LLM_TEAM_FAKE_FIXTURE_DIR = prevFixtureDir;
+    if (prevMachineSecret == null)
+      delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    else process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = prevMachineSecret;
   });
 
   it("(a) pause signal drop → next pickup emits noop outcome + pause_resume ledger row", async () => {

--- a/tests/integration/daemon-drift-observer.test.ts
+++ b/tests/integration/daemon-drift-observer.test.ts
@@ -124,15 +124,23 @@ async function persistSliceWithTrackerRef(
 
 describe("Phase 7c — drift-observer daemon role", () => {
   let prevAllowFake: string | undefined;
+  let prevMachineSecret: string | undefined;
 
   beforeEach(() => {
     prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    prevMachineSecret = process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
     process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+    // Phase 5 (audit §5-D): daemon boots fail-loud without the machine-block
+    // secret. Tests opt in with a deterministic placeholder.
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-machine-block-secret";
   });
 
   afterEach(() => {
     if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
     else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+    if (prevMachineSecret == null)
+      delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    else process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = prevMachineSecret;
   });
 
   it("(a) inbound drift on Slice tracker ref → external_observation ledger row + swept outcome", async () => {

--- a/tests/integration/daemon-llm-runner-wiring.test.ts
+++ b/tests/integration/daemon-llm-runner-wiring.test.ts
@@ -66,14 +66,19 @@ function captureStdout(): { restore: () => void; lines: () => string[] } {
 describe("Phase 7a — daemon production LLM runner wiring (G1-1)", () => {
   let prevFixtureDir: string | undefined;
   let prevAllowFake: string | undefined;
+  let prevMachineSecret: string | undefined;
 
   beforeEach(() => {
     prevFixtureDir = process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
     prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    prevMachineSecret = process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
     // PR #73 review (P1): production wiring rejects `runner: "fake"` unless
     // the test harness opts in. These integration tests use fake runners
     // to avoid spawning real CLIs, so opt in here.
     process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+    // Phase 5 (audit §5-D): daemon boots fail-loud without the machine-block
+    // secret. Tests opt in with a deterministic placeholder.
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-machine-block-secret";
   });
 
   afterEach(() => {
@@ -81,6 +86,9 @@ describe("Phase 7a — daemon production LLM runner wiring (G1-1)", () => {
     else process.env.LLM_TEAM_FAKE_FIXTURE_DIR = prevFixtureDir;
     if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
     else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+    if (prevMachineSecret == null)
+      delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    else process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = prevMachineSecret;
   });
 
   it("turn-worker --once boots from cfg.agent_profiles without --fake-llm-fixtures", async () => {

--- a/tests/integration/daemon-scout-scanner.test.ts
+++ b/tests/integration/daemon-scout-scanner.test.ts
@@ -127,15 +127,23 @@ async function persistInProgressSlice(
 
 describe("Phase 9b — scout-scanner daemon role", () => {
   let prevAllowFake: string | undefined;
+  let prevMachineSecret: string | undefined;
 
   beforeEach(() => {
     prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    prevMachineSecret = process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
     process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+    // Phase 5 (audit §5-D): daemon boots fail-loud without the machine-block
+    // secret. Tests opt in with a deterministic placeholder.
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-machine-block-secret";
   });
 
   afterEach(() => {
     if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
     else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+    if (prevMachineSecret == null)
+      delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    else process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = prevMachineSecret;
   });
 
   it("(a) runScoutScannerSweep persists PROPOSED RefactorBacklog row + ledger external_observation row, dedups on second pass", async () => {

--- a/tests/integration/pr-first-wiring-cfg.test.ts
+++ b/tests/integration/pr-first-wiring-cfg.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Phase 5 (audit §5-D, P0-1) — `target.json` schema additions + cfg →
+ * settings resolver smoke.
+ *
+ * Covers:
+ *   - `experiments.lead_pr_first` / `experiments.reviewer_pr_first` parse
+ *     to booleans (default false when omitted).
+ *   - `governance.machine_block_secret_env_name` parses to a string
+ *     (default `LLM_TEAM_MACHINE_BLOCK_SECRET` when omitted).
+ *   - `governance.bot_account` parses to an optional string.
+ *   - `governance.known_agent_profile_ids` parses to an optional string
+ *     array (default `["atlas","forge","sentinel","scout"]`).
+ *   - `buildPrFirstWiring` constructs all five components (LeadInvoker,
+ *     ReviewerInvoker, PrWatcher, PrFirstDispatcher, RecoveryCoordinator)
+ *     when `llmRunner` is supplied, and skips the LLM-dependent invokers
+ *     when `llmRunner` is null (recovery role parity).
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { FsMirrorGitHost } from "../../src/adapters/git-host/fs-mirror.js";
+import { FsStore } from "../../src/adapters/store/fs.js";
+import { FakeVerification } from "../../src/adapters/verification/fake.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import { validateOrThrow } from "../../src/application/config-validator.js";
+import {
+  buildPrFirstWiring,
+  resolvePrFirstSettings,
+} from "../../src/cli/pr-first-wiring.js";
+import { MACHINE_BLOCK_SECRET_ENV_DEFAULT } from "../../src/application/machine-block.js";
+import { SystemClock } from "../../src/ports/clock.js";
+
+function targetWith(extras: Record<string, unknown>): unknown {
+  return {
+    identity: {
+      target_id: "demo-target",
+      workdir_path: "/tmp/x",
+      audit_hash_seed: "seed",
+    },
+    agent_profiles: {
+      atlas: { runner: "fake" },
+      forge: { runner: "fake" },
+      sentinel: { runner: "fake" },
+      scout: { runner: "fake" },
+    },
+    ...extras,
+  };
+}
+
+describe("Phase 5 — target.json schema (experiments + governance)", () => {
+  it("(a) experiments omitted → lead_pr_first/reviewer_pr_first default false", () => {
+    const cfg = validateOrThrow(targetWith({}));
+    const settings = resolvePrFirstSettings(cfg);
+    expect(settings.leadPrFirst).toBe(false);
+    expect(settings.reviewerPrFirst).toBe(false);
+  });
+
+  it("(b) experiments.lead_pr_first=true / reviewer_pr_first=true round-trip", () => {
+    const cfg = validateOrThrow(
+      targetWith({
+        experiments: { lead_pr_first: true, reviewer_pr_first: true },
+      }),
+    );
+    const settings = resolvePrFirstSettings(cfg);
+    expect(settings.leadPrFirst).toBe(true);
+    expect(settings.reviewerPrFirst).toBe(true);
+  });
+
+  it("(c) governance.machine_block_secret_env_name overrides the default name", () => {
+    const cfg = validateOrThrow(
+      targetWith({
+        governance: {
+          human_team: "team-a",
+          control_issue_number: 1,
+          contract_change_issue_number: 2,
+          machine_block_secret_env_name: "CUSTOM_SECRET",
+        },
+      }),
+    );
+    const settings = resolvePrFirstSettings(cfg);
+    expect(settings.machineBlockSecretEnvName).toBe("CUSTOM_SECRET");
+  });
+
+  it("(d) default machine_block_secret_env_name = LLM_TEAM_MACHINE_BLOCK_SECRET", () => {
+    const cfg = validateOrThrow(targetWith({}));
+    const settings = resolvePrFirstSettings(cfg);
+    expect(settings.machineBlockSecretEnvName).toBe(
+      MACHINE_BLOCK_SECRET_ENV_DEFAULT,
+    );
+  });
+
+  it("(e) governance.bot_account / known_agent_profile_ids round-trip", () => {
+    const cfg = validateOrThrow(
+      targetWith({
+        governance: {
+          human_team: "team-a",
+          control_issue_number: 1,
+          contract_change_issue_number: 2,
+          bot_account: "llm-team-bot[bot]",
+          known_agent_profile_ids: ["atlas", "sentinel"],
+        },
+      }),
+    );
+    const settings = resolvePrFirstSettings(cfg);
+    expect(settings.expectedBotAccount).toBe("llm-team-bot[bot]");
+    expect(settings.knownAgentProfileIds).toEqual(["atlas", "sentinel"]);
+  });
+
+  it("(f) default known_agent_profile_ids = atlas/forge/sentinel/scout", () => {
+    const cfg = validateOrThrow(targetWith({}));
+    const settings = resolvePrFirstSettings(cfg);
+    expect(settings.knownAgentProfileIds).toEqual([
+      "atlas",
+      "forge",
+      "sentinel",
+      "scout",
+    ]);
+  });
+
+  it("(g) bot_account omitted → expectedBotAccount === undefined (legacy permissive author)", () => {
+    const cfg = validateOrThrow(targetWith({}));
+    const settings = resolvePrFirstSettings(cfg);
+    expect(settings.expectedBotAccount).toBeUndefined();
+  });
+});
+
+describe("Phase 5 — buildPrFirstWiring", () => {
+  function buildDeps(opts: { withLlm: boolean }) {
+    const workdir = mkdtempSync(join(tmpdir(), "phase5-wiring-"));
+    const store = new FsStore({ workdir });
+    const clock = new SystemClock();
+    const ledger = new FileLedger({ store });
+    const cfg = validateOrThrow(
+      targetWith({
+        experiments: { lead_pr_first: true, reviewer_pr_first: true },
+        governance: {
+          human_team: "team-a",
+          control_issue_number: 1,
+          contract_change_issue_number: 2,
+          bot_account: "llm-team-bot[bot]",
+        },
+      }),
+    );
+    return {
+      cfg,
+      deps: {
+        store,
+        clock,
+        ledger,
+        llmRunner: opts.withLlm
+          ? ({} as unknown as Parameters<typeof buildPrFirstWiring>[0]["llmRunner"])
+          : null,
+        workspace: new FakeWorkspace(join(workdir, "ws")),
+        gitHost: new FsMirrorGitHost(store),
+        verification: new FakeVerification(clock),
+        callerId: "phase5-test",
+        targetId: cfg.identity.target_id,
+        machineBlockSecret: "test-secret",
+        settings: resolvePrFirstSettings(cfg),
+      },
+    };
+  }
+
+  it("(h) llmRunner supplied → LeadInvoker + ReviewerInvoker constructed", () => {
+    const { deps } = buildDeps({ withLlm: true });
+    const wiring = buildPrFirstWiring(deps);
+    expect(wiring.leadInvoker).not.toBeNull();
+    expect(wiring.reviewerInvoker).not.toBeNull();
+    expect(wiring.prWatcher).toBeDefined();
+    expect(wiring.prFirstDispatcher).toBeDefined();
+    expect(wiring.recoveryCoordinator).toBeDefined();
+    expect(wiring.outbox).toBeDefined();
+    expect(wiring.droppedSignalCache).toBeDefined();
+  });
+
+  it("(i) llmRunner null (recovery role parity) → invokers null but watcher/dispatcher/recovery still built", () => {
+    const { deps } = buildDeps({ withLlm: false });
+    const wiring = buildPrFirstWiring(deps);
+    expect(wiring.leadInvoker).toBeNull();
+    expect(wiring.reviewerInvoker).toBeNull();
+    expect(wiring.prWatcher).toBeDefined();
+    expect(wiring.prFirstDispatcher).toBeDefined();
+    expect(wiring.recoveryCoordinator).toBeDefined();
+  });
+});

--- a/tests/integration/pr-first-wiring-cfg.test.ts
+++ b/tests/integration/pr-first-wiring-cfg.test.ts
@@ -18,7 +18,7 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FsMirrorGitHost } from "../../src/adapters/git-host/fs-mirror.js";
 import { FsStore } from "../../src/adapters/store/fs.js";
 import { FakeVerification } from "../../src/adapters/verification/fake.js";
@@ -27,6 +27,7 @@ import { FileLedger } from "../../src/application/ledger.js";
 import { validateOrThrow } from "../../src/application/config-validator.js";
 import {
   buildPrFirstWiring,
+  resolveMachineBlockSecretIfPrFirstEnabled,
   resolvePrFirstSettings,
 } from "../../src/cli/pr-first-wiring.js";
 import { MACHINE_BLOCK_SECRET_ENV_DEFAULT } from "../../src/application/machine-block.js";
@@ -183,5 +184,57 @@ describe("Phase 5 — buildPrFirstWiring", () => {
     expect(wiring.prWatcher).toBeDefined();
     expect(wiring.prFirstDispatcher).toBeDefined();
     expect(wiring.recoveryCoordinator).toBeDefined();
+  });
+
+  it("(j) PR #125 P1-1 — machineBlockSecret null + llmRunner non-null → invokers null (envelope-only deployment)", () => {
+    const { deps } = buildDeps({ withLlm: true });
+    const wiring = buildPrFirstWiring({ ...deps, machineBlockSecret: null });
+    expect(wiring.leadInvoker).toBeNull();
+    expect(wiring.reviewerInvoker).toBeNull();
+    // Non-invoker components still build so recovery role parity works.
+    expect(wiring.prWatcher).toBeDefined();
+    expect(wiring.prFirstDispatcher).toBeDefined();
+    expect(wiring.recoveryCoordinator).toBeDefined();
+    expect(wiring.outbox).toBeDefined();
+  });
+});
+
+describe("Phase 5 — resolveMachineBlockSecretIfPrFirstEnabled (PR #125 P1-1)", () => {
+  const ENV_NAME = "LLM_TEAM_MACHINE_BLOCK_SECRET";
+  let prev: string | undefined;
+  beforeEach(() => {
+    prev = process.env[ENV_NAME];
+  });
+  afterEach(() => {
+    if (prev == null) delete process.env[ENV_NAME];
+    else process.env[ENV_NAME] = prev;
+  });
+
+  it("(k) both toggles off + secret unset → returns null (envelope-only deploy boots)", () => {
+    delete process.env[ENV_NAME];
+    const cfg = validateOrThrow(targetWith({}));
+    expect(resolveMachineBlockSecretIfPrFirstEnabled(cfg, process.env)).toBeNull();
+  });
+
+  it("(l) lead_pr_first=true + secret unset → throws", () => {
+    delete process.env[ENV_NAME];
+    const cfg = validateOrThrow(
+      targetWith({ experiments: { lead_pr_first: true } }),
+    );
+    expect(() =>
+      resolveMachineBlockSecretIfPrFirstEnabled(cfg, process.env),
+    ).toThrow(/LLM_TEAM_MACHINE_BLOCK_SECRET/);
+  });
+
+  it("(m) reviewer_pr_first=true + secret set → returns the secret", () => {
+    const cfg = validateOrThrow(
+      targetWith({ experiments: { reviewer_pr_first: true } }),
+    );
+    expect(
+      resolveMachineBlockSecretIfPrFirstEnabled(cfg, {
+        ...process.env,
+        [ENV_NAME]: "live-secret",
+      }),
+    ).toBe("live-secret");
   });
 });

--- a/tests/integration/runner-llm-wiring.test.ts
+++ b/tests/integration/runner-llm-wiring.test.ts
@@ -58,13 +58,18 @@ function captureStdout(): { restore: () => void; lines: () => string[] } {
 describe("Phase 7a — runner CLI production LLM runner wiring (G1-1)", () => {
   let prevFixtureDir: string | undefined;
   let prevAllowFake: string | undefined;
+  let prevMachineSecret: string | undefined;
 
   beforeEach(() => {
     prevFixtureDir = process.env.LLM_TEAM_FAKE_FIXTURE_DIR;
     prevAllowFake = process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
+    prevMachineSecret = process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
     // PR #73 review (P1): test-only opt-in for `runner: "fake"` in the
     // production CLI wiring path.
     process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = "1";
+    // Phase 5 (audit §5-D): runner boots fail-loud without the machine-block
+    // secret. Tests opt in with a deterministic placeholder.
+    process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = "test-machine-block-secret";
   });
 
   afterEach(() => {
@@ -72,6 +77,9 @@ describe("Phase 7a — runner CLI production LLM runner wiring (G1-1)", () => {
     else process.env.LLM_TEAM_FAKE_FIXTURE_DIR = prevFixtureDir;
     if (prevAllowFake == null) delete process.env.LLM_TEAM_ALLOW_FAKE_RUNNER;
     else process.env.LLM_TEAM_ALLOW_FAKE_RUNNER = prevAllowFake;
+    if (prevMachineSecret == null)
+      delete process.env.LLM_TEAM_MACHINE_BLOCK_SECRET;
+    else process.env.LLM_TEAM_MACHINE_BLOCK_SECRET = prevMachineSecret;
   });
 
   it("--once --agent-profile forge boots from cfg without --fake-llm-fixtures", async () => {


### PR DESCRIPTION
## Summary
- audit P0-1 해소: `daemon.ts` / `runner.ts` 의 PR-first activation wiring 완성. Phase 1~4 의 ~3000 LOC (LeadInvoker / ReviewerInvoker / PrWatcher / PrFirstDispatcher / RecoveryCoordinator) 가 daemon 에서 한 번도 호출되지 않던 dead infra 상태를 종결.
- `target.json` schema 확장 (additive): `experiments.lead_pr_first` / `experiments.reviewer_pr_first` toggle + `governance.machine_block_secret_env_name` / `bot_account` / `known_agent_profile_ids` 필드.
- 인스턴스화 + daemon role 주입 (turn-worker / outer-coordinator / dialogue-coordinator / recovery) + cycle prelude PrWatcher 폴링 → PrFirstDispatcher 라우팅.
- default `false` 유지 — envelope path regression 0.

근거: `~/.claude/plans/cli-spicy-anchor.md` Phase 5 + `docs/history/2026-05-12-pr-first-audit.md` §5-D 사용자 결정 + codex-reviewer mainline audit P0-1.

### 변경 내용
| Module | Artifact | Notes |
|---|---|---|
| `src/config/target-schema.ts` | `Experiments` + `Governance` 확장 | 모두 optional/default — 기존 fixture 영향 0 |
| `src/cli/pr-first-wiring.ts` (신규) | `resolvePrFirstSettings` + `buildPrFirstWiring` | LLM-dependent invoker 는 `llmRunner` 가 null 일 때 skip (recovery role 호환) |
| `src/cli/pr-watcher-cycle.ts` (신규) | `runPrWatcherCyclePrelude` | open ReviewSurface 스캔 → poll → applied verdict → PrFirstDispatcher |
| `src/cli/daemon.ts` | fail-loud secret + 4-role wiring + cycle prelude + recovery sweep | gating on `experiments.*` 으로 envelope path 무영향 |
| `src/cli/runner.ts` | 동일 wiring (single-shot, prelude 제외) | |
| 기존 daemon/runner 5 테스트 | `LLM_TEAM_MACHINE_BLOCK_SECRET` setup 추가 | fail-loud DoD 의 정상적 부산물 |
| `tests/e2e/pr-first-wiring-mock.test.ts` (신규, 6 case) | secret/toggle/role 별 부팅 smoke | |
| `tests/integration/pr-first-wiring-cfg.test.ts` (신규, 9 case) | schema round-trip + factory | |

## Test plan
- [x] secret env var 미설정 → daemon 부팅 fail-loud (e2e (a))
- [x] custom env-var 이름 라우팅 (e2e (b))
- [x] default false → envelope path 유지 noop (e2e (c))
- [x] `experiments.lead_pr_first=true` → turn-worker / outer-coordinator 부팅 (e2e (d))
- [x] `experiments.reviewer_pr_first=true` → dialogue-coordinator 부팅 (e2e (e))
- [x] recovery role → `RecoveryCoordinator.runOnce` 호출 + counter surface (e2e (f))
- [x] schema additive: 기존 target.json fixture 0 영향, 새 필드 round-trip (integration (a)-(g))
- [x] `buildPrFirstWiring` factory: invoker null/non-null 분기 (integration (h)-(i))
- [x] 기존 1131 tests 0 regression — 1146 passing (+15 신규)
- [x] typecheck/build clean
- [x] secret 평문 노출 0 회귀: `machineBlockSecret` 은 HMAC computation 외 ledger/prompt/store 어디에도 전달되지 않음

### Out of scope (별도 issue 후보)
- `RecoveryCoordinator.buildProbe` production 구현 — 현재는 no-op probe 라 `recovered_skipped: no_probe` 만 emit. P0-1 wiring 은 호출 자체가 dod.
- audit doc 의 P1 (cycle prelude trunkRevision live resolution / `unauthorized_author_alert` action) / P2 는 별도 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)