### PR TITLE
feat(recovery): wire production probe routing for RecoveryCoordinator

### DIFF
--- a/src/application/lead-invoker.ts
+++ b/src/application/lead-invoker.ts
@@ -341,6 +341,11 @@ export class LeadInvoker {
       turnIndex: input.turnIndex,
       agentProfileId: input.agentProfileId,
       loopKind: input.parentLoop,
+      // PR #127 review P1-1 (gpt5.5): persist routing hints so the
+      // recovery probe builder can recover the Case A crash window
+      // between this `outbox.begin` and the Step 8 ReviewSurface write.
+      // Without these the probe builder fell back to `no_probe`.
+      payload: { branch: input.branch, trailerKey },
     });
     let commitSha: string;
     try {
@@ -396,6 +401,8 @@ export class LeadInvoker {
       turnIndex: input.turnIndex,
       agentProfileId: input.agentProfileId,
       loopKind: input.parentLoop,
+      // PR #127 review P1-1: surface-less probe hints.
+      payload: { branch: input.branch, headSha: commitSha, remote: remoteName },
     });
     try {
       await this.deps.workspace.push({
@@ -485,6 +492,11 @@ export class LeadInvoker {
       turnIndex: input.turnIndex,
       agentProfileId: input.agentProfileId,
       loopKind: input.parentLoop,
+      // PR #127 review P1-1: surface-less probe hints for the initial
+      // pr_open_op crash window (Case A). pr_update_op already has a
+      // persisted surface via input.existingSurface so the branch hint is
+      // harmless redundancy there.
+      payload: { branch: input.branch, headSha: commitSha },
     });
     let prRef: ExternalRefHandle;
     try {

--- a/src/application/outbox.ts
+++ b/src/application/outbox.ts
@@ -173,6 +173,26 @@ export interface OutboxScanInput {
    * receipt schema; receipt knowledge stays in the caller (plan §7-3).
    */
   hasMatchingReceipt: (idempotencyKey: string) => Promise<boolean>;
+  /**
+   * PR #127 review P1-2 (gpt5.5): slot-scoped receipt check.
+   *
+   * Live lead receipt records only the terminal `pr_open_op` / `pr_update_op`
+   * idempotency key (`k3`), not the per-step `commit_op` (`k1`) or `push_op`
+   * (`k2`) keys. Without this hook, every normally-completed lead turn
+   * resurfaces its commit/push posted rows as `posted_without_receipt`
+   * candidates on every sweep (the live receipt does not match `k1`/`k2`).
+   * The receipt's `(session_id, turn_index)` slot is the canonical
+   * "turn covered" marker — if any receipt exists for the slot tied to a
+   * pending outbox row, the lead/reviewer chain is considered covered and
+   * we skip the duplicate Case B candidate.
+   *
+   * Optional: callers that only have the key→presence index can omit this
+   * (legacy behaviour preserved).
+   */
+  hasReceiptForSlot?: (
+    sessionId: string,
+    turnIndex: number,
+  ) => Promise<boolean>;
 }
 
 export interface OutboxDeps {
@@ -451,6 +471,11 @@ export class Outbox {
         hasPosted: boolean;
         hasFailed: boolean;
         hasRecovered: boolean;
+        // PR #127 review P1-2: slot tuple captured from the pending row so
+        // the Case B scan can fall back to a turn-scoped receipt check when
+        // the per-op key (k1/k2) doesn't match the live receipt's k3.
+        sessionId: string | null;
+        turnIndex: number | null;
       }
     >();
 
@@ -470,10 +495,20 @@ export class Outbox {
         hasPosted: false,
         hasFailed: false,
         hasRecovered: false,
+        sessionId: null,
+        turnIndex: null,
       };
       switch (row.action_kind) {
         case "outbox_pending":
           cur.hasPending = true;
+          // Only the pending row carries the receipt slot tuple (invokers
+          // populate session_id / turn_index on outbox.begin). Capture once.
+          if (cur.sessionId == null && row.session_id != null) {
+            cur.sessionId = row.session_id;
+          }
+          if (cur.turnIndex == null && row.turn_index != null) {
+            cur.turnIndex = row.turn_index;
+          }
           break;
         case "outbox_posted":
           cur.hasPosted = true;
@@ -504,14 +539,36 @@ export class Outbox {
           mode: "pending_without_posted",
         });
       } else if (v.hasPosted) {
+        // PR #127 review P1-2 (gpt5.5): dedup — once a recovery sweep has
+        // emitted `outbox_recovered` for this (op_kind, key), do not re-list
+        // it as a Case B candidate on subsequent sweeps. The
+        // RecoveryCoordinator handles the receipt backfill itself; further
+        // sweeps would only repeat that no-op.
+        if (v.hasRecovered) continue;
         const receiptOk = await input.hasMatchingReceipt(v.key);
-        if (!receiptOk) {
-          candidates.push({
-            opKind: v.opKind,
-            idempotencyKey: v.key,
-            mode: "posted_without_receipt",
-          });
+        if (receiptOk) continue;
+        // Slot-scoped fallback: lead-invoker writes one receipt per turn
+        // keyed by the terminal `k3` (pr_open/pr_update). The earlier
+        // `commit_op` / `push_op` posted rows carry distinct keys (`k1`/`k2`)
+        // and never match `hasMatchingReceipt`. If any receipt exists for
+        // the same `(session_id, turn_index)` slot as the pending row, the
+        // turn is covered and we skip the duplicate candidate.
+        if (
+          input.hasReceiptForSlot != null &&
+          v.sessionId != null &&
+          v.turnIndex != null
+        ) {
+          const slotOk = await input.hasReceiptForSlot(
+            v.sessionId,
+            v.turnIndex,
+          );
+          if (slotOk) continue;
         }
+        candidates.push({
+          opKind: v.opKind,
+          idempotencyKey: v.key,
+          mode: "posted_without_receipt",
+        });
       }
     }
     return candidates;

--- a/src/application/recovery-coordinator.ts
+++ b/src/application/recovery-coordinator.ts
@@ -189,9 +189,14 @@ export class RecoveryCoordinator {
    */
   async runOnce(): Promise<RecoverySweepResult> {
     // Cache receipts once per sweep.
-    const receipts = await this.indexReceipts();
+    const { keys: receiptKeys, slots: receiptSlots } = await this.indexReceipts();
     const candidates = await this.deps.outbox.scanRecoveryCandidatesFromLedger({
-      hasMatchingReceipt: async (k) => receipts.has(k),
+      hasMatchingReceipt: async (k) => receiptKeys.has(k),
+      // PR #127 review P1-2: turn-scoped fallback so commit_op/push_op
+      // posted rows aren't re-listed forever just because the live lead
+      // receipt only stores the terminal pr_open_op key.
+      hasReceiptForSlot: async (sessionId, turnIndex) =>
+        receiptSlots.has(`${sessionId}::${turnIndex}`),
     });
     const items: RecoveryItemOutcome[] = [];
     const pendingRows = await this.indexPendingOutboxRows();
@@ -330,13 +335,17 @@ export class RecoveryCoordinator {
   // Ledger introspection helpers
   // -------------------------------------------------------------
 
-  private async indexReceipts(): Promise<Set<string>> {
-    const out = new Set<string>();
+  private async indexReceipts(): Promise<{
+    keys: Set<string>;
+    slots: Set<string>;
+  }> {
+    const keys = new Set<string>();
+    const slots = new Set<string>();
     let names: string[];
     try {
       names = await this.deps.store.list("intents");
     } catch {
-      return out;
+      return { keys, slots };
     }
     for (const n of names) {
       if (!n.endsWith(".receipt.json")) continue;
@@ -348,9 +357,13 @@ export class RecoveryCoordinator {
       } catch {
         continue;
       }
-      out.add(receipt.idempotency_key);
+      keys.add(receipt.idempotency_key);
+      // PR #127 review P1-2: index by `(session_id, turn_index)` slot so
+      // the Case B scan can recognise a turn as covered even when the
+      // pending row's per-op key doesn't match the receipt's key.
+      slots.add(`${receipt.session_id}::${receipt.turn_index}`);
     }
-    return out;
+    return { keys, slots };
   }
 
   /**

--- a/src/application/recovery-coordinator.ts
+++ b/src/application/recovery-coordinator.ts
@@ -101,6 +101,13 @@ export interface PendingOutboxRow {
   targetId: string;
   objectId: string;
   manifestId: string | null;
+  /**
+   * Raw `result_detail` from the pending ledger row. Issue #126: production
+   * probe routing for label/dismiss op_kinds reads `{ label }` /
+   * `{ externalReviewId }` from this field once Phase 6+ invokers populate
+   * it via `Outbox.begin({ payload })`. Null for current invokers.
+   */
+  resultDetail: string | null;
 }
 
 export interface RecoveryCoordinatorDeps {
@@ -154,10 +161,25 @@ export interface RecoverySweepResult {
 // --------------------------------------------------------------------------
 
 export class RecoveryCoordinator {
+  private buildProbe: ProbeBuilder;
+
   constructor(
     private readonly cfg: RecoveryCoordinatorCfg,
     private readonly deps: RecoveryCoordinatorDeps,
-  ) {}
+  ) {
+    this.buildProbe = deps.buildProbe;
+  }
+
+  /**
+   * Issue #126: late-bound probe builder. `buildPrFirstWiring` constructs
+   * the coordinator with a stub probe builder so non-recovery daemon
+   * roles can still receive the wiring without paying the production
+   * probe construction cost. The recovery role calls this once per sweep
+   * to install the role-specific routing.
+   */
+  setProbeBuilder(builder: ProbeBuilder): void {
+    this.buildProbe = builder;
+  }
 
   /**
    * One sweep. Daemon invokes this at boot and on a periodic timer.
@@ -198,7 +220,7 @@ export class RecoveryCoordinator {
         reason: "missing_pending_row",
       };
     }
-    const probe = await this.deps.buildProbe(candidate, pending);
+    const probe = await this.buildProbe(candidate, pending);
     if (probe == null) {
       return { kind: "recovered_skipped", candidate, reason: "no_probe" };
     }
@@ -370,6 +392,7 @@ export class RecoveryCoordinator {
         targetId: row.target_id,
         objectId: row.object_id,
         manifestId: row.manifest_id,
+        resultDetail: row.result_detail,
       });
     }
     return map;

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -70,6 +70,7 @@ import {
   resolvePrFirstSettings,
 } from "./pr-first-wiring.js";
 import { runPrWatcherCyclePrelude } from "./pr-watcher-cycle.js";
+import { buildProductionProbeBuilder } from "./recovery-probe-builder.js";
 
 type DaemonRole =
   | "turn-worker"
@@ -592,10 +593,19 @@ async function main(argv: readonly string[]): Promise<number> {
           // Phase 4 lease-sweep already ran above. Phase 5 audit P0-1
           // additionally invokes the PR-first `RecoveryCoordinator` so
           // outbox crash-recovery (Case A pending_without_posted, Case B
-          // posted_without_receipt) ledger rows are surfaced. The default
-          // `buildProbe` returns null (no provider-specific probe is wired
-          // here yet) so candidates report `recovered_skipped: no_probe`
-          // until a probe builder lands — but the sweep itself runs.
+          // posted_without_receipt) ledger rows are surfaced. Issue #126:
+          // production probe routing is wired here (role-specific port
+          // resolution per pr-first-wiring.ts contract) — the coordinator
+          // built by `buildPrFirstWiring` defaults to a stub `buildProbe`
+          // that the daemon overrides before each sweep so candidates
+          // actually recover instead of reporting `recovered_skipped: no_probe`.
+          prFirstWiring.recoveryCoordinator.setProbeBuilder(
+            buildProductionProbeBuilder({
+              store,
+              workspace,
+              gitHost,
+            }),
+          );
           const recoveryResult = await prFirstWiring.recoveryCoordinator.runOnce();
           outcomeJson = JSON.stringify({
             role: args.role,

--- a/src/cli/recovery-probe-builder.ts
+++ b/src/cli/recovery-probe-builder.ts
@@ -1,0 +1,271 @@
+/**
+ * Production probe routing for `RecoveryCoordinator.buildProbe` (issue #126).
+ *
+ * PR #125 (audit P0-1) wired `RecoveryCoordinator.runOnce()` into the daemon
+ * recovery role, but left `buildProbe: async () => null` so every candidate
+ * was reported as `recovered_skipped: no_probe`. The sweep ran but recovered
+ * 0 candidates — a dead-zone risk for outbox crash recovery.
+ *
+ * This module owns the per-`op_kind` probe construction. The daemon entry
+ * (`case "recovery"`) plugs the returned `ProbeBuilder` into the coordinator
+ * before invoking the sweep. Keeping the routing here (not in
+ * `pr-first-wiring.ts`) preserves role-specific port resolution per issue
+ * #126: the production GitHostPort adapter selection is a Phase 6+ concern
+ * (current wiring uses `FsMirrorGitHost`), and only the recovery role needs
+ * the probe paths.
+ *
+ * Probe map (cli-spicy-anchor.md §7-2):
+ *
+ *   | op_kind            | port             | method                            |
+ *   |--------------------|------------------|-----------------------------------|
+ *   | commit_op          | WorkspacePort    | findCommitByTrailer               |
+ *   | push_op            | WorkspacePort    | getRemoteHeadSha                  |
+ *   | pr_open_op         | GitHostPort      | findOpenPullRequestByMachineKey   |
+ *   | pr_update_op       | GitHostPort      | findPullRequestByBodyMachineKey   |
+ *   | submit_review_op   | GitHostPort      | findReviewByMachineKey            |
+ *   | merge_op           | GitHostPort      | getPullRequestMergeState          |
+ *   | add_label_op       | GitHostPort      | listLabels                        |
+ *   | remove_label_op    | GitHostPort      | listLabels                        |
+ *   | dismiss_review_op  | GitHostPort      | getReview                         |
+ *
+ * Resolution strategy:
+ *
+ *   - `pending.objectId` (and/or `pending.surfaceRef`) is the
+ *     `review_surface_id`. The probe builder loads the ReviewSurface JSON
+ *     and reads:
+ *       - `surface.branch`         → commit_op/push_op/pr_open_op headBranch
+ *       - `surface.pr_ref`         → ExternalRefHandle for PR ops
+ *   - When the surface is absent (e.g. `pr_open_op` first attempt that
+ *     crashed before the surface was persisted) the probe builder returns
+ *     `null`, and the coordinator emits `recovered_skipped: no_probe` for
+ *     that candidate. This is the correct fallback — the recovery path is
+ *     only deterministic when the originating invoker persisted enough
+ *     context onto the pending row / surface.
+ *
+ * Configuration:
+ *
+ *   - `trailerKey` defaults to `Idempotency-Key` matching
+ *     `lead-invoker.DEFAULT_TRAILER_KEY`.
+ *   - `remoteName` defaults to `origin` matching
+ *     `lead-invoker.DEFAULT_REMOTE`.
+ *   - `commitTrailerDepth` defaults to 32 (enough to span a few rebuilds
+ *     without scanning the full history). Pass-through unbounded scans are
+ *     avoided so `findCommitByTrailer` does not stall on long branches.
+ */
+import type {
+  PendingOutboxRow,
+  ProbeBuilder,
+} from "../application/recovery-coordinator.js";
+import { layout } from "../application/persistence-layout.js";
+import type { ProbeContext } from "../application/outbox.js";
+import {
+  ReviewSurface,
+  type ReviewSurface as ReviewSurfaceT,
+} from "../domain/schema/review-surface.js";
+import type { ExternalRefHandle } from "../ports/issue-tracker.js";
+import type { GitHostPort } from "../ports/git-host.js";
+import type { StorePort } from "../ports/store.js";
+import type { WorkspacePort } from "../ports/workspace.js";
+
+const DEFAULT_TRAILER_KEY = "Idempotency-Key";
+const DEFAULT_REMOTE = "origin";
+const DEFAULT_COMMIT_TRAILER_DEPTH = 32;
+
+export interface ProductionProbeBuilderDeps {
+  store: StorePort;
+  workspace: WorkspacePort;
+  gitHost: GitHostPort;
+  /** Defaults to "Idempotency-Key" — matches lead-invoker. */
+  trailerKey?: string;
+  /** Defaults to "origin" — matches lead-invoker. */
+  remoteName?: string;
+  /** Bounded walk-back for commit_op probe. Defaults to 32. */
+  commitTrailerDepth?: number;
+}
+
+/**
+ * Build a `ProbeBuilder` whose returned `ProbeContext` is routed to the
+ * actual `WorkspacePort` / `GitHostPort` instances wired in the daemon. The
+ * returned function is the value the daemon plugs into
+ * `RecoveryCoordinator.deps.buildProbe`.
+ */
+export function buildProductionProbeBuilder(
+  deps: ProductionProbeBuilderDeps,
+): ProbeBuilder {
+  const trailerKey = deps.trailerKey ?? DEFAULT_TRAILER_KEY;
+  const remoteName = deps.remoteName ?? DEFAULT_REMOTE;
+  const commitDepth = deps.commitTrailerDepth ?? DEFAULT_COMMIT_TRAILER_DEPTH;
+
+  return async (candidate, pending) => {
+    if (pending == null) return null;
+    const surface = await loadReviewSurface(deps.store, pending);
+
+    switch (candidate.opKind) {
+      case "commit_op": {
+        if (surface == null) return null;
+        const ctx: ProbeContext = {
+          opKind: "commit_op",
+          workspace: deps.workspace,
+          branch: surface.branch,
+          trailerKey,
+          value: candidate.idempotencyKey,
+          depth: commitDepth,
+        };
+        return ctx;
+      }
+      case "push_op": {
+        if (surface == null) return null;
+        const ctx: ProbeContext = {
+          opKind: "push_op",
+          workspace: deps.workspace,
+          remote: remoteName,
+          branch: surface.branch,
+          // Outbox push_op completes by re-reading the remote head; the
+          // expected sha is the head-of-branch as recorded on the surface.
+          // For pending_without_posted (no completed write), `surface.head_sha`
+          // is the local sha the lead-invoker committed before pushing.
+          expectedSha: surface.head_sha,
+        };
+        return ctx;
+      }
+      case "pr_open_op": {
+        if (surface == null) return null;
+        const ctx: ProbeContext = {
+          opKind: "pr_open_op",
+          gitHost: deps.gitHost,
+          headBranch: surface.branch,
+        };
+        return ctx;
+      }
+      case "pr_update_op": {
+        if (surface == null) return null;
+        const ctx: ProbeContext = {
+          opKind: "pr_update_op",
+          gitHost: deps.gitHost,
+          prRef: handleFromSurface(surface),
+        };
+        return ctx;
+      }
+      case "submit_review_op": {
+        if (surface == null) return null;
+        const ctx: ProbeContext = {
+          opKind: "submit_review_op",
+          gitHost: deps.gitHost,
+          prRef: handleFromSurface(surface),
+        };
+        return ctx;
+      }
+      case "merge_op": {
+        if (surface == null) return null;
+        const ctx: ProbeContext = {
+          opKind: "merge_op",
+          gitHost: deps.gitHost,
+          prRef: handleFromSurface(surface),
+        };
+        return ctx;
+      }
+      case "add_label_op":
+      case "remove_label_op": {
+        if (surface == null) return null;
+        const label = pickPayloadString(pending, "label");
+        if (label == null) return null;
+        const ctx: ProbeContext = {
+          opKind: candidate.opKind,
+          gitHost: deps.gitHost,
+          prRef: handleFromSurface(surface),
+          label,
+          expect: candidate.opKind === "add_label_op" ? "present" : "absent",
+        };
+        return ctx;
+      }
+      case "dismiss_review_op": {
+        if (surface == null) return null;
+        const externalReviewId = pickPayloadString(pending, "externalReviewId");
+        if (externalReviewId == null) return null;
+        const ctx: ProbeContext = {
+          opKind: "dismiss_review_op",
+          gitHost: deps.gitHost,
+          prRef: handleFromSurface(surface),
+          externalReviewId,
+        };
+        return ctx;
+      }
+      default: {
+        const _exhaustive: never = candidate.opKind;
+        void _exhaustive;
+        return null;
+      }
+    }
+  };
+}
+
+/**
+ * Try `pending.surfaceRef` first, then `pending.objectId`. Both invoker
+ * code paths put the `review_surface_id` in at least one of these fields:
+ *
+ *   - lead-invoker:    objectId = surfaceId,  surfaceRef = unset (commit/push/pr_open)
+ *   - reviewer-invoker: objectId = surfaceId, surfaceRef = surfaceId
+ *   - caller-dispatch (merge_op): same as reviewer
+ *
+ * Returns null when the surface JSON cannot be parsed (first-attempt
+ * pr_open_op crashes leave the surface unwritten until step 8 of the lead
+ * invoker; that case is correctly reported as `no_probe`).
+ */
+async function loadReviewSurface(
+  store: StorePort,
+  pending: PendingOutboxRow,
+): Promise<ReviewSurfaceT | null> {
+  const candidates = [pending.surfaceRef, pending.objectId].filter(
+    (v): v is string => v != null && v.length > 0,
+  );
+  for (const id of candidates) {
+    let path: string;
+    try {
+      path = layout.reviewSurface(id);
+    } catch {
+      // `objectId` is not always a ULID (e.g. system rows). Skip and try next.
+      continue;
+    }
+    const body = await store.readText(path);
+    if (body == null || body.length === 0) continue;
+    try {
+      return ReviewSurface.parse(JSON.parse(body));
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function handleFromSurface(surface: ReviewSurfaceT): ExternalRefHandle {
+  return {
+    provider: surface.pr_ref.provider,
+    id: surface.pr_ref.id,
+    url: surface.pr_ref.url,
+  };
+}
+
+/**
+ * Production label/dismiss invokers (Phase 6+) will populate the outbox
+ * pending row's `result_detail` with `{ label: ... }` or
+ * `{ externalReviewId: ... }`. Until those invokers exist this helper
+ * returns null and the probe builder yields a `no_probe` outcome — which
+ * is the correct fallback while no production caller for these op_kinds
+ * exists in the codebase.
+ *
+ * Defensive: result_detail is plain string (may be JSON or non-JSON).
+ */
+function pickPayloadString(
+  pending: PendingOutboxRow,
+  key: "label" | "externalReviewId",
+): string | null {
+  const raw = pending.resultDetail;
+  if (raw == null || raw.length === 0) return null;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const v = parsed[key];
+    return typeof v === "string" && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/recovery-probe-builder.ts
+++ b/src/cli/recovery-probe-builder.ts
@@ -35,12 +35,16 @@
  *     and reads:
  *       - `surface.branch`         → commit_op/push_op/pr_open_op headBranch
  *       - `surface.pr_ref`         → ExternalRefHandle for PR ops
- *   - When the surface is absent (e.g. `pr_open_op` first attempt that
- *     crashed before the surface was persisted) the probe builder returns
- *     `null`, and the coordinator emits `recovered_skipped: no_probe` for
- *     that candidate. This is the correct fallback — the recovery path is
- *     only deterministic when the originating invoker persisted enough
- *     context onto the pending row / surface.
+ *   - When the surface is absent (PR #127 review P1-1, gpt5.5): for
+ *     `commit_op` / `push_op` / `pr_open_op` we fall back to the routing
+ *     hints persisted on the `outbox_pending` row's `result_detail`
+ *     payload (`branch`, `headSha`, `trailerKey`, `remote`). Lead-invoker
+ *     populates these on `outbox.begin` so the Case A crash window between
+ *     `outbox.begin(commit_op|push_op|pr_open_op)` and the ReviewSurface
+ *     write at Step 8 is recoverable without a surface. The other
+ *     `op_kinds` (pr_update/submit_review/merge/label/dismiss) require the
+ *     `pr_ref` from a previously-persisted ReviewSurface and still return
+ *     null when the surface is missing — that is the correct fallback.
  *
  * Configuration:
  *
@@ -99,41 +103,49 @@ export function buildProductionProbeBuilder(
   return async (candidate, pending) => {
     if (pending == null) return null;
     const surface = await loadReviewSurface(deps.store, pending);
+    // PR #127 review P1-1: surface-less fallback hints persisted on the
+    // outbox_pending row's payload by lead-invoker.
+    const hints = readPayloadHints(pending);
 
     switch (candidate.opKind) {
       case "commit_op": {
-        if (surface == null) return null;
+        const branch = surface?.branch ?? hints.branch;
+        if (branch == null) return null;
         const ctx: ProbeContext = {
           opKind: "commit_op",
           workspace: deps.workspace,
-          branch: surface.branch,
-          trailerKey,
+          branch,
+          trailerKey: hints.trailerKey ?? trailerKey,
           value: candidate.idempotencyKey,
           depth: commitDepth,
         };
         return ctx;
       }
       case "push_op": {
-        if (surface == null) return null;
+        const branch = surface?.branch ?? hints.branch;
+        // expectedSha must be known: surface.head_sha after Step 8, or the
+        // headSha hint persisted by lead-invoker on outbox.begin(push_op).
+        const expectedSha = surface?.head_sha ?? hints.headSha;
+        if (branch == null || expectedSha == null) return null;
         const ctx: ProbeContext = {
           opKind: "push_op",
           workspace: deps.workspace,
-          remote: remoteName,
-          branch: surface.branch,
+          remote: hints.remote ?? remoteName,
+          branch,
           // Outbox push_op completes by re-reading the remote head; the
-          // expected sha is the head-of-branch as recorded on the surface.
-          // For pending_without_posted (no completed write), `surface.head_sha`
-          // is the local sha the lead-invoker committed before pushing.
-          expectedSha: surface.head_sha,
+          // expected sha is the head-of-branch as recorded on the surface
+          // (or the lead-invoker hint when the surface is not yet written).
+          expectedSha,
         };
         return ctx;
       }
       case "pr_open_op": {
-        if (surface == null) return null;
+        const headBranch = surface?.branch ?? hints.branch;
+        if (headBranch == null) return null;
         const ctx: ProbeContext = {
           opKind: "pr_open_op",
           gitHost: deps.gitHost,
-          headBranch: surface.branch,
+          headBranch,
         };
         return ctx;
       }
@@ -268,4 +280,45 @@ function pickPayloadString(
   } catch {
     return null;
   }
+}
+
+/**
+ * PR #127 review P1-1 (gpt5.5): surface-less routing hints.
+ *
+ * Lead-invoker populates these on `outbox.begin` for commit_op / push_op /
+ * pr_open_op so a crash between begin and the Step 8 ReviewSurface write is
+ * still recoverable. All fields are optional — missing fields fall through
+ * to defaults (trailerKey/remote) or force a `no_probe` outcome (branch /
+ * headSha when no surface).
+ */
+interface PendingProbeHints {
+  branch?: string;
+  headSha?: string;
+  trailerKey?: string;
+  remote?: string;
+}
+
+function readPayloadHints(pending: PendingOutboxRow): PendingProbeHints {
+  const raw = pending.resultDetail;
+  if (raw == null || raw.length === 0) return {};
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+  const out: PendingProbeHints = {};
+  if (typeof parsed.branch === "string" && parsed.branch.length > 0) {
+    out.branch = parsed.branch;
+  }
+  if (typeof parsed.headSha === "string" && parsed.headSha.length > 0) {
+    out.headSha = parsed.headSha;
+  }
+  if (typeof parsed.trailerKey === "string" && parsed.trailerKey.length > 0) {
+    out.trailerKey = parsed.trailerKey;
+  }
+  if (typeof parsed.remote === "string" && parsed.remote.length > 0) {
+    out.remote = parsed.remote;
+  }
+  return out;
 }

--- a/tests/cli/recovery-probe-builder.test.ts
+++ b/tests/cli/recovery-probe-builder.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Issue #126 — production probe routing unit tests.
+ *
+ * Covers per-`op_kind` probe construction by `buildProductionProbeBuilder`:
+ *
+ *   - non-null probe shapes for all 9 op_kinds when the supporting context
+ *     (ReviewSurface JSON, result_detail payload) is present;
+ *   - null fallback when the surface is absent (pr_open_op first attempt)
+ *     or label/dismiss payload is missing — the RecoveryCoordinator emits
+ *     `recovered_skipped: no_probe` for those, which is the correct
+ *     fallback rather than a dead-zone regression.
+ *
+ * Each probe is then executed via `runOutboxProbe` against the fake
+ * adapters to confirm routing actually resolves to the right port method.
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { FsMirrorGitHost } from "../../src/adapters/git-host/fs-mirror.js";
+import { MemoryStore } from "../../src/adapters/store/memory.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { layout } from "../../src/application/persistence-layout.js";
+import { runOutboxProbe } from "../../src/application/outbox.js";
+import type { PendingOutboxRow } from "../../src/application/recovery-coordinator.js";
+import type { OutboxRecoveryCandidate } from "../../src/application/outbox.js";
+import { buildProductionProbeBuilder } from "../../src/cli/recovery-probe-builder.js";
+import type { ReviewSurface as ReviewSurfaceT } from "../../src/domain/schema/review-surface.js";
+
+const TARGET = "demo";
+const CALLER = "test-caller";
+const SURFACE_ID = "01HZSR0000000000000000000A";
+const SLICE_ID = "01HZS00000000000000000000A";
+const BRANCH = `slice/${SLICE_ID}`;
+const HEAD_SHA = "abc1234567890abcdef1234567890abcdef1234";
+
+async function seedSurface(
+  store: MemoryStore,
+  overrides: Partial<ReviewSurfaceT> = {},
+): Promise<ReviewSurfaceT> {
+  const surface: ReviewSurfaceT = {
+    review_surface_id: SURFACE_ID,
+    parent_kind: "slice",
+    parent_id: SLICE_ID,
+    parent_phase: null,
+    pr_ref: {
+      provider: "fs_mirror",
+      id: "1",
+      node_id: null,
+      url: "fs-mirror://prs/1",
+    },
+    branch: BRANCH,
+    base_ref: "main",
+    head_sha: HEAD_SHA,
+    review_round: 0,
+    lifecycle_state: "open",
+    review_state: "pending_review",
+    build_state: "ready",
+    latest_verification_run_id: null,
+    last_synced_external_revision: null,
+    created_at: "2026-05-10T00:00:00.000Z",
+    updated_at: "2026-05-10T00:00:00.000Z",
+    ...overrides,
+  };
+  await store.writeAtomic(
+    layout.reviewSurface(SURFACE_ID),
+    JSON.stringify(surface),
+  );
+  return surface;
+}
+
+function pending(
+  opKind: PendingOutboxRow["opKind"],
+  overrides: Partial<PendingOutboxRow> = {},
+): PendingOutboxRow {
+  return {
+    opKind,
+    idempotencyKey: "K-TEST",
+    surfaceRef: SURFACE_ID,
+    sessionId: null,
+    turnIndex: null,
+    agentProfileId: null,
+    loopKind: null,
+    callerId: CALLER,
+    targetId: TARGET,
+    objectId: SURFACE_ID,
+    manifestId: null,
+    resultDetail: null,
+    ...overrides,
+  };
+}
+
+function candidate(
+  opKind: OutboxRecoveryCandidate["opKind"],
+  key = "K-TEST",
+): OutboxRecoveryCandidate {
+  return { opKind, idempotencyKey: key, mode: "pending_without_posted" };
+}
+
+function makeDeps() {
+  const store = new MemoryStore();
+  const gitHost = new FsMirrorGitHost(store);
+  const wsRoot = mkdtempSync(join(tmpdir(), "rpb-"));
+  const workspace = new FakeWorkspace(wsRoot);
+  return { store, gitHost, workspace };
+}
+
+describe("buildProductionProbeBuilder · per-op_kind routing", () => {
+  it("commit_op → non-null probe; routes to workspace.findCommitByTrailer", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    await seedSurface(store);
+    const idemKey = "K-COMMIT";
+    workspace.seedCommitTrailer(BRANCH, "commit-sha-A", {
+      "Idempotency-Key": idemKey,
+    });
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("commit_op", idemKey),
+      pending("commit_op", { idempotencyKey: idemKey }),
+    );
+    expect(probe).not.toBeNull();
+    expect(probe!.opKind).toBe("commit_op");
+    const probeRes = await runOutboxProbe({
+      ...(probe!),
+      // Outbox.recover injects idempotencyKey before calling runOutboxProbe.
+      idempotencyKey: idemKey,
+    } as unknown as Parameters<typeof runOutboxProbe>[0]);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe("commit-sha-A");
+  });
+
+  it("push_op → non-null probe; routes to workspace.getRemoteHeadSha", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    workspace.seedRemoteHead("origin", surface.branch, surface.head_sha);
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(candidate("push_op"), pending("push_op"));
+    expect(probe).not.toBeNull();
+    expect(probe!.opKind).toBe("push_op");
+    const probeRes = await runOutboxProbe(probe!);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe(surface.head_sha);
+  });
+
+  it("pr_open_op → non-null probe; routes to gitHost.findOpenPullRequestByMachineKey", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    const idemKey = "K-OPEN";
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: `body\n<!-- llm-team:pr-machine\nidempotency_key: ${idemKey}\n-->`,
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("pr_open_op", idemKey),
+      pending("pr_open_op", { idempotencyKey: idemKey }),
+    );
+    expect(probe).not.toBeNull();
+    expect(probe!.opKind).toBe("pr_open_op");
+    const probeRes = await runOutboxProbe({
+      ...(probe!),
+      idempotencyKey: idemKey,
+    } as unknown as Parameters<typeof runOutboxProbe>[0]);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe(opened.id);
+  });
+
+  it("pr_open_op without surface → null (no_probe fallback for first-attempt crash)", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    // No surface seeded.
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("pr_open_op"),
+      pending("pr_open_op"),
+    );
+    expect(probe).toBeNull();
+  });
+
+  it("pr_update_op → non-null probe; routes to gitHost.findPullRequestByBodyMachineKey", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    const idemKey = "K-UPDATE";
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await gitHost.updatePullRequestBody({
+      prRef: opened,
+      body: `body\n<!-- llm-team:pr-machine\nidempotency_key: ${idemKey}\n-->`,
+    });
+    // Surface pr_ref already points at the opened PR.
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("pr_update_op", idemKey),
+      pending("pr_update_op", { idempotencyKey: idemKey }),
+    );
+    expect(probe).not.toBeNull();
+    expect(probe!.opKind).toBe("pr_update_op");
+    const probeRes = await runOutboxProbe({
+      ...(probe!),
+      idempotencyKey: idemKey,
+    } as unknown as Parameters<typeof runOutboxProbe>[0]);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe(opened.id);
+  });
+
+  it("submit_review_op → non-null probe; routes to gitHost.findReviewByMachineKey", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    const idemKey = "K-SUBMIT";
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const submitted = await gitHost.submitPullRequestReview({
+      prRef: opened,
+      intent: "approve",
+      body: `ok\n<!-- llm-team:review-machine\nidempotency_key: ${idemKey}\n-->`,
+      idempotencyKey: idemKey,
+    });
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("submit_review_op", idemKey),
+      pending("submit_review_op", { idempotencyKey: idemKey }),
+    );
+    expect(probe).not.toBeNull();
+    const probeRes = await runOutboxProbe({
+      ...(probe!),
+      idempotencyKey: idemKey,
+    } as unknown as Parameters<typeof runOutboxProbe>[0]);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe(submitted.externalReviewId);
+  });
+
+  it("merge_op → non-null probe; routes to gitHost.getPullRequestMergeState", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await gitHost.mergePullRequest({ prRef: opened, strategy: "squash" });
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(candidate("merge_op"), pending("merge_op"));
+    expect(probe).not.toBeNull();
+    const probeRes = await runOutboxProbe(probe!);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toMatch(/^merge-1-/);
+  });
+
+  it("add_label_op → non-null probe when result_detail carries {label}; routes to gitHost.listLabels", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await gitHost.addLabel(opened, "ready-for-review");
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("add_label_op"),
+      pending("add_label_op", {
+        resultDetail: JSON.stringify({ label: "ready-for-review" }),
+      }),
+    );
+    expect(probe).not.toBeNull();
+    expect(probe!.opKind).toBe("add_label_op");
+    const probeRes = await runOutboxProbe(probe!);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe("ready-for-review");
+  });
+
+  it("add_label_op without result_detail.label → null (no_probe until Phase 6+ invoker)", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    await seedSurface(store);
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("add_label_op"),
+      pending("add_label_op"),
+    );
+    expect(probe).toBeNull();
+  });
+
+  it("remove_label_op → non-null probe; expect=absent semantic", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    // Label was never added → removal probe with expect=absent should pass.
+    void opened;
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("remove_label_op"),
+      pending("remove_label_op", {
+        resultDetail: JSON.stringify({ label: "never-added" }),
+      }),
+    );
+    expect(probe).not.toBeNull();
+    expect(probe!.opKind).toBe("remove_label_op");
+    if (probe!.opKind === "remove_label_op") {
+      expect(probe!.expect).toBe("absent");
+    }
+    const probeRes = await runOutboxProbe(probe!);
+    expect(probeRes.recovered).toBe(true);
+  });
+
+  it("dismiss_review_op → non-null probe when result_detail carries {externalReviewId}", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    const surface = await seedSurface(store);
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const submitted = await gitHost.submitPullRequestReview({
+      prRef: opened,
+      intent: "request_changes",
+      body: "body",
+      idempotencyKey: "K-PRE",
+    });
+    await gitHost.dismissReview({
+      prRef: opened,
+      externalReviewId: submitted.externalReviewId,
+      reason: "stale",
+    });
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("dismiss_review_op"),
+      pending("dismiss_review_op", {
+        resultDetail: JSON.stringify({
+          externalReviewId: submitted.externalReviewId,
+        }),
+      }),
+    );
+    expect(probe).not.toBeNull();
+    const probeRes = await runOutboxProbe(probe!);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe(submitted.externalReviewId);
+  });
+
+  it("dismiss_review_op without externalReviewId payload → null", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    await seedSurface(store);
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("dismiss_review_op"),
+      pending("dismiss_review_op"),
+    );
+    expect(probe).toBeNull();
+  });
+
+  it("missing pending row → null (defensive)", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    await seedSurface(store);
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(candidate("submit_review_op"), null);
+    expect(probe).toBeNull();
+  });
+
+  it("surface resolved via objectId when surfaceRef is null (lead-invoker path)", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    await seedSurface(store);
+    workspace.seedRemoteHead("origin", BRANCH, HEAD_SHA);
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    // Lead-invoker omits surfaceRef on push_op pending row; the builder
+    // must fall through to objectId to load the surface.
+    const probe = await build(
+      candidate("push_op"),
+      pending("push_op", { surfaceRef: null, objectId: SURFACE_ID }),
+    );
+    expect(probe).not.toBeNull();
+    const probeRes = await runOutboxProbe(probe!);
+    expect(probeRes.recovered).toBe(true);
+  });
+});

--- a/tests/cli/recovery-probe-builder.test.ts
+++ b/tests/cli/recovery-probe-builder.test.ts
@@ -170,15 +170,100 @@ describe("buildProductionProbeBuilder · per-op_kind routing", () => {
     expect(probeRes.externalId).toBe(opened.id);
   });
 
-  it("pr_open_op without surface → null (no_probe fallback for first-attempt crash)", async () => {
+  it("pr_open_op without surface AND without payload hints → null (no_probe)", async () => {
     const { store, gitHost, workspace } = makeDeps();
-    // No surface seeded.
+    // No surface seeded; pending row carries no `branch` payload hint.
     const build = buildProductionProbeBuilder({ store, workspace, gitHost });
     const probe = await build(
       candidate("pr_open_op"),
       pending("pr_open_op"),
     );
     expect(probe).toBeNull();
+  });
+
+  it("pr_open_op without surface but WITH payload branch hint → non-null probe (PR #127 review P1-1 surface-less fallback)", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    // No surface — Case A crash window between `outbox.begin(pr_open_op)`
+    // and the Step 8 ReviewSurface write. Lead-invoker persists `branch`
+    // on the pending row payload so recovery can still probe.
+    const idemKey = "K-OPEN-NO-SURFACE";
+    const opened = await gitHost.openPullRequest({
+      title: "t",
+      body: `body\n<!-- llm-team:pr-machine\nidempotency_key: ${idemKey}\n-->`,
+      headBranch: BRANCH,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("pr_open_op", idemKey),
+      pending("pr_open_op", {
+        idempotencyKey: idemKey,
+        surfaceRef: null,
+        resultDetail: JSON.stringify({ branch: BRANCH }),
+      }),
+    );
+    expect(probe).not.toBeNull();
+    expect(probe!.opKind).toBe("pr_open_op");
+    const probeRes = await runOutboxProbe({
+      ...(probe!),
+      idempotencyKey: idemKey,
+    } as unknown as Parameters<typeof runOutboxProbe>[0]);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe(opened.id);
+  });
+
+  it("commit_op without surface but WITH payload branch hint → non-null probe (PR #127 review P1-1)", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    // No surface seeded — first-attempt crash window for commit_op.
+    const idemKey = "K-COMMIT-NO-SURFACE";
+    workspace.seedCommitTrailer(BRANCH, "commit-sha-X", {
+      "Idempotency-Key": idemKey,
+    });
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("commit_op", idemKey),
+      pending("commit_op", {
+        idempotencyKey: idemKey,
+        surfaceRef: null,
+        resultDetail: JSON.stringify({
+          branch: BRANCH,
+          trailerKey: "Idempotency-Key",
+        }),
+      }),
+    );
+    expect(probe).not.toBeNull();
+    const probeRes = await runOutboxProbe({
+      ...(probe!),
+      idempotencyKey: idemKey,
+    } as unknown as Parameters<typeof runOutboxProbe>[0]);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe("commit-sha-X");
+  });
+
+  it("push_op without surface but WITH payload branch+headSha hints → non-null probe (PR #127 review P1-1)", async () => {
+    const { store, gitHost, workspace } = makeDeps();
+    // No surface seeded — Case A crash window for push_op.
+    const expectedSha = "push-sha-X";
+    workspace.seedRemoteHead("origin", BRANCH, expectedSha);
+    const build = buildProductionProbeBuilder({ store, workspace, gitHost });
+    const probe = await build(
+      candidate("push_op", "K-PUSH-NO-SURFACE"),
+      pending("push_op", {
+        idempotencyKey: "K-PUSH-NO-SURFACE",
+        surfaceRef: null,
+        resultDetail: JSON.stringify({
+          branch: BRANCH,
+          headSha: expectedSha,
+          remote: "origin",
+        }),
+      }),
+    );
+    expect(probe).not.toBeNull();
+    const probeRes = await runOutboxProbe(probe!);
+    expect(probeRes.recovered).toBe(true);
+    expect(probeRes.externalId).toBe(expectedSha);
   });
 
   it("pr_update_op → non-null probe; routes to gitHost.findPullRequestByBodyMachineKey", async () => {

--- a/tests/e2e/recovery-probe-routing.test.ts
+++ b/tests/e2e/recovery-probe-routing.test.ts
@@ -581,4 +581,158 @@ describe("recovery probe routing · e2e per-op_kind (issue #126)", () => {
     );
     expect(noProbe).toHaveLength(0);
   });
+
+  it("PR #127 review P1-1: pr_open_op surface-less Case A → recovered via payload hints", async () => {
+    // Crash window: outbox.begin(pr_open_op) succeeded but the ReviewSurface
+    // write at Step 8 never landed. Lead-invoker persists `branch` on the
+    // pending row payload so recovery still resolves the headBranch and
+    // probes `findOpenPullRequestByMachineKey` correctly.
+    const deps = makeBase();
+    // NOTE: NO seedSurface — this is the bug window.
+    const idemKey = "K-OPEN-CASEA";
+    await deps.gitHost.openPullRequest({
+      title: "t",
+      body: `body\n<!-- llm-team:pr-machine\nidempotency_key: ${idemKey}\n-->`,
+      headBranch: BRANCH,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "pr_open_op",
+      idempotencyKey: idemKey,
+      surfaceRef: null,
+      resultDetail: JSON.stringify({ branch: BRANCH }),
+      loopKind: "inner",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("PR #127 review P1-2: Case B scan skips commit_op/push_op rows when the (session,turn) slot already has a receipt", async () => {
+    // Live lead happy path: commit_op (k1) and push_op (k2) are posted, but
+    // the live receipt stores only the terminal pr_open_op key (k3). Without
+    // slot-scoped dedup the scan would re-list k1/k2 as Case B candidates
+    // every sweep. With the fix, the receipt at slot (SESSION_ID, TURN_INDEX)
+    // covers them.
+    const deps = makeBase();
+    await seedSurface(deps.store);
+    // Append commit_op + push_op pending+posted rows (no recovery yet — we
+    // are simulating the live happy path, not Case A recovery).
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "commit_op",
+      idempotencyKey: "K1-COMMIT",
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    await deps.outbox.complete({
+      opKind: "commit_op",
+      idempotencyKey: "K1-COMMIT",
+      status: "posted",
+      externalId: "commit-sha",
+      callerId: CALLER,
+      targetId: TARGET,
+      objectId: SURFACE_ID,
+      manifestId: null,
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "push_op",
+      idempotencyKey: "K2-PUSH",
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    await deps.outbox.complete({
+      opKind: "push_op",
+      idempotencyKey: "K2-PUSH",
+      status: "posted",
+      externalId: HEAD_SHA,
+      callerId: CALLER,
+      targetId: TARGET,
+      objectId: SURFACE_ID,
+      manifestId: null,
+    });
+    // Live receipt — keyed by terminal `k3`, NOT k1/k2.
+    const receipt = AgentRunReceipt.parse({
+      session_id: SESSION_ID,
+      turn_index: TURN_INDEX,
+      parent_loop: "inner",
+      agent_profile_id: AGENT_PROFILE,
+      agent_role_in_session: "lead",
+      idempotency_key: "K3-PR-OPEN",
+      diagnostics_ref: "live",
+      external_review_id: null,
+      external_pr_id: "1",
+      commit_sha: "commit-sha",
+      exit_status: "ok",
+      recorded_at: ISO,
+    });
+    await deps.store.writeAtomic(
+      layout.agentRunReceipt(SESSION_ID, TURN_INDEX),
+      JSON.stringify(receipt),
+    );
+
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    // No Case B candidates for commit_op / push_op — the slot is covered.
+    expect(sweep.scanned).toBe(0);
+    expect(sweep.items).toHaveLength(0);
+  });
+
+  it("PR #127 review P1-2: once outbox_recovered is emitted, subsequent sweeps do not re-list the same Case B candidate", async () => {
+    // Seed a posted_without_receipt scenario, run sweep 1 (recovers + emits
+    // outbox_recovered), then run sweep 2 — must not re-list the same row.
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const opened = await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const idemKey = "K-CASEB-DEDUP";
+    const submitted = await deps.gitHost.submitPullRequestReview({
+      prRef: opened,
+      intent: "approve",
+      body: `ok\n<!-- llm-team:review-machine\nidempotency_key: ${idemKey}\n-->`,
+      idempotencyKey: idemKey,
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "submit_review_op",
+      idempotencyKey: idemKey,
+      loopKind: "middle",
+    });
+    await deps.outbox.complete({
+      opKind: "submit_review_op",
+      idempotencyKey: idemKey,
+      status: "posted",
+      externalId: submitted.externalReviewId,
+      externalReviewId: submitted.externalReviewId,
+      callerId: CALLER,
+      targetId: TARGET,
+      objectId: SURFACE_ID,
+      manifestId: null,
+      surfaceRef: SURFACE_ID,
+    });
+    const coordinator = makeCoordinator(deps);
+    const first = await coordinator.runOnce();
+    expect(first.scanned).toBe(1);
+    expect(
+      first.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+    // Second sweep — `outbox_recovered` row already exists for this
+    // (op_kind, key); scan must skip the duplicate Case B candidate.
+    const second = await coordinator.runOnce();
+    expect(second.scanned).toBe(0);
+    expect(second.items).toHaveLength(0);
+  });
 });

--- a/tests/e2e/recovery-probe-routing.test.ts
+++ b/tests/e2e/recovery-probe-routing.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Issue #126 — e2e production probe routing.
+ *
+ * Validates that wiring `buildProductionProbeBuilder` into the
+ * `RecoveryCoordinator` recovers `pending_without_posted` outbox candidates
+ * across the supported op_kinds. Without this wiring (PR #125 baseline)
+ * every candidate was reported as `recovered_skipped: no_probe` — the
+ * "dead-zone" the issue cites.
+ *
+ * The test seeds:
+ *   - a ReviewSurface JSON at the canonical layout path (the probe builder
+ *     reads `surface.branch` / `surface.pr_ref` to route);
+ *   - a provider-local artifact (commit trailer, remote head, PR body or
+ *     review body machine-block) so the probe positively confirms the
+ *     external write happened.
+ *
+ * For each op_kind the test then appends a low-level `outbox_pending` row
+ * (mirroring real invoker output) and asserts:
+ *   1. the coordinator does NOT emit `recovered_skipped: no_probe`;
+ *   2. a `recovered_backfilled` outcome is produced (or, when the receipt
+ *      tuple is intentionally absent, `recovered_skipped: no_receipt_slot`
+ *      — still proof that the probe was invoked and matched).
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { FsMirrorGitHost } from "../../src/adapters/git-host/fs-mirror.js";
+import { MemoryStore } from "../../src/adapters/store/memory.js";
+import { FakeWorkspace } from "../../src/adapters/workspace/fake.js";
+import { FileLedger } from "../../src/application/ledger.js";
+import { Outbox, type OutboxOpKind } from "../../src/application/outbox.js";
+import {
+  LEDGER_TRANSITIONS_PATH,
+  layout,
+} from "../../src/application/persistence-layout.js";
+import {
+  RecoveryCoordinator,
+} from "../../src/application/recovery-coordinator.js";
+import { buildProductionProbeBuilder } from "../../src/cli/recovery-probe-builder.js";
+import { LedgerRow } from "../../src/domain/schema/ledger.js";
+import { AgentRunReceipt } from "../../src/domain/schema/agent-run-receipt.js";
+import { newMonotonicId } from "../../src/domain/ids.js";
+import { FixedClock } from "../../src/ports/clock.js";
+import type { ReviewSurface as ReviewSurfaceT } from "../../src/domain/schema/review-surface.js";
+
+const ISO = "2026-05-14T00:00:00.000Z";
+const FIXED_MS = new Date(ISO).valueOf();
+const TARGET = "demo";
+const CALLER = "test-caller";
+const SURFACE_ID = "01HZSR0000000000000000000A";
+const SESSION_ID = "01HZSE0000000000000000000A";
+const SLICE_ID = "01HZS00000000000000000000A";
+const TURN_INDEX = 0;
+const AGENT_PROFILE = "sentinel";
+const BRANCH = `slice/${SLICE_ID}`;
+const HEAD_SHA = "abc1234567890abcdef1234567890abcdef1234";
+
+function makeBase() {
+  const store = new MemoryStore();
+  const clock = new FixedClock(FIXED_MS);
+  const ledger = new FileLedger({ store });
+  const gitHost = new FsMirrorGitHost(store);
+  const outbox = new Outbox({ store, ledger });
+  const wsRoot = mkdtempSync(join(tmpdir(), "rpr-"));
+  const workspace = new FakeWorkspace(wsRoot);
+  return { store, clock, ledger, gitHost, outbox, workspace };
+}
+
+async function seedSurface(
+  store: MemoryStore,
+  overrides: Partial<ReviewSurfaceT> = {},
+): Promise<ReviewSurfaceT> {
+  const surface: ReviewSurfaceT = {
+    review_surface_id: SURFACE_ID,
+    parent_kind: "slice",
+    parent_id: SLICE_ID,
+    parent_phase: null,
+    pr_ref: {
+      provider: "fs_mirror",
+      id: "1",
+      node_id: null,
+      url: "fs-mirror://prs/1",
+    },
+    branch: BRANCH,
+    base_ref: "main",
+    head_sha: HEAD_SHA,
+    review_round: 0,
+    lifecycle_state: "open",
+    review_state: "pending_review",
+    build_state: "ready",
+    latest_verification_run_id: null,
+    last_synced_external_revision: null,
+    created_at: ISO,
+    updated_at: ISO,
+    ...overrides,
+  };
+  await store.writeAtomic(
+    layout.reviewSurface(SURFACE_ID),
+    JSON.stringify(surface),
+  );
+  return surface;
+}
+
+async function appendPending(
+  ledger: FileLedger,
+  clock: FixedClock,
+  opts: {
+    opKind: OutboxOpKind;
+    idempotencyKey: string;
+    surfaceRef?: string | null;
+    objectId?: string;
+    resultDetail?: string | null;
+    sessionId?: string | null;
+    turnIndex?: number | null;
+    agentProfileId?: string | null;
+    loopKind?: "outer" | "middle" | "inner" | null;
+  },
+): Promise<void> {
+  await ledger.appendTransition({
+    transition_id: newMonotonicId(FIXED_MS),
+    target_id: TARGET,
+    object_id: opts.objectId ?? SURFACE_ID,
+    object_kind: "system",
+    from_state: null,
+    to_state: "outbox_pending",
+    loop_kind: opts.loopKind ?? "middle",
+    phase: null,
+    slice_id: SLICE_ID,
+    slice_kind: null,
+    dod_revision: null,
+    session_id: opts.sessionId === undefined ? SESSION_ID : opts.sessionId,
+    turn_index: opts.turnIndex === undefined ? TURN_INDEX : opts.turnIndex,
+    slot_kind: null,
+    agent_profile_id:
+      opts.agentProfileId === undefined ? AGENT_PROFILE : opts.agentProfileId,
+    contribution_kind: null,
+    action_kind: "outbox_pending",
+    final_verdict: null,
+    caller_id: CALLER,
+    manifest_id: null,
+    input_revision_pins: [],
+    output_hash: null,
+    verification_run_id: null,
+    metric_run_id: null,
+    idempotency_key: `outbox/${opts.opKind}/${opts.idempotencyKey}/begin`,
+    lease_token: null,
+    lease_kind: null,
+    result: "applied",
+    result_detail: opts.resultDetail ?? null,
+    timestamp: clock.isoNow(),
+    ...(opts.surfaceRef === undefined ? { surface_ref: SURFACE_ID } : {}),
+    ...(opts.surfaceRef != null ? { surface_ref: opts.surfaceRef } : {}),
+    op_kind: opts.opKind,
+  });
+}
+
+async function readActionRows(
+  store: MemoryStore,
+  action: string,
+): Promise<unknown[]> {
+  const body = (await store.readText(LEDGER_TRANSITIONS_PATH)) ?? "";
+  return body
+    .split("\n")
+    .filter((s) => s.length > 0)
+    .map((s) => LedgerRow.parse(JSON.parse(s)))
+    .filter((r) => r.action_kind === action);
+}
+
+function makeCoordinator(deps: ReturnType<typeof makeBase>) {
+  const { store, clock, ledger, gitHost, outbox, workspace } = deps;
+  return new RecoveryCoordinator(
+    { callerId: CALLER, targetId: TARGET },
+    {
+      store,
+      clock,
+      ledger,
+      outbox,
+      buildProbe: buildProductionProbeBuilder({ store, workspace, gitHost }),
+    },
+  );
+}
+
+describe("recovery probe routing · e2e per-op_kind (issue #126)", () => {
+  it("commit_op pending_without_posted → recovered (no `no_probe`)", async () => {
+    const deps = makeBase();
+    await seedSurface(deps.store);
+    const idemKey = "K-COMMIT";
+    deps.workspace.seedCommitTrailer(BRANCH, "commit-sha-A", {
+      "Idempotency-Key": idemKey,
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "commit_op",
+      idempotencyKey: idemKey,
+      // lead-invoker omits surfaceRef for commit_op; only objectId carries it.
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(sweep.scanned).toBe(1);
+    const skipped = sweep.items.find(
+      (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+    );
+    expect(skipped).toBeUndefined();
+    const recovered = sweep.items.find(
+      (i) => i.kind === "recovered_backfilled",
+    );
+    expect(recovered).toBeDefined();
+    const recoveredRows = await readActionRows(deps.store, "outbox_recovered");
+    expect(recoveredRows.length).toBeGreaterThanOrEqual(1);
+    const receipt = AgentRunReceipt.parse(
+      JSON.parse(
+        (await deps.store.readText(
+          layout.agentRunReceipt(SESSION_ID, TURN_INDEX),
+        )) ?? "",
+      ),
+    );
+    expect(receipt.idempotency_key).toBe(idemKey);
+    expect(receipt.commit_sha).toBe("commit-sha-A");
+  });
+
+  it("push_op pending_without_posted → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    deps.workspace.seedRemoteHead("origin", surface.branch, surface.head_sha);
+    const idemKey = "K-PUSH";
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "push_op",
+      idempotencyKey: idemKey,
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("pr_open_op pending_without_posted → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const idemKey = "K-OPEN";
+    await deps.gitHost.openPullRequest({
+      title: "t",
+      body: `body\n<!-- llm-team:pr-machine\nidempotency_key: ${idemKey}\n-->`,
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "pr_open_op",
+      idempotencyKey: idemKey,
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("pr_update_op pending_without_posted → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const opened = await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const idemKey = "K-UPDATE";
+    await deps.gitHost.updatePullRequestBody({
+      prRef: opened,
+      body: `body\n<!-- llm-team:pr-machine\nidempotency_key: ${idemKey}\n-->`,
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "pr_update_op",
+      idempotencyKey: idemKey,
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("submit_review_op pending_without_posted → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const opened = await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const idemKey = "K-SUBMIT";
+    await deps.gitHost.submitPullRequestReview({
+      prRef: opened,
+      intent: "approve",
+      body: `ok\n<!-- llm-team:review-machine\nidempotency_key: ${idemKey}\n-->`,
+      idempotencyKey: idemKey,
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "submit_review_op",
+      idempotencyKey: idemKey,
+      loopKind: "middle",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("merge_op pending_without_posted → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const opened = await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await deps.gitHost.mergePullRequest({ prRef: opened, strategy: "squash" });
+    const idemKey = "K-MERGE";
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "merge_op",
+      idempotencyKey: idemKey,
+      loopKind: "outer",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("add_label_op pending_without_posted (result_detail={label}) → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const opened = await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    await deps.gitHost.addLabel(opened, "ready-for-review");
+    const idemKey = "K-LABEL-ADD";
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "add_label_op",
+      idempotencyKey: idemKey,
+      resultDetail: JSON.stringify({ label: "ready-for-review" }),
+      loopKind: "outer",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("remove_label_op pending_without_posted (label absent) → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const idemKey = "K-LABEL-RM";
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "remove_label_op",
+      idempotencyKey: idemKey,
+      resultDetail: JSON.stringify({ label: "stale-label" }),
+      loopKind: "outer",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("dismiss_review_op pending_without_posted (result_detail={externalReviewId}) → recovered", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const opened = await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const submitted = await deps.gitHost.submitPullRequestReview({
+      prRef: opened,
+      intent: "request_changes",
+      body: "x",
+      idempotencyKey: "K-PRE",
+    });
+    await deps.gitHost.dismissReview({
+      prRef: opened,
+      externalReviewId: submitted.externalReviewId,
+      reason: "stale",
+    });
+    const idemKey = "K-DISMISS";
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "dismiss_review_op",
+      idempotencyKey: idemKey,
+      resultDetail: JSON.stringify({
+        externalReviewId: submitted.externalReviewId,
+      }),
+      loopKind: "middle",
+    });
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find(
+        (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+      ),
+    ).toBeUndefined();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+  });
+
+  it("posted_without_receipt across op_kinds → recovered + outbox_posted dedup (1 row)", async () => {
+    const deps = makeBase();
+    const surface = await seedSurface(deps.store);
+    const opened = await deps.gitHost.openPullRequest({
+      title: "t",
+      body: "x",
+      headBranch: surface.branch,
+      baseBranch: "main",
+      draft: false,
+      labels: [],
+    });
+    const idemKey = "K-POSTED-NO-RECEIPT";
+    const submitted = await deps.gitHost.submitPullRequestReview({
+      prRef: opened,
+      intent: "approve",
+      body: `ok\n<!-- llm-team:review-machine\nidempotency_key: ${idemKey}\n-->`,
+      idempotencyKey: idemKey,
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "submit_review_op",
+      idempotencyKey: idemKey,
+      loopKind: "middle",
+    });
+    await deps.outbox.complete({
+      opKind: "submit_review_op",
+      idempotencyKey: idemKey,
+      status: "posted",
+      externalId: submitted.externalReviewId,
+      externalReviewId: submitted.externalReviewId,
+      callerId: CALLER,
+      targetId: TARGET,
+      objectId: SURFACE_ID,
+      manifestId: null,
+      surfaceRef: SURFACE_ID,
+    });
+    // Crash here — no receipt blob.
+    const coordinator = makeCoordinator(deps);
+    const sweep = await coordinator.runOnce();
+    expect(
+      sweep.items.find((i) => i.kind === "recovered_backfilled"),
+    ).toBeDefined();
+    // No duplicate posted row — exactly 1.
+    const posted = await readActionRows(deps.store, "outbox_posted");
+    expect(posted).toHaveLength(1);
+    const receipt = AgentRunReceipt.parse(
+      JSON.parse(
+        (await deps.store.readText(
+          layout.agentRunReceipt(SESSION_ID, TURN_INDEX),
+        )) ?? "",
+      ),
+    );
+    expect(receipt.idempotency_key).toBe(idemKey);
+    expect(receipt.external_review_id).toBe(submitted.externalReviewId);
+  });
+
+  it("regression: stub buildProbe (PR #125 baseline) emits `no_probe` for every candidate — production builder fixes this", async () => {
+    // First sweep: stub builder.
+    const deps = makeBase();
+    await seedSurface(deps.store);
+    deps.workspace.seedCommitTrailer(BRANCH, "commit-sha-A", {
+      "Idempotency-Key": "K-REG",
+    });
+    await appendPending(deps.ledger, deps.clock, {
+      opKind: "commit_op",
+      idempotencyKey: "K-REG",
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    const stubbed = new RecoveryCoordinator(
+      { callerId: CALLER, targetId: TARGET },
+      {
+        store: deps.store,
+        clock: deps.clock,
+        ledger: deps.ledger,
+        outbox: deps.outbox,
+        buildProbe: async () => null,
+      },
+    );
+    const baseline = await stubbed.runOnce();
+    const baselineSkipped = baseline.items.filter(
+      (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+    );
+    expect(baselineSkipped.length).toBe(1);
+
+    // Second sweep with production builder: rebuild ledger state to a fresh
+    // pending row (without a recovered marker overlapping the prior sweep).
+    const deps2 = makeBase();
+    await seedSurface(deps2.store);
+    deps2.workspace.seedCommitTrailer(BRANCH, "commit-sha-A", {
+      "Idempotency-Key": "K-REG2",
+    });
+    await appendPending(deps2.ledger, deps2.clock, {
+      opKind: "commit_op",
+      idempotencyKey: "K-REG2",
+      surfaceRef: null,
+      loopKind: "inner",
+    });
+    const production = makeCoordinator(deps2);
+    const sweep = await production.runOnce();
+    const noProbe = sweep.items.filter(
+      (i) => i.kind === "recovered_skipped" && i.reason === "no_probe",
+    );
+    expect(noProbe).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- audit P0-2 / PR #125 self-review P1-2 본질 해소: `RecoveryCoordinator.buildProbe` 가 9 op_kind 별 실제 probe 라우팅 수행.
- daemon recovery role 에서 `WorkspacePort` + `GitHostPort` 실 인스턴스로 `buildProductionProbeBuilder` 를 `setProbeBuilder` 로 주입.
- e2e: 각 op_kind 별 `pending_without_posted` outbox entry → recover (no_probe 0).

closes #126

### 변경 내용
| Module | Artifact | Notes |
|---|---|---|
| `src/cli/recovery-probe-builder.ts` | new | per-op_kind `ProbeBuilder`. ReviewSurface JSON → `surface.branch` / `surface.pr_ref` 기반 라우팅. `result_detail` JSON → `{label}` / `{externalReviewId}` for label/dismiss ops. |
| `src/cli/daemon.ts` | wiring | `case "recovery"` 에서 `prFirstWiring.recoveryCoordinator.setProbeBuilder(buildProductionProbeBuilder({ store, workspace, gitHost }))` 호출 후 `runOnce()`. |
| `src/application/recovery-coordinator.ts` | additive | `setProbeBuilder()` 메서드 + `PendingOutboxRow.resultDetail` 필드 (label/dismiss payload 통로). |
| `tests/cli/recovery-probe-builder.test.ts` | new | 14 tests — per-op_kind probe shape + `runOutboxProbe` 실 라우팅. |
| `tests/e2e/recovery-probe-routing.test.ts` | new | 11 tests — 9 op_kinds × `pending_without_posted` + `posted_without_receipt` dedup + baseline `no_probe`-회귀 가드. |

### Design notes
- **PR-first toggle off 시 영향 0**: `setProbeBuilder` 는 recovery role 진입 후에만 호출. `prFirstSettings` / invoker 구성은 변경 없음.
- **`buildPrFirstWiring` 비-침범**: production 라우팅을 wiring 모듈에 두지 않음 — issue body 권고 ("role-specific port resolution은 daemon entry 안에서") 준수. wiring 은 stub `buildProbe` 그대로.
- **Surface 부재 fallback**: `pr_open_op` 첫 시도 크래시는 surface JSON 이 아직 없으므로 `no_probe` 반환. 이는 dead-zone 회귀가 아닌 정상 fallback (재시도 시 surface 가 persistent 면 회수 가능).
- **Label/dismiss ops**: 현재 production caller 가 없어 `result_detail` payload 가 비어 있을 수 있음 → `no_probe`. Phase 6+ 에서 invoker 가 `Outbox.begin({ payload })` 를 채우면 자동 회수.

## Test plan
- [x] 9 op_kind 별 probe 단위 테스트 (14 unit tests · `tests/cli/recovery-probe-builder.test.ts`)
- [x] e2e: 9 op_kind 별 `pending_without_posted` → recovered + outbox_posted + receipt backfill (`tests/e2e/recovery-probe-routing.test.ts`)
- [x] e2e: `posted_without_receipt` → recovered + `outbox_posted` 중복 0 + receipt backfill
- [x] e2e regression: stub `buildProbe` 는 `no_probe` 1건, production builder 는 0건 (dead-zone 해소 확인)
- [x] 기존 1151 tests 0 regression (전체 1176 passing, +25 신규)
- [x] typecheck clean
- [x] build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)