### PR TITLE
ops(monitoring): post-commit hook → infra ingest

### DIFF
--- a/docs/operations/monitoring-hook.md
+++ b/docs/operations/monitoring-hook.md
@@ -1,0 +1,5 @@
+# Monitoring post-commit hook
+
+`~/dev/infra/` 의 `git_commits` 적재용. 설치: `./scripts/install-monitoring-hook.sh`. 실패는 silent (commit 차단 안 함).
+
+ingest URL override: `MONITORING_INGEST_URL=http://mba.local:8080`.

--- a/scripts/git-hooks/post-commit
+++ b/scripts/git-hooks/post-commit
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# llm-team monitoring hook — POST commit metadata to infra ingest.
+# 실패해도 commit 자체는 성공해야 한다 — 모든 에러를 swallow.
+set -u
+
+INGEST_URL="${MONITORING_INGEST_URL:-http://localhost:8080}"
+
+# git common dir points to main .git regardless of worktree; its parent is the main repo root.
+common_git_dir="$(git rev-parse --git-common-dir 2>/dev/null || echo "")"
+if [ -n "$common_git_dir" ] && [ -d "$common_git_dir" ]; then
+  main_repo_root="$(cd "$common_git_dir/.." && pwd -P)"
+else
+  main_repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo unknown)"
+fi
+repo="$(basename "$main_repo_root")"
+sha="$(git rev-parse HEAD)"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+author_email="$(git log -1 --pretty=format:'%ae')"
+committed_at="$(git log -1 --pretty=format:'%aI')"
+subject="$(git log -1 --pretty=format:'%s')"
+body="$(git log -1 --pretty=format:'%b')"
+files="$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | jq -R . | jq -s . 2>/dev/null || echo '[]')"
+
+payload="$(jq -n \
+  --arg repo "$repo" \
+  --arg sha "$sha" \
+  --arg branch "$branch" \
+  --arg author_email "$author_email" \
+  --arg committed_at "$committed_at" \
+  --arg subject "$subject" \
+  --arg body "$body" \
+  --argjson files "$files" \
+  '{repo: $repo, sha: $sha, branch: $branch, author_email: $author_email,
+    committed_at: $committed_at, subject: $subject, body: $body, files_changed: $files}' \
+  2>/dev/null)"
+
+if [ -n "$payload" ]; then
+  curl -s -m 3 -o /dev/null \
+    -X POST "$INGEST_URL/git_commits" \
+    -H 'content-type: application/json' \
+    -d "$payload" 2>/dev/null || true
+fi
+
+exit 0

--- a/scripts/install-monitoring-hook.sh
+++ b/scripts/install-monitoring-hook.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# 설치: ./scripts/install-monitoring-hook.sh
+# `core.hooksPath` 를 scripts/git-hooks 로 설정 — main checkout / 워크트리 모두에서 동작.
+# 기존에 다른 hook 설정이 있었다면 백업.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+target="scripts/git-hooks"
+
+if [ ! -d "$repo_root/$target" ]; then
+  echo "error: $repo_root/$target not found" >&2
+  exit 1
+fi
+
+prev="$(git config --get core.hooksPath || true)"
+if [ -n "$prev" ] && [ "$prev" != "$target" ]; then
+  echo "기존 core.hooksPath 백업: $prev  (git config --unset core.hooksPath 으로 복원)"
+fi
+
+chmod +x "$repo_root/$target"/* 2>/dev/null || true
+git config core.hooksPath "$target"
+echo "설치 완료: core.hooksPath = $target"


### PR DESCRIPTION
## Summary

llm-team의 모든 commit 직후 sha / branch / author / files 정보를 infra repo 의 ingest `/git_commits` 로 POST 하는 post-commit hook 을 추가한다. infra W2 데이터 layer 의 `git_commits` 테이블 source 가 되며, custom-dashboard 의 cycle-PR 연계 시각화 입력으로 쓰인다.

- `scripts/git-hooks/post-commit` — POST to `${MONITORING_INGEST_URL:-http://localhost:8080}/git_commits`. 실패는 silent (commit 차단 안 함).
- `scripts/install-monitoring-hook.sh` — `git config core.hooksPath scripts/git-hooks` 로 설정 (worktree-safe).
- `docs/operations/monitoring-hook.md` — 1 줄 설치 가이드.

## Cross-repo context

대응하는 infra 측 endpoint 는 `~/dev/infra` repo 의 W2 작업 (`feat/phase-1-w2-data-layer`) 에서 추가된 `/git_commits` POST endpoint. 그 repo 는 local-only 라 PR 별도 없음.

## Repo detection (worktree-safe)

워크트리에서도 `repo` 필드가 항상 `llm-team` 으로 잡히도록 `git rev-parse --git-common-dir` 의 부모 디렉토리 basename 을 사용. main checkout 의 `basename $(toplevel)` 와 동일한 결과.

## Network failure handling

`curl -s -m 3 -o /dev/null ... || true` 로 묶어 ingest 미가동·LAN 오프라인 시에도 commit 자체는 막지 않는다. 데이터 손실은 받아들이는 트레이드오프 (재시도 큐 없음).

## Test plan

- [x] 설치: `./scripts/install-monitoring-hook.sh` — `core.hooksPath = scripts/git-hooks` 설정 확인
- [x] smoke: `git commit --allow-empty -m "..."` → infra `git_commits` 테이블에 row 적재 확인
- [x] worktree 에서도 동작: `repo` 필드가 "llm-team" 으로 잡힘
- [x] ingest 다운 상태에서 commit 정상 동작 확인 (3s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)