### PR TITLE
feat(phase-6-0a): GitHostPort adapter selector via governance.git_host_provider

### DIFF
--- a/src/adapters/git-host/factory.ts
+++ b/src/adapters/git-host/factory.ts
@@ -1,0 +1,72 @@
+/**
+ * Phase 6.0a — `GitHostPort` factory.
+ *
+ * The daemon previously hardcoded `FsMirrorGitHost` at every wire-up site
+ * regardless of `cfg.governance.git_host_provider`. This module routes to
+ * the right adapter based on the schema field (mirrors
+ * `team-membership/factory.ts`):
+ *
+ *   provider="fs-mirror" (default) → FsMirrorGitHost(store)
+ *   provider="github"             → GitHubGitHost({repo, exec, labelPrefix?})
+ *
+ * The default preserves backward compatibility: deployments / fixtures that
+ * never set the field stay on the in-process mirror used by tests and
+ * self-host smoke.
+ *
+ * `GhExec` is injected (defaults to `ProcessGhExec`) so integration tests
+ * can substitute a deterministic stub instead of spawning the real `gh`
+ * CLI. Schema cross-field validation (`config-validator` →
+ * `target-schema.ts`) guarantees `git_host_repo` is present when
+ * `provider="github"`; this factory asserts the same invariant defensively
+ * so a hand-constructed `Governance` cannot bypass it.
+ *
+ * Statelessness contract: pure function — every call returns a fresh
+ * adapter instance with no module-level cache. A `git_host_provider` /
+ * `git_host_repo` change is only picked up after a daemon restart.
+ */
+
+import type { StorePort } from "../../ports/store.js";
+import type { GitHostPort } from "../../ports/git-host.js";
+import type { Governance } from "../../config/target-schema.js";
+import type { GhExec } from "../issue-tracker/github.js";
+import { ProcessGhExec } from "../team-membership/github.js";
+import { FsMirrorGitHost } from "./fs-mirror.js";
+import { GitHubGitHost } from "./github.js";
+
+export interface BuildGitHostDeps {
+  store: StorePort;
+  /** Test-only override; production callers omit and use `ProcessGhExec`. */
+  ghExec?: GhExec;
+}
+
+export function buildGitHost(
+  governance: Governance | undefined,
+  deps: BuildGitHostDeps,
+): GitHostPort {
+  const provider = governance?.git_host_provider ?? "fs-mirror";
+  switch (provider) {
+    case "fs-mirror":
+      return new FsMirrorGitHost(deps.store);
+    case "github": {
+      const repo = governance?.git_host_repo;
+      if (repo == null || repo.length === 0) {
+        throw new Error(
+          'git_host_repo ("<owner>/<name>") is required when git_host_provider="github"',
+        );
+      }
+      return new GitHubGitHost({
+        repo,
+        exec: deps.ghExec ?? new ProcessGhExec(),
+        labelPrefix: governance?.git_host_label_prefix,
+      });
+    }
+    default: {
+      // Exhaustive check — adding a new variant to `GitHostProvider` must
+      // force this switch to be updated at compile time, otherwise the
+      // factory would silently return `undefined` and every PR op would
+      // crash with `TypeError`. Mirrors team-membership/factory.ts.
+      const _exhaustive: never = provider;
+      throw new Error(`unknown git_host_provider: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -49,6 +49,7 @@ import { FakeWorkspace } from "../adapters/workspace/fake.js";
 import { FsHumanSignal } from "../adapters/human-signal/fs.js";
 import { FsMirrorIssueTracker } from "../adapters/issue-tracker/fs-mirror.js";
 import { FsMirrorGitHost } from "../adapters/git-host/fs-mirror.js";
+import { buildGitHost } from "../adapters/git-host/factory.js";
 import { buildTeamMembership } from "../adapters/team-membership/factory.js";
 import { resolveEnforcementLevel } from "../application/invariant-enforcement.js";
 import { validateOrThrow } from "../application/config-validator.js";
@@ -318,10 +319,13 @@ async function main(argv: readonly string[]): Promise<number> {
 
     // Phase 5 (audit §5-D, P0-1): build the PR-first invoker/dispatcher/
     // watcher graph. Default `experiments.{lead,reviewer}_pr_first === false`
-    // keeps the legacy envelope path active until operators opt in. The
-    // `FsMirrorGitHost` adapter is wired here too — production GitHub-API
-    // adapter selection is a separate concern (Phase 6+).
-    const gitHost = new FsMirrorGitHost(store);
+    // keeps the legacy envelope path active until operators opt in.
+    //
+    // Phase 6.0a: GitHostPort adapter is now resolved from
+    // `governance.git_host_provider` (default `fs-mirror`). Set
+    // `git_host_provider: "github"` + `git_host_repo: "<owner>/<name>"`
+    // for production PR lifecycle on a real repo.
+    const gitHost = buildGitHost(cfg.governance, { store });
     const prFirstWiring = buildPrFirstWiring({
       store,
       clock,

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -12,7 +12,7 @@ import { FakeVerification } from "../adapters/verification/fake.js";
 import { ShellVerification } from "../adapters/verification/shell.js";
 import { GitWorktreeWorkspace } from "../adapters/workspace/git-worktree.js";
 import { FakeWorkspace } from "../adapters/workspace/fake.js";
-import { FsMirrorGitHost } from "../adapters/git-host/fs-mirror.js";
+import { buildGitHost } from "../adapters/git-host/factory.js";
 import { validateOrThrow } from "../application/config-validator.js";
 import { FileLedger } from "../application/ledger.js";
 import { LOG_DAEMON_PATH } from "../application/persistence-layout.js";
@@ -195,7 +195,9 @@ async function main(argv: readonly string[]): Promise<number> {
     // Phase 5 (audit §5-D, P0-1): construct the PR-first wiring once per
     // runner invocation. `experiments.{lead,reviewer}_pr_first` toggles in
     // target.json decide whether the invokers are actually consumed.
-    const gitHost = new FsMirrorGitHost(store);
+    //
+    // Phase 6.0a: GitHostPort selector via `governance.git_host_provider`.
+    const gitHost = buildGitHost(cfg.governance, { store });
     const prFirstWiring = buildPrFirstWiring({
       store,
       clock,

--- a/src/config/target-schema.ts
+++ b/src/config/target-schema.ts
@@ -26,6 +26,17 @@ export type ProfileCfg = z.infer<typeof ProfileCfg>;
 export const HumanTeamProvider = z.enum(["github", "fs-mirror"]);
 export type HumanTeamProvider = z.infer<typeof HumanTeamProvider>;
 
+/**
+ * TCC-GOVERNANCE `git_host_provider` (Phase 6.0a) — selects the
+ * `GitHostPort` adapter the daemon binds. `fs-mirror` (default) keeps the
+ * Phase 1-5 in-process PR mirror used by tests and self-hosting smoke;
+ * `github` opts the deployment into the `gh pr` CLI adapter for real PR
+ * lifecycle on a target repo. The schema default preserves backward
+ * compatibility — deployments that never set the field stay on fs-mirror.
+ */
+export const GitHostProvider = z.enum(["github", "fs-mirror"]);
+export type GitHostProvider = z.infer<typeof GitHostProvider>;
+
 export const Governance = z
   .object({
     human_team: z.string().min(1),
@@ -55,6 +66,26 @@ export const Governance = z
      * built-in profiles (atlas / forge / sentinel / scout).
      */
     known_agent_profile_ids: z.array(z.string().min(1)).optional(),
+    /**
+     * Phase 6.0a — `GitHostPort` adapter selector. `fs-mirror` (default)
+     * keeps the in-process PR mirror used by tests/self-host smoke;
+     * `github` routes PR open/update/merge/review through the `gh pr` CLI
+     * against `git_host_repo`. See `[[git-host-factory]]`.
+     */
+    git_host_provider: GitHostProvider.default("fs-mirror"),
+    /**
+     * Phase 6.0a — `<owner>/<name>` repo identifier passed to
+     * `gh pr --repo`. Required when `git_host_provider="github"`; ignored
+     * for `fs-mirror`. Cross-field validation enforces presence at
+     * `validateOrThrow`.
+     */
+    git_host_repo: z.string().min(1).optional(),
+    /**
+     * Phase 6.0a — optional label prefix applied to every PR label
+     * (`<prefix>/<label>`). Mirrors `GitHubGitHostOptions.labelPrefix`.
+     * Useful for isolating bot-authored PRs from production labels.
+     */
+    git_host_label_prefix: z.string().min(1).optional(),
   })
   .strict()
   .refine(
@@ -63,6 +94,14 @@ export const Governance = z
       message:
         "control_issue_number and contract_change_issue_number must differ",
       path: ["contract_change_issue_number"],
+    },
+  )
+  .refine(
+    (g) => g.git_host_provider !== "github" || g.git_host_repo != null,
+    {
+      message:
+        "git_host_repo (\"<owner>/<name>\") is required when git_host_provider=\"github\"",
+      path: ["git_host_repo"],
     },
   );
 

--- a/tests/integration/git-host-provider-wiring.test.ts
+++ b/tests/integration/git-host-provider-wiring.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Phase 6.0a — `governance.git_host_provider` factory routing.
+ *
+ * Audit §5-D Phase 6 follow-up: the daemon previously hardcoded
+ * `FsMirrorGitHost` regardless of target config, so the `GitHubGitHost`
+ * adapter (475 lines, fully implemented) was dead code. This test pins the
+ * factory: `buildGitHost` MUST route to the right adapter based on
+ * `cfg.governance.git_host_provider`, and the github branch MUST consult
+ * the injected `GhExec` stub (no real `gh` CLI / network).
+ *
+ * Coverage:
+ *   1. provider="fs-mirror" (default) → FsMirrorGitHost.
+ *   2. provider="github" + repo set → GitHubGitHost; openPullRequest
+ *      consults GhExec and parses the resulting URL.
+ *   3. provider="github" without repo → throws at factory time
+ *      (defensive duplicate of the schema cross-field check).
+ *   4. governance block absent → defaults to fs-mirror (backward compat).
+ *   5. Schema cross-field validation rejects provider="github" w/o repo.
+ */
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "../../src/adapters/store/memory.js";
+import { buildGitHost } from "../../src/adapters/git-host/factory.js";
+import { FsMirrorGitHost } from "../../src/adapters/git-host/fs-mirror.js";
+import { GitHubGitHost } from "../../src/adapters/git-host/github.js";
+import { Governance } from "../../src/config/target-schema.js";
+import type { GhExec, GhExecResult } from "../../src/adapters/issue-tracker/github.js";
+
+class RecordingGhExec implements GhExec {
+  public readonly calls: string[][] = [];
+  constructor(private readonly canned: GhExecResult) {}
+  async run(args: string[]): Promise<GhExecResult> {
+    this.calls.push(args);
+    return this.canned;
+  }
+}
+
+const baseGovernance = {
+  human_team: "acme/dev",
+  control_issue_number: 9001,
+  contract_change_issue_number: 9002,
+};
+
+describe("buildGitHost (Phase 6.0a) — provider routing", () => {
+  it("provider=\"fs-mirror\" (default) returns FsMirrorGitHost", () => {
+    const store = new MemoryStore();
+    const gov = Governance.parse({ ...baseGovernance });
+    const host = buildGitHost(gov, { store });
+    expect(host).toBeInstanceOf(FsMirrorGitHost);
+  });
+
+  it("governance absent → defaults to fs-mirror (backward compat)", () => {
+    const store = new MemoryStore();
+    const host = buildGitHost(undefined, { store });
+    expect(host).toBeInstanceOf(FsMirrorGitHost);
+  });
+
+  it("provider=\"github\" with repo set → GitHubGitHost, opens PR via injected GhExec", async () => {
+    const store = new MemoryStore();
+    const gov = Governance.parse({
+      ...baseGovernance,
+      git_host_provider: "github",
+      git_host_repo: "acme/widgets",
+    });
+    const exec = new RecordingGhExec({
+      stdout: "https://github.com/acme/widgets/pull/42\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    const host = buildGitHost(gov, { store, ghExec: exec });
+    expect(host).toBeInstanceOf(GitHubGitHost);
+
+    const ref = await host.openPullRequest({
+      headBranch: "slice/abc",
+      baseBranch: "main",
+      title: "test PR",
+      body: "body",
+      draft: false,
+      labels: [],
+    });
+    expect(ref).toEqual({
+      provider: "github",
+      id: "42",
+      url: "https://github.com/acme/widgets/pull/42",
+    });
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0]).toContain("--repo");
+    expect(exec.calls[0]).toContain("acme/widgets");
+  });
+
+  it("provider=\"github\" missing repo at factory → throws (defensive)", () => {
+    const store = new MemoryStore();
+    // Bypass the schema refine by constructing the object directly — the
+    // factory must self-defend so a hand-built Governance can't crash the
+    // daemon at the first PR call.
+    const gov = {
+      ...baseGovernance,
+      signal_command_prefix: "/",
+      human_team_cache_ttl_seconds: 300,
+      human_team_provider: "fs-mirror" as const,
+      unauthorized_author_alert: false,
+      git_host_provider: "github" as const,
+      // git_host_repo intentionally omitted
+    };
+    expect(() => buildGitHost(gov as never, { store })).toThrow(
+      /git_host_repo.*required/,
+    );
+  });
+
+  it("provider=\"github\" applies labelPrefix when configured", async () => {
+    const store = new MemoryStore();
+    const gov = Governance.parse({
+      ...baseGovernance,
+      git_host_provider: "github",
+      git_host_repo: "acme/widgets",
+      git_host_label_prefix: "smoke",
+    });
+    const exec = new RecordingGhExec({
+      stdout: "https://github.com/acme/widgets/pull/7\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    const host = buildGitHost(gov, { store, ghExec: exec });
+
+    await host.openPullRequest({
+      headBranch: "slice/x",
+      baseBranch: "main",
+      title: "labeled PR",
+      body: "body",
+      draft: false,
+      labels: ["needs-review"],
+    });
+    const args = exec.calls[0]!;
+    expect(args).toContain("smoke/needs-review");
+  });
+});
+
+describe("Governance schema — git_host_* cross-field validation", () => {
+  it("provider=\"github\" without git_host_repo → schema parse fails", () => {
+    expect(() =>
+      Governance.parse({
+        ...baseGovernance,
+        git_host_provider: "github",
+      }),
+    ).toThrow(/git_host_repo.*required/);
+  });
+
+  it("provider=\"github\" with git_host_repo → parses", () => {
+    const gov = Governance.parse({
+      ...baseGovernance,
+      git_host_provider: "github",
+      git_host_repo: "owner/name",
+    });
+    expect(gov.git_host_provider).toBe("github");
+    expect(gov.git_host_repo).toBe("owner/name");
+  });
+
+  it("provider omitted defaults to fs-mirror", () => {
+    const gov = Governance.parse({ ...baseGovernance });
+    expect(gov.git_host_provider).toBe("fs-mirror");
+    expect(gov.git_host_repo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `governance.git_host_provider` (enum, default `fs-mirror`) + `git_host_repo` + `git_host_label_prefix` schema fields with cross-field validation
- New `src/adapters/git-host/factory.ts` — `buildGitHost(governance, deps)` mirrors `team-membership/factory.ts` pattern
- `daemon.ts` + `runner.ts` PR-first sites now route through factory; `drift-observer` stays FsMirror-only by design (provider-guarded sweep)

## Why

Audit §5-D Phase 6 follow-up. The daemon hardcoded `new FsMirrorGitHost(store)`, leaving the fully-implemented `GitHubGitHost` adapter (475 lines, all PR-first methods) as dead code. This was the structural blocker for real GitHub 1-cycle validation against a target repo.

Default `fs-mirror` keeps every existing fixture / test / self-host smoke path unchanged — zero regression for current callers. Production deployments opt into real GitHub PR lifecycle by setting `governance.git_host_provider: "github"` + `git_host_repo: "<owner>/<name>"`.

## Test plan

- [x] `npm run typecheck` (clean)
- [x] `npm run build` (clean)
- [x] `npm test` — 1190 passed, 4 skipped
- [x] New `tests/integration/git-host-provider-wiring.test.ts` (8 cases): fs-mirror default / github with repo opens PR via injected GhExec / github without repo throws at factory / governance absent → fs-mirror / labelPrefix applied / schema cross-field validation / default value / parses with repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)